### PR TITLE
Do not store a codec inside Aggregator

### DIFF
--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/PrimitiveAggregateOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/PrimitiveAggregateOnSpark.scala
@@ -47,14 +47,16 @@ private[spark] object PrimitiveAggregateOnSpark {
     }
 
   private def fallback[T, R](expr: PrimitiveAggregate[T, R], cf: ColumnFactory[T]): Column = {
-    val aggregator = PrimitiveAggregateEvaluation.aggregator[T, R](expr)
+    val aggregatorAndCodec = PrimitiveAggregateEvaluation.aggregatorAndIntermediateCodec[T, R](expr)
+    val aggregator = aggregatorAndCodec.aggregator
+    val intermediateCodec = aggregatorAndCodec.codec
     // Due to SPARK-52023 returning an Option from a udaf can cause data corruption/crashes.
     // To avoid this we instead wrap the output in a Tuple1 and then extract the Option afterwards.
     val outputNeedsWorkaround = expr.codec.isInstanceOf[Codec.Option[?]]
     val sparkAggregator =
       if outputNeedsWorkaround then
-        aggregatorAsSparkWrappedOutput(aggregator)(using aggregator.intermediateCodec, expr.codec)
-      else aggregatorAsSpark(aggregator)(using aggregator.intermediateCodec, expr.codec)
+        aggregatorAsSparkWrappedOutput(aggregator)(using intermediateCodec, expr.codec)
+      else aggregatorAsSpark(aggregator)(using intermediateCodec, expr.codec)
     val customAggregate = udaf(sparkAggregator, CodecToEncoder.convert(using cf.codec))
     val resultExpr = customAggregate(cf.columns*)
     if outputNeedsWorkaround then resultExpr("_1") else resultExpr

--- a/tyda/src/main/scala/com/choreograph/tyda/Aggregator.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Aggregator.scala
@@ -1,7 +1,5 @@
 package com.choreograph.tyda
 
-import com.choreograph.tyda.shapeless3extras.tupleInstances
-
 /** Aggregator class used to evalaute an [[AggregateExpr]].
   *
   * This modelled on Spark's `Aggregator` class so that it can be easily used to
@@ -15,7 +13,6 @@ private[tyda] sealed trait Aggregator[From, Intermediate, To] extends Serializab
   def reduce(b: Intermediate, a: From): Intermediate
   def merge(b1: Intermediate, b2: Intermediate): Intermediate
   def finish(reduction: Intermediate): To
-  def intermediateCodec: Codec[Intermediate]
 }
 
 private[tyda] object Aggregator {
@@ -25,7 +22,6 @@ private[tyda] object Aggregator {
     def reduce(b: I2, a: From): I2 = agg.reduce(b, f(a))
     def merge(b1: I2, b2: I2): I2 = agg.merge(b1, b2)
     def finish(reduction: I2): To = agg.finish(reduction)
-    def intermediateCodec: Codec[I2] = agg.intermediateCodec
   }
 
   final case class AndThen[From, I1, I2, To](agg: Aggregator[From, I1, I2], f: I2 => To)
@@ -34,10 +30,9 @@ private[tyda] object Aggregator {
     def reduce(b: I1, a: From): I1 = agg.reduce(b, a)
     def merge(b1: I1, b2: I1): I1 = agg.merge(b1, b2)
     def finish(reduction: I1): To = f(agg.finish(reduction))
-    def intermediateCodec: Codec[I1] = agg.intermediateCodec
   }
 
-  final case class Reduce[T: Codec](r: (T, T) => T) extends Aggregator[T, Option[T], T] {
+  final case class Reduce[T](r: (T, T) => T) extends Aggregator[T, Option[T], T] {
     def zero: Option[T] = None
     def reduce(b: Option[T], a: T): Option[T] = Some(b.fold(a)(r(_, a)))
     def merge(b1: Option[T], b2: Option[T]): Option[T] =
@@ -49,7 +44,6 @@ private[tyda] object Aggregator {
       }
     def finish(reduction: Option[T]): T =
       reduction.getOrElse(unreachable("Aggregator.Reduce.finish called with empty reduction"))
-    def intermediateCodec: Codec[Option[T]] = summon
   }
 
   final case class Combined[From, To <: Tuple](aggs: IArray[Aggregator[From, ?, ?]])
@@ -81,10 +75,5 @@ private[tyda] object Aggregator {
         .map { case (agg, intermediate) => agg.finish(intermediate.asInstanceOf) }
       // TYPE SAFETY: The results should match the output types of the aggregators
       Tuple.fromIArray(results).asInstanceOf[To]
-    def intermediateCodec: Codec[Tuple] = {
-      val codecs = aggs.map(_.intermediateCodec)
-      // TYPE SAFETY: Each element in codecs is of type Codec[?]
-      Codec.tuple(tupleInstances(Tuple.fromIArray(codecs).asInstanceOf[Tuple.Map[Tuple, Codec]]))
-    }
   }
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregateEvaluation.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregateEvaluation.scala
@@ -6,26 +6,50 @@ import com.choreograph.tyda.Aggregator.Reduce
 
 private[tyda] object PrimitiveAggregateEvaluation {
   def aggregator[From, To](agg: PrimitiveAggregate[From, To]): Aggregator[From, ?, To] =
+    aggregatorAndIntermediateCodec(agg).aggregator
+
+  final case class AggregatorAndIntermediateCodec[From, I1, To](
+      aggregator: Aggregator[From, I1, To],
+      codec: Codec[I1]
+  )
+  private def make[From, I: Codec, To](
+      agg: Aggregator[From, I, To]
+  ): AggregatorAndIntermediateCodec[From, I, To] = AggregatorAndIntermediateCodec(agg, Codec[I])
+
+  def aggregatorAndIntermediateCodec[From, To](
+      agg: PrimitiveAggregate[From, To]
+  ): AggregatorAndIntermediateCodec[From, ?, To] =
     agg match {
       case PrimitiveAggregate.Collect() =>
         given Codec[To] = agg.codec
-        Compose(Seq(_), Reduce[Seq[From]](_ ++ _))
-      case PrimitiveAggregate.Count() => Compose(_ => 1L, Reduce[Long](_ + _))
-      case PrimitiveAggregate.CountSome() => Compose(t => if t.isDefined then 1L else 0L, Reduce[Long](_ + _))
-      case PrimitiveAggregate.BoolAnd() => Reduce[Boolean](_ && _)
-      case PrimitiveAggregate.BoolOr() => Reduce[Boolean](_ || _)
-      case PrimitiveAggregate.Min(comparable) => Reduce(comparableToOrd(comparable).min)(using agg.codec)
-      case PrimitiveAggregate.Max(comparable) => Reduce(comparableToOrd(comparable).max)(using agg.codec)
+        make(Compose(Seq(_), Reduce[Seq[From]](_ ++ _)))
+      case PrimitiveAggregate.Count() => make(Compose(_ => 1L, Reduce[Long](_ + _)))
+      case PrimitiveAggregate.CountSome() =>
+        make(Compose(t => if t.isDefined then 1L else 0L, Reduce[Long](_ + _)))
+      case PrimitiveAggregate.BoolAnd() => make(Reduce[Boolean](_ && _))
+      case PrimitiveAggregate.BoolOr() => make(Reduce[Boolean](_ || _))
+      case PrimitiveAggregate.Min(comparable) =>
+        given Codec[To] = agg.codec
+        make(Reduce(comparableToOrd(comparable).min))
+      case PrimitiveAggregate.Max(comparable) =>
+        given Codec[To] = agg.codec
+        make(Reduce(comparableToOrd(comparable).max))
       case minBy: PrimitiveAggregate.MinBy[?, ?] =>
-        minByAggregator(comparableToOrd(minBy.comparable), minBy.inputCodec)
+        minByAggregator(comparableToOrd(minBy.comparable))(using minBy.inputCodec)
       case maxBy: PrimitiveAggregate.MaxBy[?, ?] =>
-        minByAggregator(comparableToOrd(maxBy.comparable).reverse, maxBy.inputCodec)
-      case PrimitiveAggregate.Reduce(f) => Reduce(f)(using agg.codec)
-      case PrimitiveAggregate.Sum(magnet) => Compose(magnet.toResult, Reduce(magnet.add)(using magnet.codec))
+        minByAggregator(comparableToOrd(maxBy.comparable).reverse)(using maxBy.inputCodec)
+      case PrimitiveAggregate.Reduce(f) =>
+        given Codec[To] = agg.codec
+        make(Reduce(f))
+      case PrimitiveAggregate.Sum(magnet) =>
+        given Codec[To] = magnet.codec
+        make(Compose(magnet.toResult, Reduce(magnet.add)))
     }
 
-  def minByAggregator[V, O](ord: Ord[O], codec: Codec[(V, O)]): Aggregator[(V, O), ?, V] =
-    AndThen(Reduce[(V, O)]((a, b) => if ord.lt(a._2, b._2) then a else b)(using codec), _._1)
+  def minByAggregator[V, O](
+      ord: Ord[O]
+  )(using codec: Codec[(V, O)]): AggregatorAndIntermediateCodec[(V, O), ?, V] =
+    make(AndThen(Reduce[(V, O)]((a, b) => if ord.lt(a._2, b._2) then a else b), _._1))
 
   def comparableToOrd[T](comparable: Comparable[T]): Ord[T] =
     comparable match {

--- a/tyda/src/test/scala/com/choreograph/tyda/AggregatorSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/AggregatorSpec.scala
@@ -1,0 +1,61 @@
+package com.choreograph.tyda
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.ObjectStreamClass
+
+import scala.util.Using
+
+import org.scalatest.funsuite.AnyFunSuite
+
+object AggregatorSpec {
+  def assertDoesNotCapture(value: Serializable, forbiddenClasses: Class[?]*): Unit = {
+    val bytes = Using.resource(ByteArrayOutputStream()) { baos =>
+      Using.resource(ObjectOutputStream(baos))(_.writeObject(value))
+      baos.toByteArray
+    }
+    Using.resource(ByteArrayInputStream(bytes)) { bais =>
+      val ois = new ObjectInputStream(bais) {
+        override def resolveClass(desc: ObjectStreamClass): Class[?] = {
+          val cls = super.resolveClass(desc)
+          forbiddenClasses.foreach { forbidden =>
+            assert(
+              !forbidden.isAssignableFrom(cls),
+              s"${forbidden.getSimpleName} subtype found in serialized value: ${desc.getName}"
+            )
+          }
+          cls
+        }
+      }
+      ois.readObject(): Unit
+    }
+  }
+}
+
+class AggregatorSpec extends AnyFunSuite {
+  import AggregatorSpec.*
+
+  def testAggregatorDoesNotCaptureCodec[P <: PrimitiveAggregate[?, ?]: TypeName](agg: P): Unit =
+    test(s"Aggregator for ${TypeName.name[P]} does not serialize any Codec") {
+      assertDoesNotCapture(
+        PrimitiveAggregateEvaluation.aggregatorAndIntermediateCodec(agg).aggregator,
+        classOf[Codec[?]]
+      )
+    }
+
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Collect[Long]())
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Collect[Option[Long]]())
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Collect[(a: Int, b: String)]())
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Count[Long]())
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.CountSome[Long]())
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.BoolAnd())
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.BoolOr())
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Min[Long](Comparable.long))
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Max[Long](Comparable.long))
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.MinBy[Long, Long](Comparable.long))
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.MaxBy[Long, Long](Comparable.long))
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Reduce[Long](_ + _))
+  testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Sum(SumMagnet[Long]))
+}

--- a/tyda/src/test/scala/com/choreograph/tyda/AggregatorSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/AggregatorSpec.scala
@@ -45,6 +45,10 @@ class AggregatorSpec extends AnyFunSuite {
       )
     }
 
+  test("asstDoesNotCapture should throw on forbiddenidden class") {
+    assertThrows[AssertionError] { assertDoesNotCapture(Tuple1(Codec[Long]), classOf[Codec[?]]) }
+  }
+
   testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Collect[Long]())
   testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Collect[Option[Long]]())
   testAggregatorDoesNotCaptureCodec(PrimitiveAggregate.Collect[(a: Int, b: String)]())


### PR DESCRIPTION
Since we are serializing Aggregators as part of the Spark backend it
makes sense to keep them as small as possible. The only reason we had
the codec their in the first place as that Spark needed it, but as
showed here we can store it "next to" instead of in the Aggreator.
