### PR TITLE
Except in Dataset API

### DIFF
--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/Except.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/Except.scala
@@ -1,0 +1,18 @@
+package com.choreograph.tyda.rewrite
+
+import com.choreograph.tyda.Dataset
+import com.choreograph.tyda.ExprNode
+
+object Except {
+  def unapply[T](ds: Dataset[T]): Option[(Dataset[T], Dataset[T])] =
+    ds match {
+      case Dataset.Distinct(Dataset.LeftAntiJoin(left, right, on)) => on.expr match {
+          case ExprNode.Equals(lhs, rhs) => (on.arg1, on.arg2) match {
+              case (`lhs`, `rhs`) | (`rhs`, `lhs`) => Some((left, right))
+              case _ => None
+            }
+          case _ => None
+        }
+      case _ => None
+    }
+}

--- a/tyda-spark/src/test/resources/golden/DatasetOnSparkGoldenExplainSuite.golden
+++ b/tyda-spark/src/test/resources/golden/DatasetOnSparkGoldenExplainSuite.golden
@@ -35,6 +35,58 @@ AdaptiveSparkPlan isFinalPlan=false
 
 ------ end
 
+------ Test: except
+== Parsed Logical Plan ==
+Deduplicate [_1#1, _2#2]
++- Project [tmp#3._1 AS _1#1, tmp#3._2 AS _2#2]
+   +- Project [struct(_1, _1#4, _2, _2#5) AS tmp#3]
+      +- Join LeftAnti, (cast(struct(_1, _1#4, _2, _2#5) as struct<_1:int,_2:string>) = cast(struct(_1, _1#6, _2, _2#7) as struct<_1:int,_2:string>))
+         :- Project [tmp#8._1 AS _1#4, tmp#8._2 AS _2#5]
+         :  +- Project [struct(_1, struct(the cake is a lie 🎂, null), _2, struct(_1, _1#9, _2, _2#10))._2 AS tmp#8]
+         :     +- SubqueryAlias golden_test_t1
+         :        +- View (`golden_test_t1`, [_1#9,_2#10])
+         :           +- LocalRelation [_1#9, _2#10]
+         +- Project [tmp#11._1 AS _1#6, tmp#11._2 AS _2#7]
+            +- Project [struct(_1, struct(the cake is a lie 🎂, null), _2, struct(_1, _1#12, _2, _2#13))._2 AS tmp#11]
+               +- SubqueryAlias golden_test_t2
+                  +- View (`golden_test_t2`, [_1#12,_2#13])
+                     +- LocalRelation [_1#12, _2#13]
+
+== Analyzed Logical Plan ==
+_1: int, _2: string
+Deduplicate [_1#1, _2#2]
++- Project [tmp#3._1 AS _1#1, tmp#3._2 AS _2#2]
+   +- Project [struct(_1, _1#4, _2, _2#5) AS tmp#3]
+      +- Join LeftAnti, (cast(struct(_1, _1#4, _2, _2#5) as struct<_1:int,_2:string>) = cast(struct(_1, _1#6, _2, _2#7) as struct<_1:int,_2:string>))
+         :- Project [tmp#8._1 AS _1#4, tmp#8._2 AS _2#5]
+         :  +- Project [struct(_1, struct(the cake is a lie 🎂, null), _2, struct(_1, _1#9, _2, _2#10))._2 AS tmp#8]
+         :     +- SubqueryAlias golden_test_t1
+         :        +- View (`golden_test_t1`, [_1#9,_2#10])
+         :           +- LocalRelation [_1#9, _2#10]
+         +- Project [tmp#11._1 AS _1#6, tmp#11._2 AS _2#7]
+            +- Project [struct(_1, struct(the cake is a lie 🎂, null), _2, struct(_1, _1#12, _2, _2#13))._2 AS tmp#11]
+               +- SubqueryAlias golden_test_t2
+                  +- View (`golden_test_t2`, [_1#12,_2#13])
+                     +- LocalRelation [_1#12, _2#13]
+
+== Optimized Logical Plan ==
+Aggregate [_1#4, _2#5], [_1#4, _2#5]
++- Join LeftAnti, (struct(_1, _1#4, _2, _2#5) = struct(_1, _1#6, _2, _2#7))
+   :- LocalRelation [_1#4, _2#5]
+   +- LocalRelation [_1#6, _2#7]
+
+== Physical Plan ==
+AdaptiveSparkPlan isFinalPlan=false
++- HashAggregate(keys=[_1#4, _2#5], functions=[], output=[_1#4, _2#5])
+   +- Exchange hashpartitioning(_1#4, _2#5, 1), ENSURE_REQUIREMENTS, [plan_id=1]
+      +- HashAggregate(keys=[_1#4, _2#5], functions=[], output=[_1#4, _2#5])
+         +- BroadcastHashJoin [struct(_1, _1#4, _2, _2#5)], [struct(_1, _1#6, _2, _2#7)], LeftAnti, BuildRight, false
+            :- LocalTableScan [_1#4, _2#5]
+            +- BroadcastExchange HashedRelationBroadcastMode(List(struct(_1, input[0, int, false], _2, input[1, string, true])),false), [plan_id=2]
+               +- LocalTableScan [_1#6, _2#7]
+
+------ end
+
 ------ Test: explode option
 == Parsed Logical Plan ==
 Project [opt1#1 AS value#2]

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/DatasetOnSparkGoldenExplainSuite.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/DatasetOnSparkGoldenExplainSuite.scala
@@ -46,6 +46,8 @@ class DatasetOnSparkGoldenExplainSuite extends GoldenTestSuite, SharedSparkSessi
 
   testExplain("union") { ds1.union(ds2) }
 
+  testExplain("except") { ds1.except(ds2) }
+
   testExplain("aggregate") { ds1.groupByKey(_._1).aggregate(r => (count = count(), min = min(r._1))) }
 
   testExplain("project") { ds4.project[(string: String)] }

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/DatasetUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/DatasetUnparser.scala
@@ -4,8 +4,10 @@ import java.io.StringWriter
 
 import scala.annotation.targetName
 
+import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.NonEmpty
+import com.choreograph.tyda.rewrite.Except
 import com.choreograph.tyda.rewrite.ExplodeOptionToFilter
 import com.choreograph.tyda.sql.ast.Query
 import com.choreograph.tyda.sql.ast.SqlExpr
@@ -83,6 +85,23 @@ def toSql(action: Dataset.Action, dialect: SqlDialect): Result[String] = {
   }
 }
 
+/** Check if there are struct columns ignoring any top level struct. */
+private def hasInnerStructColumns(codec: Codec[?]): Boolean = {
+  def hasStructColumn(codec: Codec[?]): Boolean =
+    Codec
+      .iterate(codec)
+      .exists {
+        case Codec.Product(_, _, _) => true
+        case _ => false
+      }
+  codec match {
+    case Codec.Product(_, fields, _) =>
+      fields.foldLeft0(false)([t] => (acc, f) => hasStructColumn(f.codec) || acc)
+    case Codec.FromInjection(_, to) => hasInnerStructColumns(to)
+    case other => hasStructColumn(other)
+  }
+}
+
 private def queryToString(query: Query): String = {
   val stringWriter = new StringWriter()
   SqlWriter(stringWriter).write(query)
@@ -93,6 +112,13 @@ private def unparseDs[T](ds: Dataset[T], args: UnparserArgs): Result[SelectBuild
   def inner[U](ds: Dataset[U]): Result[SelectBuilder[?, U]] = {
     val result: Result[SelectBuilder[?, U]] = ds match {
       case Dataset.Aggregate(input, aggregate) => inner(input).flatMap(_.aggregate(aggregate))
+      case Except(left, right)
+          if args.dialect.supportsExceptDistinctOnStructColumns || !hasInnerStructColumns(left.codec) =>
+        for {
+          lhs <- inner(left)
+          rhs <- inner(right)
+          except <- lhs.except(rhs)
+        } yield except
       case Dataset.Distinct(input) => inner(input).map(_.copy(distinct = true))
       case Dataset.Filter(input, predicate) => inner(input).map(_.filter(predicate))
       case Dataset.FromSeq(values, codec) => SelectBuilder.fromSeq(values, codec, args)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -246,6 +246,15 @@ private final case class SelectBuilder[T, R](
       SelectBuilder.from(newFrom, args)
     }
 
+  def except(rhs: SelectBuilder[?, ?]): Result[SelectBuilder[?, R]] =
+    for {
+      left <- build()
+      right <- rhs.build()
+    } yield {
+      val newFrom = TypedFrom(Query.Except(left, right, false), args.aliasGen)(using select.expr.codec)
+      SelectBuilder.from(newFrom, args)
+    }
+
   private def toSubquery: Result[SelectBuilder[R, R]] = build().map(makeSubquery(_, select.expr.codec))
 
   private def requiresSubqueryForSeqOps[T, R](compiled: CompiledExprOrExplode[T, R]): Boolean =

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -57,6 +57,9 @@ final case class SqlDialect(
     // BigQuery complains when the struct functions is used in GROUP BY clause but has no problem
     // when done as part of a subquery first.
     useSubqueryToAvoidStructInGroupBy: Boolean = false,
+    // BigQuery does not support EXCEPT DISTINCT when any SELECT column is of STRUCT type.
+    // When false, the Distinct(LeftAntiJoin(_ == _)) pattern uses NOT EXISTS + DISTINCT instead.
+    supportsExceptDistinctOnStructColumns: Boolean = true,
     values: SqlDialect.Values,
     writeSupport: SqlDialect.WriteSupport,
     rand: String,
@@ -371,6 +374,7 @@ object SqlDialect {
     trimFunction = TrimFunction.Characters("trim", " "),
     tryCast = "SAFE_CAST",
     useSubqueryToAvoidStructInGroupBy = true,
+    supportsExceptDistinctOnStructColumns = false,
     values = Values.SelectUnionAll,
     rand = "RAND",
     writeSupport = WriteSupport.ExportData,

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/Query.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/Query.scala
@@ -13,6 +13,7 @@ private[sql] enum Query {
       limit: Option[Int] = None
   )
   case Union(left: Query, right: Query, all: Boolean)
+  case Except(left: Query, right: Query, all: Boolean)
   case CreateTable(tableName: String, format: String, location: SqlExpr, query: Query, options: Query.Options)
   case ExportData(query: Query, options: Query.Options)
 }

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
@@ -96,7 +96,11 @@ private[tyda] final case class SqlWriter(writer: Writer) {
 
       case Query.Union(left, right, all) =>
         val union = if (all) then "UNION ALL" else "UNION"
-        writeSql"$left $union $right"
+        writeSql"($left) $union ($right)"
+
+      case Query.Except(left, right, all) =>
+        val except = if (all) then "EXCEPT" else "EXCEPT DISTINCT"
+        writeSql"($left) $except ($right)"
 
       case Query.CreateTable(tableName, format, location, query, options) =>
         writeSql"CREATE TABLE $tableName USING $format$options LOCATION $location AS $query"

--- a/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
@@ -14,6 +14,18 @@ SELECT DISTINCT t1.value AS value FROM t1
 SELECT DISTINCT t1.value AS value FROM t1
 ------ end
 
+------ Test: except
+(SELECT t1.value AS value FROM t1) EXCEPT DISTINCT (SELECT t2.value AS value FROM t2)
+------ end
+
+------ Test: except on struct
+(SELECT t1._1 AS _1, t1._2 AS _2 FROM t1) EXCEPT DISTINCT (SELECT t2._1 AS _1, t2._2 AS _2 FROM t2)
+------ end
+
+------ Test: except with self
+(SELECT t1.value AS value FROM t1) EXCEPT DISTINCT (SELECT t1.value AS value FROM t1)
+------ end
+
 ------ Test: explode Map
 SELECT t2._1 AS _1, t2._2 AS _2 FROM (SELECT CAST(t0.value AS ARRAY<STRUCT<_1 INT,_2 INT>>) AS value FROM (SELECT t1.value AS value FROM t1) AS t0) AS t1, t1.value AS t2
 ------ end
@@ -139,15 +151,15 @@ SELECT CAST(1 AS INT) AS value FROM t1
 ------ end
 
 ------ Test: union
-SELECT t1.value AS value FROM t1 UNION ALL SELECT t2.value AS value FROM t2
+(SELECT t1.value AS value FROM t1) UNION ALL (SELECT t2.value AS value FROM t2)
 ------ end
 
 ------ Test: union on struct
-SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 UNION ALL SELECT t2._1 AS _1, t2._2 AS _2 FROM t2
+(SELECT t1._1 AS _1, t1._2 AS _2 FROM t1) UNION ALL (SELECT t2._1 AS _1, t2._2 AS _2 FROM t2)
 ------ end
 
 ------ Test: union with self
-SELECT t1.value AS value FROM t1 UNION ALL SELECT t1.value AS value FROM t1
+(SELECT t1.value AS value FROM t1) UNION ALL (SELECT t1.value AS value FROM t1)
 ------ end
 
 ------ Test: where

--- a/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
@@ -14,6 +14,18 @@ SELECT DISTINCT t1.value AS value FROM t1
 SELECT DISTINCT t1.value AS value FROM t1
 ------ end
 
+------ Test: except
+(SELECT t1.value AS value FROM t1) EXCEPT DISTINCT (SELECT t2.value AS value FROM t2)
+------ end
+
+------ Test: except on struct
+(SELECT t1._1 AS _1, t1._2 AS _2 FROM t1) EXCEPT DISTINCT (SELECT t2._1 AS _1, t2._2 AS _2 FROM t2)
+------ end
+
+------ Test: except with self
+(SELECT t1.value AS value FROM t1) EXCEPT DISTINCT (SELECT t1.value AS value FROM t1)
+------ end
+
 ------ Test: explode Map
 SELECT t0._1._1 AS _1, t0._1._2 AS _2 FROM (SELECT explode(CAST(map_entries(t1.value) AS ARRAY<STRUCT<_1 INT NOT NULL,_2 INT NOT NULL>>)) AS _1 FROM t1) AS t0
 ------ end
@@ -139,15 +151,15 @@ SELECT CAST(1 AS INT) AS value FROM t1
 ------ end
 
 ------ Test: union
-SELECT t1.value AS value FROM t1 UNION ALL SELECT t2.value AS value FROM t2
+(SELECT t1.value AS value FROM t1) UNION ALL (SELECT t2.value AS value FROM t2)
 ------ end
 
 ------ Test: union on struct
-SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 UNION ALL SELECT t2._1 AS _1, t2._2 AS _2 FROM t2
+(SELECT t1._1 AS _1, t1._2 AS _2 FROM t1) UNION ALL (SELECT t2._1 AS _1, t2._2 AS _2 FROM t2)
 ------ end
 
 ------ Test: union with self
-SELECT t1.value AS value FROM t1 UNION ALL SELECT t1.value AS value FROM t1
+(SELECT t1.value AS value FROM t1) UNION ALL (SELECT t1.value AS value FROM t1)
 ------ end
 
 ------ Test: where

--- a/tyda-sql/src/test/resources/golden/DatasetJoinBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetJoinBigQueryGoldenSuite.golden
@@ -142,12 +142,16 @@ SELECT struct(t0._1 AS _1, t0._2 AS _2) AS _1, struct(t1._1 AS _1, t1._2 AS _2) 
 SELECT struct(t0._1 AS _1, t0._2 AS _2) AS _1, struct(t1._1 AS _1, t1._2 AS _2) AS _2 FROM (SELECT DISTINCT struct(t1._1 AS _1, t1._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1)) AS t0 JOIN t1 ON (t0._1._2 = t1._2)
 ------ end
 
+------ Test: self join mutiple left with except
+SELECT struct(t0._1 AS _1, t0._2 AS _2) AS _1, struct(t1._1 AS _1, t1._2 AS _2) AS _2 FROM (SELECT DISTINCT struct(t1._1 AS _1, t1._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1) WHERE (NOT EXISTS (SELECT struct(t2._1 AS _1, t2._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2 FROM t2 WHERE (struct(struct(t1._1 AS _1, t1._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2) = struct(struct(t2._1 AS _1, t2._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2))))) AS t0 JOIN t1 ON (t0._1._2 = t1._2)
+------ end
+
 ------ Test: self join mutiple left with select
 SELECT struct(t1._1 AS _1, t1._2 AS _2) AS _1, struct(t1._1 AS _1, t1._2 AS _2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1) JOIN t1 ON (t1._2 = t1._2)
 ------ end
 
 ------ Test: self join mutiple left with union
-SELECT struct(t0._1 AS _1, t0._2 AS _2) AS _1, struct(t1._1 AS _1, t1._2 AS _2) AS _2 FROM (SELECT struct(t1._1 AS _1, t1._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1) UNION ALL SELECT struct(t2._1 AS _1, t2._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2 FROM t2) AS t0 JOIN t1 ON (t0._1._2 = t1._2)
+SELECT struct(t0._1 AS _1, t0._2 AS _2) AS _1, struct(t1._1 AS _1, t1._2 AS _2) AS _2 FROM ((SELECT struct(t1._1 AS _1, t1._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1)) UNION ALL (SELECT struct(t2._1 AS _1, t2._2 AS _2) AS _1, struct(t2._1 AS _1, t2._2 AS _2) AS _2 FROM t2)) AS t0 JOIN t1 ON (t0._1._2 = t1._2)
 ------ end
 
 ------ Test: self join mutiple nested left hand side

--- a/tyda-sql/src/test/resources/golden/DatasetJoinSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetJoinSparkSqlGoldenSuite.golden
@@ -142,12 +142,16 @@ SELECT named_struct('_1', t0._1, '_2', t0._2) AS _1, named_struct('_1', t1._1, '
 SELECT named_struct('_1', t0._1, '_2', t0._2) AS _1, named_struct('_1', t1._1, '_2', t1._2) AS _2 FROM (SELECT DISTINCT named_struct('_1', t1._1, '_2', t1._2) AS _1, named_struct('_1', t2._1, '_2', t2._2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1)) AS t0 JOIN t1 ON (t0._1._2 = t1._2)
 ------ end
 
+------ Test: self join mutiple left with except
+SELECT named_struct('_1', t0._1, '_2', t0._2) AS _1, named_struct('_1', t1._1, '_2', t1._2) AS _2 FROM ((SELECT named_struct('_1', t1._1, '_2', t1._2) AS _1, named_struct('_1', t2._1, '_2', t2._2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1)) EXCEPT DISTINCT (SELECT named_struct('_1', t2._1, '_2', t2._2) AS _1, named_struct('_1', t2._1, '_2', t2._2) AS _2 FROM t2)) AS t0 JOIN t1 ON (t0._1._2 = t1._2)
+------ end
+
 ------ Test: self join mutiple left with select
 SELECT named_struct('_1', t1._1, '_2', t1._2) AS _1, named_struct('_1', t1._1, '_2', t1._2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1) JOIN t1 ON (t1._2 = t1._2)
 ------ end
 
 ------ Test: self join mutiple left with union
-SELECT named_struct('_1', t0._1, '_2', t0._2) AS _1, named_struct('_1', t1._1, '_2', t1._2) AS _2 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2) AS _1, named_struct('_1', t2._1, '_2', t2._2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1) UNION ALL SELECT named_struct('_1', t2._1, '_2', t2._2) AS _1, named_struct('_1', t2._1, '_2', t2._2) AS _2 FROM t2) AS t0 JOIN t1 ON (t0._1._2 = t1._2)
+SELECT named_struct('_1', t0._1, '_2', t0._2) AS _1, named_struct('_1', t1._1, '_2', t1._2) AS _2 FROM ((SELECT named_struct('_1', t1._1, '_2', t1._2) AS _1, named_struct('_1', t2._1, '_2', t2._2) AS _2 FROM t1 JOIN t2 ON (t1._1 = t2._1)) UNION ALL (SELECT named_struct('_1', t2._1, '_2', t2._2) AS _1, named_struct('_1', t2._1, '_2', t2._2) AS _2 FROM t2)) AS t0 JOIN t1 ON (t0._1._2 = t1._2)
 ------ end
 
 ------ Test: self join mutiple nested left hand side

--- a/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
@@ -23,7 +23,7 @@ SELECT `table-name`.`dashed-column` AS `dashed-column` FROM `table-name`
 ------ end
 
 ------ Test: escape strings
-SELECT 'O\'R' AS value UNION ALL SELECT 'Line1\nLine2' AS value UNION ALL SELECT 'Tab\tCharacter' AS value
+(SELECT 'O\'R' AS value) UNION ALL ((SELECT 'Line1\nLine2' AS value) UNION ALL (SELECT 'Tab\tCharacter' AS value))
 ------ end
 
 ------ Test: escape value columns
@@ -39,7 +39,7 @@ SELECT table1.a AS _1, t0 AS _2 FROM table1, table1.d AS t0
 ------ end
 
 ------ Test: fromSeq
-SELECT CAST(1 AS INT) AS value UNION ALL SELECT CAST(2 AS INT) AS value UNION ALL SELECT CAST(3 AS INT) AS value
+(SELECT CAST(1 AS INT) AS value) UNION ALL ((SELECT CAST(2 AS INT) AS value) UNION ALL (SELECT CAST(3 AS INT) AS value))
 ------ end
 
 ------ Test: full outer join product on lhs

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
@@ -90,6 +90,10 @@ trait DatasetBasicSuite extends DatasetSuite {
   test[(Int, Int), (Int, Int), (Int, Int)]("union on struct", (left, right) => left.union(right))
   test[Int, Int]("union with self", ds => ds.union(ds))
 
+  test[Int, Int, Int]("except", (left, right) => left.except(right))
+  test[(Int, Int), (Int, Int), (Int, Int)]("except on struct", (left, right) => left.except(right))
+  test[Int, Int]("except with self", ds => ds.except(ds))
+
   test[Int, Int]("limit basic", _.limit(5))
   test[Int, Int]("limit zero", _.limit(0))
   test[(Int, Int), (Int, Int)]("limit after select", _.select(x => (x._1, x._2)).limit(3))

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetJoinSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetJoinSuite.scala
@@ -135,6 +135,12 @@ trait DatasetJoinSuite extends DatasetSuite {
       ds1.join(ds2, _._1 == _._1).union(ds2.select(identity, identity)).join(ds1, _._1._2 == _._2)
   )
   test[Pair, Pair, ((Pair, Pair), Pair)](
+    "self join mutiple left with except",
+    (ds1: Dataset[Pair], ds2: Dataset[Pair]) =>
+      ds1.join(ds2, _._1 == _._1).except(ds2.select(identity, identity)).join(ds1, _._1._2 == _._2)
+  )
+
+  test[Pair, Pair, ((Pair, Pair), Pair)](
     "self join mutiple left with distinct",
     (ds1: Dataset[Pair], ds2: Dataset[Pair]) =>
       ds1.join(ds2, _._1 == _._1).distinct.join(ds1, _._1._2 == _._2)

--- a/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
@@ -434,6 +434,13 @@ sealed trait Dataset[T: Codec] {
     */
   def union(other: Dataset[T]): Dataset[T] = Dataset.Union(this, other)
 
+  /** Returns a new Dataset containing the rows in this Dataset that are not
+    * present in the other Dataset. Duplicate rows are eliminated.
+    *
+    * This is equivalent to SQL `EXCEPT DISTINCT`.
+    */
+  def except(other: Dataset[T])(using Groupable[T]): Dataset[T] = leftAntiJoin(other, _ == _).distinct
+
   /** Proivdes a hint that the Dataset should be cached.
     *
     * There is no corresponding uncache method it expected that the runner will


### PR DESCRIPTION
Introducing Except in Dataset API: returns a new Dataset containing the rows in main dataset that are not in the dataset passed as parameter. Duplicated rows are eliminated. This is equivalent to SQL `DISTINCT EXCEPT`

**Note**: BigQuery does not support `INTERSECT DISTINCT` or `EXCEPT DISTINCT` operation with type `STRUCT`, so a workaround based on AntiLeftJoin + distinct has been implemented instead.