### PR TITLE
Implement RemoveMultipleExplodes rewrite

### DIFF
--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/RemoveMultipleExplodes.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/RemoveMultipleExplodes.scala
@@ -1,0 +1,86 @@
+package com.choreograph.tyda.rewrite
+
+import com.choreograph.tyda.CompiledExplodeExpr
+import com.choreograph.tyda.CompiledExpr
+import com.choreograph.tyda.CompiledExprOrExplode
+import com.choreograph.tyda.CompiledExprOrExplode.compose
+import com.choreograph.tyda.Dataset
+import com.choreograph.tyda.ExprNode
+import com.choreograph.tyda.shapeless3extras.tupleInstances
+
+/** Rewrites SelectN with multiple explodes into several selects.
+  *
+  * Will rewrite a select like
+  * ```
+  * SelectN: x => explode(x._1), x => explode(x._2), x => explode(x._3)
+  * ```
+  * into
+  * ```
+  * SelectN: x => x._2, x => x._3, x => explode(x._1._3)
+  *   SelectN: x => x._1, x => x._2, explode(x._1._2)
+  *     SelectN: x => x._1, x => explode(x._1._1)
+  *      SelectN: x => Tuple1(x)
+  * ```
+  *
+  * This rewrite is useful for Spark < 3.5.1 that does not support multiple
+  * selects and for engines like postgres, datafusion where multiple unnests are
+  * zipped instead of cartesian products.
+  */
+object RemoveMultipleExplodes extends DatasetRule {
+
+  def unapply[T](ds: Dataset[T]): Option[Dataset[T]] =
+    ds match {
+      case selectN: Dataset.SelectN[u, r] if countExplodes(selectN) > 1 => Some(rewriteSelectN[u, r](selectN))
+      case _ => None
+    }
+
+  def apply[T](ds: Dataset[T]): Dataset[T] = unapply(ds).getOrElse(ds)
+
+  private def countExplodes(selectN: Dataset.SelectN[?, ?]): Int =
+    tupleInstances(selectN.exprs).foldLeft0(0)([t] =>
+      (acc, compiled) =>
+        compiled match {
+          case _: CompiledExplodeExpr[?, ?] => acc + 1
+          case _: CompiledExpr[?, ?] => acc
+        }
+    )
+
+  private def rewriteSelectN[T, R <: Tuple](selectN: Dataset.SelectN[T, R]): Dataset[R] = {
+    val arity = tupleInstances(selectN.exprs).arity
+
+    def step[U <: Tuple, E](
+        ds: Dataset[U],
+        compiled: CompiledExprOrExplode[T, E],
+        index: Int
+    ): Dataset[? <: Tuple] = {
+      def column[T](ordinal: Int): CompiledExpr[U, T] = {
+        val ref = ExprNode.Reference[U]()(using ds.codec)
+        CompiledExpr(ref, ExprNode.Select[U, T](ref, s"_${ordinal}"))
+      }
+
+      // For final step exclude the row column
+      val existingResults = if index == arity then (2 to index).map(column) else (1 to index).map(column)
+
+      val row = column[T](1)
+      val adaptedExpr = compiled.compose(row)
+
+      /* TYPE SAFETY: All exprs are of type CompiledExprOrExplode.From[U] */
+      val nextResults = Tuple
+        .fromArray((existingResults :+ adaptedExpr).toArray)
+        .asInstanceOf[Tuple.Map[Tuple, CompiledExprOrExplode.From[U]]]
+
+      Dataset.SelectN(ds, nextResults)
+    }
+
+    val dsInitial: Dataset[T *: EmptyTuple] = selectN.input.select(_ *: EmptyTuple)
+    val (result, _) =
+      tupleInstances(selectN.exprs).foldLeft0((dsInitial: Dataset[? <: Tuple], 0)) { [t] => (acc, compiled) =>
+        val (dsPrev, idx) = acc
+        val nextDs = step(dsPrev, compiled, idx + 1)
+        (nextDs, idx + 1)
+      }
+
+    /* TYPE SAFETY: In the final select each of the tuple elements is the same as the original select */
+    result.asInstanceOf[Dataset[R]]
+  }
+}

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/RemoveMultipleExplodes.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/RemoveMultipleExplodes.scala
@@ -64,7 +64,7 @@ object RemoveMultipleExplodes extends DatasetRule {
       val row = column[T](1)
       val adaptedExpr = compiled.compose(row)
 
-      /* TYPE SAFETY: All exprs are of type CompiledExprOrExplode.From[U] */
+      // TYPE SAFETY: All exprs are of type CompiledExprOrExplode.From[U]
       val nextResults = Tuple
         .fromArray((existingResults :+ adaptedExpr).toArray)
         .asInstanceOf[Tuple.Map[Tuple, CompiledExprOrExplode.From[U]]]
@@ -80,7 +80,7 @@ object RemoveMultipleExplodes extends DatasetRule {
         (nextDs, idx + 1)
       }
 
-    /* TYPE SAFETY: In the final select each of the tuple elements is the same as the original select */
+    // TYPE SAFETY: In the final select each of the tuple elements is the same as the original select
     result.asInstanceOf[Dataset[R]]
   }
 }

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
@@ -42,6 +42,7 @@ import com.choreograph.tyda.TreeApi.Continue
 import com.choreograph.tyda.TreeApi.Skip
 import com.choreograph.tyda.functions.some
 import com.choreograph.tyda.rewrite.ExplodeOptionToFilter
+import com.choreograph.tyda.rewrite.RemoveMultipleExplodes
 import com.choreograph.tyda.rewrite.ReplacementMap
 import com.choreograph.tyda.rewrite.ReplacementMap.Replacement
 import com.choreograph.tyda.rewrite.SparkJsonCompatability
@@ -268,25 +269,7 @@ object DatasetOnSpark {
           IntermediateDataset(filtered)
         case ExplodeOptionToFilter(ds) => toIntermediate(ds)
         case select: Dataset.Select1[?, T] => IntermediateDataset(select1(select))
-        // Workaround for https://issues.apache.org/jira/browse/SPARK-47241 that is present in Spark 3.5.1
-        // The bug means that multiple explodes in the same select lead to planning issues, but planning them
-        // as concecutive selects works.
-        case selectN: Dataset.SelectN[?, ?] if multipleExplodes(selectN) =>
-          val input = toIntermediate(selectN.input).toDataset
-          val exprs = tupleInstances(selectN.exprs)
-          val rowColumnName = "row"
-          val (df, _) =
-            exprs.foldLeft0((input.select(struct("*").as(rowColumnName)), 0)) { [t] => (dsAndCount, expr) =>
-              val (ds, resultExprCount) = dsAndCount
-              val cf = ColumnFactory(ds(rowColumnName))(using selectN.input.codec)
-              val select = convertExplodeExpr(cf, expr)
-              val existingResultColumns = (1 to resultExprCount).map(i => ds(s"_$i"))
-              val columns = existingResultColumns ++
-                Seq(select.as(s"_${resultExprCount + 1}"), ds(rowColumnName))
-              (ds.select(columns*), resultExprCount + 1)
-            }
-          val columns = (1 to exprs.arity).map(i => df(s"_$i"))
-          IntermediateDataset(df.select(columns*).as[T])
+        case RemoveMultipleExplodes(ds) => toIntermediate(ds)
         case selectN: Dataset.SelectN[?, ?] =>
           val (input, cf) = toIntermediate(selectN.input).toDataFrameAndColumnFactory
           val columns = tupleInstances(selectN.exprs)
@@ -389,17 +372,6 @@ object DatasetOnSpark {
         val column = convertExplodeExpr(cf, other)
         selectAndUnpack(df, column)
     }
-  }
-
-  private def multipleExplodes(select: Dataset.SelectN[?, ?]): Boolean = {
-    val explodes = tupleInstances(select.exprs).foldLeft0(0)([t] =>
-      (count, expr) =>
-        expr match {
-          case CompiledExplodeExpr(_, _) => count + 1
-          case _ => count
-        }
-    )
-    explodes > 1
   }
 
   private def isSelfJoin(left: Dataset[?], right: Dataset[?]): Boolean = {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -352,66 +352,24 @@ private final case class SelectBuilder[T, R](
       exprs: Tuple.Map[R2, [X] =>> CompiledExprOrExplode[R, X]]
   ): Result[SelectBuilder[?, R2]] =
     args.dialect.explode match {
-      case SqlDialect.ExplodeSupport.Function(_, supportMultiple) =>
-        selectNExplodeFunction(exprs, supportMultiple)
+      case SqlDialect.ExplodeSupport.Function(_, _) => selectNExplodeFunction(exprs)
       case SqlDialect.ExplodeSupport.InnerJoin => selectNExplodeJoin(exprs)
     }
 
   private def selectNExplodeFunction[R2 <: Tuple](
-      exprs: Tuple.Map[R2, [X] =>> CompiledExprOrExplode[R, X]],
-      supportMultipleExplodes: Boolean
+      exprs: Tuple.Map[R2, [X] =>> CompiledExprOrExplode[R, X]]
   ): Result[SelectBuilder[?, R2]] = {
-
-    val nbrExplodes = tupleInstances(exprs).foldLeft0(0)([t] =>
-      (acc, compiled) =>
-        compiled match {
-          case _: CompiledExplodeExpr[?, ?] => acc + 1
-          case compiled: CompiledExpr[?, ?] => acc
-        }
-    )
     val codec = Codec.tuple(tupleInstances(exprs).mapK([t] => _.codec))
-    // Workaround for old Spark versions not supporting multiple explodes
-    if nbrExplodes > 1 && !supportMultipleExplodes then {
-      val rowColumnName = "row"
-      val queryResult = buildWithSelect(NonEmpty[Seq]((RelaxedCompiledExpr(select), rowColumnName)))
-      tupleInstances(exprs)
-        .foldLeft0(queryResult.map((_, 0)))([t] =>
-          (result, selectExpr) =>
-            result.flatMap((query, resultCount) =>
-              val alias = args.aliasGen.table()
-              val from = From.Subquery(query, alias)
-              val rowExpr = SqlExpr.FieldAccess(SqlExpr.Ident(alias), rowColumnName)
-              def column(name: String) = SqlExpr.As(SqlExpr.FieldAccess(SqlExpr.Ident(alias), name), name)
-              val existingResultColumns = (1 to resultCount).map(i => column(s"_${i}"))
+    val newSelect = NonEmpty
+      .from(
+        tupleInstances(exprs)
+          .mapConst([t] => compiled => andThenRelaxed(select, compiled))
+          .zipWithIndex
+          .map { case (e, i) => (e, s"_${i + 1}") }
+      )
+      .getOrElse(unreachable("Selects contains at least one statement"))
 
-              val (arg, expr) = selectExpr match {
-                case explode: CompiledExplodeExpr[?, ?] => (explode.arg, ExplodeExpr(explode.expr))
-                case compiled: CompiledExpr[?, ?] => (compiled.arg, compiled.expr)
-              }
-              val newQuery = simplifyAndToSqlExpr(expr, Map(arg -> IdentifierOrSqlExpr.Expr(rowExpr)), args)
-                .map(SqlExpr.As(_, s"_${resultCount + 1}"))
-                .map(newResult =>
-                  NonEmpty[Seq](SqlExpr.As(rowExpr, rowColumnName)) ++ existingResultColumns ++ Seq(newResult)
-                )
-                .map(newSelect =>
-                  Query.Select(newSelect, Some(from), None, Seq.empty, None, distinct = false)
-                )
-              newQuery.map((_, resultCount + 1))
-            )
-        )
-        .map((query, _) => makeSubquery(query, codec))
-    } else {
-      val newSelect = NonEmpty
-        .from(
-          tupleInstances(exprs)
-            .mapConst([t] => compiled => andThenRelaxed(select, compiled))
-            .zipWithIndex
-            .map { case (e, i) => (e, s"_${i + 1}") }
-        )
-        .getOrElse(unreachable("Selects contains at least one statement"))
-
-      buildWithSelect(newSelect).map(makeSubquery(_, codec))
-    }
+    buildWithSelect(newSelect).map(makeSubquery(_, codec))
   }
 
   private def selectNExplodeJoin[R2 <: Tuple](

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -545,7 +545,7 @@ object SqlDialect {
       SparkJsonCompatability.AdaptReads,
       SparkJsonCompatability.ConvertWrites,
       SparkJsonCompatability.AdaptToJson,
-      SparkJsonCompatability.ConvertFromJson
+      SparkJsonCompatability.ConvertFromJson,
       RemoveMultipleExplodes
     )
   )

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -9,6 +9,7 @@ import com.choreograph.tyda.rewrite.DisfavorIsNotDistinctFrom
 import com.choreograph.tyda.rewrite.DistributeProductAndSeqEquals
 import com.choreograph.tyda.rewrite.ExprRule
 import com.choreograph.tyda.rewrite.RemoveArrayCasts
+import com.choreograph.tyda.rewrite.RemoveMultipleExplodes
 import com.choreograph.tyda.rewrite.RemoveNullSafeEqualsInJoinCondition
 import com.choreograph.tyda.rewrite.SparkJsonCompatability
 import com.choreograph.tyda.rewrite.WrapOptionInCollect
@@ -545,6 +546,7 @@ object SqlDialect {
       SparkJsonCompatability.ConvertWrites,
       SparkJsonCompatability.AdaptToJson,
       SparkJsonCompatability.ConvertFromJson
+      RemoveMultipleExplodes
     )
   )
 }

--- a/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
@@ -43,7 +43,7 @@ SELECT explode(t0.value) AS value FROM (SELECT explode(t1.value) AS value FROM t
 ------ end
 
 ------ Test: explode multiple nested Seq
-SELECT t1.row AS row, t1._1 AS _1, explode(t1.row._2) AS _2 FROM (SELECT t0.row AS row, explode(t0.row._1) AS _1 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2) AS row FROM t1) AS t0) AS t1
+SELECT t0._2 AS _1, explode(t0._1._2) AS _2 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2) AS _1, explode(t1._1) AS _2 FROM t1) AS t0
 ------ end
 
 ------ Test: explode nested Seq
@@ -123,7 +123,7 @@ SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS
 ------ end
 
 ------ Test: select 7 explode
-SELECT t6.row AS row, t6._1 AS _1, t6._2 AS _2, t6._3 AS _3, t6._4 AS _4, t6._5 AS _5, t6._6 AS _6, explode(t6.row._7) AS _7 FROM (SELECT t5.row AS row, t5._1 AS _1, t5._2 AS _2, t5._3 AS _3, t5._4 AS _4, t5._5 AS _5, explode(t5.row._6) AS _6 FROM (SELECT t4.row AS row, t4._1 AS _1, t4._2 AS _2, t4._3 AS _3, t4._4 AS _4, explode(t4.row._5) AS _5 FROM (SELECT t3.row AS row, t3._1 AS _1, t3._2 AS _2, t3._3 AS _3, explode(t3.row._4) AS _4 FROM (SELECT t2.row AS row, t2._1 AS _1, t2._2 AS _2, explode(t2.row._3) AS _3 FROM (SELECT t1.row AS row, t1._1 AS _1, explode(t1.row._2) AS _2 FROM (SELECT t0.row AS row, explode(t0.row._1) AS _1 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2, '_3', t1._3, '_4', t1._4, '_5', t1._5, '_6', t1._6, '_7', t1._7) AS row FROM t1) AS t0) AS t1) AS t2) AS t3) AS t4) AS t5) AS t6
+SELECT t5._2 AS _1, t5._3 AS _2, t5._4 AS _3, t5._5 AS _4, t5._6 AS _5, t5._7 AS _6, explode(t5._1._7) AS _7 FROM (SELECT t4._1 AS _1, t4._2 AS _2, t4._3 AS _3, t4._4 AS _4, t4._5 AS _5, t4._6 AS _6, explode(t4._1._6) AS _7 FROM (SELECT t3._1 AS _1, t3._2 AS _2, t3._3 AS _3, t3._4 AS _4, t3._5 AS _5, explode(t3._1._5) AS _6 FROM (SELECT t2._1 AS _1, t2._2 AS _2, t2._3 AS _3, t2._4 AS _4, explode(t2._1._4) AS _5 FROM (SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, explode(t1._1._3) AS _4 FROM (SELECT t0._1 AS _1, t0._2 AS _2, explode(t0._1._2) AS _3 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2, '_3', t1._3, '_4', t1._4, '_5', t1._5, '_6', t1._6, '_7', t1._7) AS _1, explode(t1._1) AS _2 FROM t1) AS t0) AS t1) AS t2) AS t3) AS t4) AS t5
 ------ end
 
 ------ Test: select Product
@@ -143,7 +143,7 @@ SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 WHERE ((t1._1 IS NOT NULL) AND (t1._2 IS
 ------ end
 
 ------ Test: select multiple explode seq
-SELECT t1.row AS row, t1._1 AS _1, explode(t1.row._2) AS _2 FROM (SELECT t0.row AS row, explode(t0.row._1) AS _1 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2) AS row FROM t1) AS t0) AS t1
+SELECT t0._2 AS _1, explode(t0._1._2) AS _2 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2) AS _1, explode(t1._1) AS _2 FROM t1) AS t0
 ------ end
 
 ------ Test: select nested access

--- a/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
@@ -67,7 +67,7 @@ SELECT table1.a AS _1, table2.a AS _2 FROM table1 JOIN table2 ON (table1.a = tab
 ------ end
 
 ------ Test: join and then explode
-SELECT t1.row AS row, t1._1 AS _1, explode(t1.row._2.d) AS _2 FROM (SELECT t0.row AS row, explode(t0.row._1.d) AS _1 FROM (SELECT named_struct('_1', named_struct('a', table1.a, 'b', table1.b, 'c', table1.c, 'd', table1.d), '_2', named_struct('a', table2.a, 'b', table2.b, 'c', table2.c, 'd', table2.d)) AS row FROM table1 JOIN table2 ON (table1.a = table2.a)) AS t0) AS t1
+SELECT t0._2 AS _1, explode(t0._1._2.d) AS _2 FROM (SELECT named_struct('_1', named_struct('a', table1.a, 'b', table1.b, 'c', table1.c, 'd', table1.d), '_2', named_struct('a', table2.a, 'b', table2.b, 'c', table2.c, 'd', table2.d)) AS _1, explode(table1.d) AS _2 FROM table1 JOIN table2 ON (table1.a = table2.a)) AS t0
 ------ end
 
 ------ Test: join+aggregate on lhs

--- a/tyda/src/main/scala/com/choreograph/tyda/CompiledExprOrExplode.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/CompiledExprOrExplode.scala
@@ -15,4 +15,12 @@ private[tyda] object CompiledExprOrExplode {
   }
   def apply[T: Codec, R, I: AsExprOrExplode.Of[R]](f: Expr[T] => I): CompiledExprOrExplode[T, R] =
     apply(f.andThen(AsExprOrExplode(_)))
+
+  extension [T, R](compiled: CompiledExprOrExplode[T, R]) {
+    def compose[A](g: CompiledExpr[A, T]): CompiledExprOrExplode[A, R] =
+      compiled match {
+        case compiled @ CompiledExpr(_, _) => compiled.compose(g)
+        case compiled @ CompiledExplodeExpr(_, _) => compiled.compose(g)
+      }
+  }
 }


### PR DESCRIPTION
This moves the duplicated logic in SelectBuilder and DatasetOnSpark in
to a shared rewrite rule instead.

Created this to take gemini 3.5 flash for a Spin. I did the overall
structure create, but had to refactor the rule implementation quite a bit
for it to be acceptable.

The changes in the golden files are actually a bug fix where in the
SelectBuilder we output the temporary row column. This seems to have not
caused any issue since the decoder for Spark uses column names to
extract the results. But it actually triggered failures for Spark 4.0.2,
see https://gitlab.com/2sixty/open-intelligence/foundation/core/-/merge_requests/1657
So it good to get it fixed.
