### PR TITLE
Add NoPublishPlugin to root project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p tyda-big-query/target tyda-docs/target tyda-rewrite/target target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
+        run: mkdir -p tyda-big-query/target tyda-docs/target tyda-rewrite/target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar tyda-big-query/target tyda-docs/target tyda-rewrite/target target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
+        run: tar cf targets.tar tyda-big-query/target tyda-docs/target tyda-rewrite/target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-## Building and testing
+## Building and testing 2
 
 Project names are camelCased. The camelCased name is derived from the directory
 name (e.g. directory `tyda-spark` → project `tydaSpark`). When in doubt check

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val root = (project in file("."))
     tydaTable,
     tydaTestSuites
   )
-  .enablePlugins(ScalaUnidocPlugin)
+  .enablePlugins(ScalaUnidocPlugin, NoPublishPlugin)
   .settings(commonSettings)
   .settings(docSettings)
   // Run mdoc as part of unidoc generation

--- a/build.sbt
+++ b/build.sbt
@@ -173,6 +173,7 @@ lazy val scalafixRules = (project in file("scalafix/rules"))
   .disablePlugins(ScalafixPlugin)
   .enablePlugins(NoPublishPlugin)
   .settings(Dependencies.scalafix)
+
 lazy val scalafixInput = (project in file("scalafix/input"))
   .disablePlugins(ScalafixPlugin)
   .enablePlugins(NoPublishPlugin)


### PR DESCRIPTION
The root project has the same name as tyda and tiggered a bush of mimia failures. But there should be no reason to publish the root project.