### PR TITLE
Always allow integers as in Strings in JSON

### DIFF
--- a/tyda-json/src/main/scala/com/choreograph/tyda/json/CodecToJsoniter.scala
+++ b/tyda-json/src/main/scala/com/choreograph/tyda/json/CodecToJsoniter.scala
@@ -94,9 +94,9 @@ object CodecToJsoniter {
   private def reader[T](codec: Codec[T]): Reader[T] =
     codec match {
       case Codec.Boolean => _.readBoolean()
-      case Codec.Byte => _.readByte()
-      case Codec.Short => _.readShort()
-      case Codec.Int => _.readInt()
+      case Codec.Byte => in => if in.nextValueIsString() then in.readStringAsByte() else in.readByte()
+      case Codec.Short => in => if in.nextValueIsString() then in.readStringAsShort() else in.readShort()
+      case Codec.Int => in => if in.nextValueIsString() then in.readStringAsInt() else in.readInt()
       case Codec.Long => in => if in.nextValueIsString() then in.readStringAsLong() else in.readLong()
       case Codec.Float => in => if in.nextValueIsString() then in.readString(null).toFloat else in.readFloat()
       case Codec.Double =>

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/SparkJsonCompatability.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/SparkJsonCompatability.scala
@@ -1,10 +1,12 @@
 package com.choreograph.tyda.rewrite
+import com.choreograph.tyda.CanTryCast
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.Expr
 import com.choreograph.tyda.Format
 import com.choreograph.tyda.NumericsReadMode.ReadAdapter
 import com.choreograph.tyda.NumericsReadMode.buildReadAdapter
+import com.choreograph.tyda.SimpleTypeName
 import com.choreograph.tyda.functions.microsToDuration
 import com.choreograph.tyda.rewrite.Cast.buildConverterDown
 
@@ -59,6 +61,10 @@ object SparkJsonCompatability {
   private def readAdapter[T](codec: Codec[T]): Option[ReadAdapter[T, ?]] =
     buildReadAdapter(codec)([t] =>
       _ match {
+        case Codec.Byte => tryCastAndExpect[Byte]
+        case Codec.Short => tryCastAndExpect[Short]
+        case Codec.Int => tryCastAndExpect[Int]
+        case Codec.Long => tryCastAndExpect[Long]
         case Codec.Map(given Codec[k], given Codec[v]) => Some(ReadAdapter(
             Codec[Seq[(key: k, value: v)]],
             // TODO: Would be nice if this could just be a cast instead of a higher order function
@@ -68,6 +74,12 @@ object SparkJsonCompatability {
         case _ => None
       }
     )
+
+  private def tryCastAndExpect[To: SimpleTypeName](using CanTryCast[String, To]): Option[ReadAdapter[To, ?]] =
+    Some(ReadAdapter(
+      Codec[String],
+      _.tryCast[To].expect(s"Read value was out of bounds or invalid for ${SimpleTypeName.name[To]}")
+    ))
 
   private def writeConverter[T](codec: Codec[T]): Option[Cast[T, ?]] = {
     import com.choreograph.tyda.Expr.toMicros

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/DatasetReadWriteSuiteAsGoldenSuite.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/DatasetReadWriteSuiteAsGoldenSuite.scala
@@ -30,6 +30,7 @@ trait DatasetReadWriteSuiteAsGoldenSuite extends SqlGoldenTestSuite, DatasetRead
   }
 
   override def testReadExtended[Old: Arbitrary: Codec: TypeName, New: Codec: TypeName: Equality](
-      _update: Old => New
+      _update: Old => New,
+      _customName: Option[String] = None
   ): Unit = ()
 }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetReadWriteSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetReadWriteSuite.scala
@@ -176,12 +176,12 @@ trait DatasetReadWriteSuite extends DatasetSuite {
   }
 
   def testReadExtended[Old: Arbitrary: Codec: TypeName, New: Codec: TypeName: Equality](
-      update: Old => New
+      update: Old => New,
+      customName: Option[String] = None
   ): Unit = {
     if !includeReadTests then return
-    test(s"read ${TypeName.name[Old]} as ${TypeName.name[New]}")(
-      checkReadWrite[Old, New](reference, implementation, update, NumericsReadMode.Exact)
-    )
+    val name = customName.getOrElse(s"read ${TypeName.name[Old]} as ${TypeName.name[New]}")
+    test(name)(checkReadWrite[Old, New](reference, implementation, update, NumericsReadMode.Exact))
   }
 
   def testReadPartitioned[P: Arbitrary: Codec: TypeName: Labelling as labels, M: Arbitrary: Codec: TypeName](
@@ -288,4 +288,28 @@ trait DatasetReadWriteSuite extends DatasetSuite {
     case Type.Int => TypeExtended.Int
     case Type.Decimal => TypeExtended.Decimal(None, None)
   }
+
+  /** Verifies that string-encoded numbers in JSON (e.g., "123") are cleanly
+    * coerced into their respective integral types on read. This ensures
+    * consistent cross-backend behavior (tydaJson, tydaSpark, tydaBigQuery) when
+    * parsing and decoding loose JSON formats without throwing strict schema
+    * errors.
+    */
+  private def testJsonCoercion[Num: Codec: Equality: TypeName: com.choreograph.tyda.SimpleTypeName](
+      fromString: String => Num
+  )(using Arbitrary[Num]): Unit =
+    if (format == Format.Json) {
+      given Arbitrary[String] = Arbitrary[Num].map(_.toString)
+      testReadExtended[String, Num](
+        fromString,
+        customName = Some(
+          s"JSON coercion: read string-encoded numbers as ${com.choreograph.tyda.SimpleTypeName.name[Num]}"
+        )
+      )
+    }
+
+  testJsonCoercion[Byte](_.toByte)
+  testJsonCoercion[Short](_.toShort)
+  testJsonCoercion[Int](_.toInt)
+  testJsonCoercion[Long](_.toLong)
 }


### PR DESCRIPTION
Before we were a bit inconsistent around handling on this and most
likely the Spark backend could not read data written by the BigQuery
backend.

This aims so solve this and make it part of the contract that
all backends should support reading integral types from Strings. The
motivation is that this is something that commonly produced in the
ecosystem.
