### PR TITLE
no publish plugin on root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p tyda-big-query/target tyda-docs/target tyda-rewrite/target target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
+        run: mkdir -p tyda-big-query/target tyda-docs/target tyda-rewrite/target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar tyda-big-query/target tyda-docs/target tyda-rewrite/target target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
+        run: tar cf targets.tar tyda-big-query/target tyda-docs/target tyda-rewrite/target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val root = (project in file("."))
     tydaTable,
     tydaTestSuites
   )
-  .enablePlugins(ScalaUnidocPlugin)
+  .enablePlugins(ScalaUnidocPlugin, NoPublishPlugin)
   .settings(commonSettings)
   .settings(docSettings)
   // Run mdoc as part of unidoc generation


### PR DESCRIPTION
The root project has the same name as tyda and tiggered a bush of mima
failures. But there should be no reason to publish the root project.

