### PR TITLE
Support countDistinct aggregate

### DIFF
--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/explain.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/explain.scala
@@ -112,6 +112,7 @@ private def explainPrimitiveAggregate(primitive: PrimitiveAggregate[?, ?], arg: 
     case PrimitiveAggregate.Collect() => "collect($arg)"
     case PrimitiveAggregate.Count() => "count($arg)"
     case PrimitiveAggregate.CountSome() => "countSome($arg)"
+    case PrimitiveAggregate.CountDistinct() => "countDistinct($arg)"
     case PrimitiveAggregate.BoolAnd() => "boolAnd($arg)"
     case PrimitiveAggregate.BoolOr() => "boolOr($arg)"
     case PrimitiveAggregate.Min(ord) => s"min($arg)(using $ord)"

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/RemoveDistinctAggregatesOnArraysAndStructs.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/RemoveDistinctAggregatesOnArraysAndStructs.scala
@@ -1,0 +1,215 @@
+package com.choreograph.tyda.rewrite
+
+import scala.NamedTuple.AnyNamedTuple
+
+import com.choreograph.tyda.AggregateExpr
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.CompiledAggregateExpr
+import com.choreograph.tyda.CompiledExpr
+import com.choreograph.tyda.Dataset
+import com.choreograph.tyda.Expr
+import com.choreograph.tyda.ExprNode
+import com.choreograph.tyda.NonEmpty
+import com.choreograph.tyda.PrimitiveAggregate
+import com.choreograph.tyda.TreeApi.Continue
+import com.choreograph.tyda.TreeApi.Skip
+import com.choreograph.tyda.TreeApi.Stop
+import com.choreograph.tyda.aggregates.count
+import com.choreograph.tyda.functions.namedTuple
+
+/** Rewrites `COUNT(DISTINCT expr)` where `expr` is a complex type (collection,
+  * struct) into an equivalent grouped subquery, for engines that do not support
+  * `DISTINCT` on such types (e.g. BigQuery).
+  *
+  * Each unsupported aggregate is rewritten as:
+  * {{{
+  * SELECT key, COUNT(*) FROM (SELECT DISTINCT key, expr FROM input) GROUP BY key
+  * }}}
+  *
+  * Supported aggregates are evaluated in a separate subquery and the results
+  * are joined back together before the final expression is reconstructed.
+  */
+object RemoveDistinctAggregatesOnArraysAndStructs extends DatasetRule {
+
+  private final case class RewriteCandidate[A, T, R](
+      aggRef: ExprNode.Reference[A],
+      agg: ExprNode.Aggregate[T, R],
+      replacement: CompiledAggregateExpr[T, R]
+  ) {
+    def compute[K <: AnyNamedTuple](
+        input: Dataset[A],
+        key: CompiledExpr[A, K]
+    ): AggregatePart[K, (value: R)] = {
+      val distinctInput: Dataset[(K, T)] =
+        Dataset.Distinct(Dataset.Select1(input, key.combine(CompiledExpr(aggRef, agg.arg))))
+      given Codec[K] = key.codec
+      given Codec[T] = agg.arg.codec
+      given Codec[R] = agg.codec
+      val wrapped = replacement.andThen(CompiledExpr(v => namedTuple((value = v))))
+      val ds =
+        Dataset.GroupedAggregate(distinctInput, CompiledExpr(_._1), wrapped.compose(CompiledExpr(_._2)))
+      AggregatePart(ds, Seq(Replacement(agg, CompiledExpr[(value: R), R](_.value))))
+    }
+  }
+
+  private object UnsupportedDistinctInput {
+    def unapply[T](agg: ExprNode[T]): Boolean =
+      agg.codec match {
+        case CollectionCodec(_) => true
+        case StructCodec() => true
+        case _ => false
+      }
+  }
+  private object UnsupportedAggregate {
+    def unapply[T, R](agg: ExprNode.Aggregate[T, R]): Option[CompiledAggregateExpr[T, R]] =
+      agg match {
+        case ExprNode.Aggregate(arg @ UnsupportedDistinctInput(), PrimitiveAggregate.CountDistinct()) =>
+          Some(CompiledAggregateExpr[T, R](count(_))(using arg.codec))
+        case _ => None
+      }
+  }
+
+  /* Hold an unsupported aggregate `agg` and `extractor` that camptures how to extract the same result from
+   * the output after the rewrite. */
+  private final case class Replacement[V, T, R](
+      agg: ExprNode.Aggregate[T, R],
+      extractor: CompiledExpr[V, R]
+  ) {
+    def compose[A: Codec](expr: Expr[A] => Expr[V]): Replacement[A, T, R] =
+      Replacement(agg, extractor.compose(CompiledExpr(expr)))
+  }
+
+  private final case class AggregatePart[K, V](ds: Dataset[(K, V)], replacements: Seq[Replacement[V, ?, ?]]) {
+    def join[U](other: AggregatePart[K, U]): AggregatePart[K, (V, U)] = {
+      val joined = ds.join(other.ds)
+      given Codec[U] = other.ds.codec.elements._2
+      given Codec[V] = ds.codec.elements._2
+      AggregatePart(
+        joined,
+        replacements.map(_.compose[(V, U)](_._1)) ++ other.replacements.map(_.compose[(V, U)](_._2))
+      )
+    }
+
+    def finish[U](originalExpr: CompiledAggregateExpr[?, U]): Dataset[(K, U)] = {
+      val resultRef = ExprNode.Reference()(using ds.codec)
+      val replaced = replacements
+        .map(_.compose[(K, V)](_._2)(using ds.codec))
+        .foldLeft(originalExpr.expr) { case (expr, Replacement(agg, extractor)) =>
+          expr.replace(agg, extractor.expr.replace(extractor.arg, resultRef))
+        }
+      val key = CompiledExpr[(K, V), K](_._1)(using ds.codec)
+      val value = CompiledExpr(resultRef, replaced)
+      Dataset.Select1(ds, key.combine(value))
+    }
+  }
+
+  private def computeSupportedPart[A, K <: AnyNamedTuple, R <: AnyNamedTuple](
+      input: Dataset[A],
+      key: CompiledExpr[A, K],
+      aggregate: CompiledAggregateExpr[A, R],
+      supported: Seq[ExprNode.Aggregate[?, ?]]
+  ): AggregatePart[K, ?] = {
+    type Result <: AnyNamedTuple
+
+    val fields = supported.zipWithIndex.map(_._2).map(i => s"result${i}")
+    /* TYPE SAFETY: We construct the output so that supportedCompiledAggregate and initialReplacements have
+     * compatible types. */
+    val supportedCompiledAggregate: CompiledAggregateExpr[A, Result] =
+      CompiledAggregateExpr(aggregate.arg, ExprNode.makeNamedTupleUnsafe(supported, fields).asInstanceOf)
+    val supportedComputed = Dataset.GroupedAggregate(input, key, supportedCompiledAggregate)
+    val ref = ExprNode.Reference()(using supportedCompiledAggregate.expr.codec)
+    val initialReplacements: Seq[Replacement[Result, ?, ?]] = supported
+      .zip(fields)
+      .map((agg, name) => Replacement(agg, CompiledExpr(ref, ExprNode.Select(ref, name))))
+    AggregatePart(supportedComputed, initialReplacements)
+  }
+
+  def rewriteGrouped[V, K <: AnyNamedTuple, R <: AnyNamedTuple](
+      groupedAggregate: Dataset.GroupedAggregate[V, K, R]
+  ): Option[Dataset[(K, R)]] = {
+    val input = groupedAggregate.input
+    val key = groupedAggregate.key
+    val aggregate = groupedAggregate.agg
+    val (unsupported, supported) = aggregate
+      .expr
+      .collect { case node @ ExprNode.Aggregate(_, _) => node }
+      .partitionMap {
+        case agg @ UnsupportedAggregate(replacementAgg) =>
+          Left(RewriteCandidate(aggregate.arg, agg, replacementAgg))
+        case other => Right(other)
+      }
+    if unsupported.isEmpty then return None
+
+    val parts = NonEmpty.from(supported).map(computeSupportedPart(input, key, aggregate, _)) ++
+      unsupported.map(_.compute(input, key))
+    Some(parts.reduce(_.join(_)).finish(aggregate))
+  }
+
+  def rewriteAggregate[V, R](aggregate: Dataset.Aggregate[V, R]): Option[Dataset[Option[R]]] = {
+    val input = aggregate.input
+    val agg = aggregate.agg
+    val hasUnsupported = agg
+      .expr
+      .exists {
+        case UnsupportedAggregate(_) => true
+        case _ => false
+      }
+    if !hasUnsupported then return None
+
+    val nbrAggregates = agg
+      .expr
+      .count {
+        case ExprNode.Aggregate(_, _) => true
+        case _ => false
+      }
+
+    def computeDistinctInput[A, B](unsupported: ExprNode.Aggregate[A, B]): Dataset[A] = {
+      val extractArg = {
+        val ref = ExprNode.Reference()(using agg.arg.codec)
+        CompiledExpr(ref, unsupported.arg.replace(agg.arg, ref))
+      }
+      Dataset.Distinct(Dataset.Select1(input, extractArg))
+    }
+
+    if nbrAggregates == 1 then {
+      /* Acc case class is only use to make sure the compiler tracks that the distinctInput and newRef has the
+       * same type parameter. */
+      final case class Acc[T](distinctInput: Dataset[T], newRef: ExprNode.Reference[T])
+      val (Some(acc), newExpr) = agg
+        .expr
+        .transformAccumulateDown[Option[Acc[?]]](None)([t] =>
+          (_, node) =>
+            node match {
+              case unsupported @ UnsupportedAggregate(replacement) =>
+                val newRef = ExprNode.Reference()(using unsupported.arg.codec)
+                Stop(
+                  Some(Acc(computeDistinctInput(unsupported), newRef)),
+                  replacement.expr.replace(replacement.arg, newRef)
+                )
+              case other => Continue((None, other))
+            }
+        ): @unchecked // Safe since we already checked that there is exactly one unssupported aggregate
+      Some(Dataset.Aggregate(acc.distinctInput, CompiledAggregateExpr(acc.newRef, newExpr)))
+    } else {
+
+      val exprWithSubqueries = agg
+        .expr
+        .transformDown([t] =>
+          _ match {
+            case unsupported @ UnsupportedAggregate(replacement) =>
+              val computed = Dataset.Aggregate(computeDistinctInput(unsupported), replacement)
+              Skip(ExprNode.ScalarSubquery(computed).get)
+            case other => Continue(other)
+          }
+        )
+      Some(Dataset.Aggregate(input, CompiledAggregateExpr(agg.arg, exprWithSubqueries)))
+    }
+  }
+
+  def apply[T](dataset: Dataset[T]): Dataset[T] =
+    dataset match {
+      case ds @ Dataset.GroupedAggregate(_, _, _) => rewriteGrouped(ds).getOrElse(dataset)
+      case ds @ Dataset.Aggregate(_, _) => rewriteAggregate(ds).getOrElse(dataset)
+      case _ => dataset
+    }
+}

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/StructCodec.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/StructCodec.scala
@@ -1,0 +1,13 @@
+package com.choreograph.tyda.rewrite
+
+import com.choreograph.tyda.Codec
+
+private[tyda] object StructCodec {
+  def unapply[T](codec: Codec[T]): Boolean =
+    codec match {
+      case Codec.Product(_, _, _) => true
+      case Codec.Option(Codec.Option(_)) => true
+      case Codec.FromInjection(_, to) => unapply(to)
+      case _ => false
+    }
+}

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/PrimitiveAggregateOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/PrimitiveAggregateOnSpark.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.functions.bool_and
 import org.apache.spark.sql.functions.bool_or
 import org.apache.spark.sql.functions.collect_list
 import org.apache.spark.sql.functions.count
+import org.apache.spark.sql.functions.countDistinct
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.functions.max_by
@@ -29,6 +30,7 @@ private[spark] object PrimitiveAggregateOnSpark {
       case PrimitiveAggregate.Collect() if !cf.codec.isInstanceOf[Codec.Option[?]] => collect_list(cf.row)
       case PrimitiveAggregate.Count() => count(lit(1))
       case PrimitiveAggregate.CountSome() => count(cf.row)
+      case PrimitiveAggregate.CountDistinct() => countDistinct(cf.row)
       case PrimitiveAggregate.BoolAnd() => bool_and(cf.row)
       case PrimitiveAggregate.BoolOr() => bool_or(cf.row)
       case PrimitiveAggregate.Max(_) => max(cf.row)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -711,6 +711,7 @@ private def primitiveAggregate[T: Codec](
     Right(SqlExpr.Function(name, Seq(SqlExpr.FieldAccess(arg, "_1"), SqlExpr.FieldAccess(arg, "_2"))))
   agg match {
     case PrimitiveAggregate.Count() => simple("count")
+    case PrimitiveAggregate.CountDistinct() => Right(SqlExpr.Function("count", Seq(arg), distinct = true))
     case PrimitiveAggregate.BoolAnd() => simple(dialect.boolAndFunction)
     case PrimitiveAggregate.BoolOr() => simple(dialect.boolOrFunction)
     case agg @ (PrimitiveAggregate.Min(_)) if isFloatingPoint(Codec[T]) =>

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -9,6 +9,7 @@ import com.choreograph.tyda.rewrite.DisfavorIsNotDistinctFrom
 import com.choreograph.tyda.rewrite.DistributeProductAndSeqEquals
 import com.choreograph.tyda.rewrite.ExprRule
 import com.choreograph.tyda.rewrite.RemoveArrayCasts
+import com.choreograph.tyda.rewrite.RemoveDistinctAggregatesOnArraysAndStructs
 import com.choreograph.tyda.rewrite.RemoveNullSafeEqualsInJoinCondition
 import com.choreograph.tyda.rewrite.SparkJsonCompatability
 import com.choreograph.tyda.rewrite.WrapOptionInCollect
@@ -379,7 +380,8 @@ object SqlDialect {
       DistributeProductAndSeqEquals,
       DisfavorIsNotDistinctFrom,
       RemoveArrayCasts,
-      RemoveNullSafeEqualsInJoinCondition
+      RemoveNullSafeEqualsInJoinCondition,
+      RemoveDistinctAggregatesOnArraysAndStructs
     )
   )
 

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
@@ -5,7 +5,7 @@ private[sql] enum SqlExpr {
   case Brackets(exprs: Seq[SqlExpr])
   case BinaryOp(op: String, lhs: SqlExpr, rhs: SqlExpr)
   case FieldAccess(struct: SqlExpr, field: Identifier)
-  case Function(name: String, args: Seq[SqlExpr])
+  case Function(name: String, args: Seq[SqlExpr], distinct: Boolean = false)
   case Index(array: SqlExpr, index: SqlExpr)
   case Ident(name: Identifier)
   case LiteralString(value: String)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
@@ -32,7 +32,8 @@ private[tyda] final case class SqlWriter(writer: Writer) {
       case SqlExpr.BinaryOp(op, lhs, rhs) => writeSql"($lhs $op $rhs)"
       case SqlExpr.Brackets(exprs) => writeSql1"[$exprs]"
       case SqlExpr.FieldAccess(struct, field) => writeSql"$struct.$field"
-      case SqlExpr.Function(name, args) => writeSql"$name($args)"
+      case SqlExpr.Function(name, args, distinct) =>
+        if distinct then writeSql"$name(DISTINCT $args)" else writeSql"$name($args)"
       case SqlExpr.Index(arr, idx) => writeSql"$arr[$idx]"
       case SqlExpr.Ident(name) => write(name)
       case SqlExpr.UnaryOp(op, e, true) => writeSql"($op $e)"

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
@@ -94,6 +94,38 @@ SELECT t1._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM t1 GROUP BY t1._1
 SELECT count(CAST(1 AS INT)) AS value FROM t1 GROUP BY CAST(NULL AS INT)
 ------ end
 
+------ Test: countDistinct array
+SELECT count(CAST(1 AS INT)) AS value FROM (SELECT DISTINCT struct(CAST(1 AS INT) AS key) AS _1, t1.value AS _2 FROM t1) AS t0 GROUP BY t0._1
+------ end
+
+------ Test: countDistinct group by
+SELECT t1._1 AS _1, count(DISTINCT t1._2) AS _2 FROM t1 GROUP BY t1._1
+------ end
+
+------ Test: countDistinct struct
+SELECT count(CAST(1 AS INT)) AS value FROM (SELECT DISTINCT struct(CAST(1 AS INT) AS key) AS _1, struct(t1._1 AS _1, t1._2 AS _2) AS _2 FROM t1) AS t0 GROUP BY t0._1
+------ end
+
+------ Test: countDistinct struct multiple
+SELECT t2._1.key AS key, t2._2.value AS d1, t3._2.value AS d2 FROM (SELECT t0._1 AS _1, struct(count(CAST(1 AS INT)) AS value) AS _2 FROM (SELECT DISTINCT struct(t1._1._1 AS key) AS _1, t1._1 AS _2 FROM t1) AS t0 GROUP BY t0._1) AS t2 JOIN (SELECT t1._1 AS _1, struct(count(CAST(1 AS INT)) AS value) AS _2 FROM (SELECT DISTINCT struct(t1._1._1 AS key) AS _1, t1._2 AS _2 FROM t1) AS t1 GROUP BY t1._1) AS t3 ON (t2._1 = t3._1)
+------ end
+
+------ Test: countDistinct struct multiple and supported
+SELECT t1._1.key AS key, t2._2.value AS d1, t4._2.value AS d2, t1._2.result0 AS tot FROM (SELECT struct(t1._1._1 AS key) AS _1, struct(count(CAST(1 AS INT)) AS result0) AS _2 FROM t1 GROUP BY t1._1._1) AS t1 JOIN (SELECT t0._1 AS _1, struct(count(CAST(1 AS INT)) AS value) AS _2 FROM (SELECT DISTINCT struct(t1._1._1 AS key) AS _1, t1._1 AS _2 FROM t1) AS t0 GROUP BY t0._1) AS t2 ON (t1._1 = t2._1) JOIN (SELECT t3._1 AS _1, struct(count(CAST(1 AS INT)) AS value) AS _2 FROM (SELECT DISTINCT struct(t1._1._1 AS key) AS _1, t1._2 AS _2 FROM t1) AS t3 GROUP BY t3._1) AS t4 ON (t1._1 = t4._1)
+------ end
+
+------ Test: countDistinct struct multiple and supported ungrouped
+SELECT CASE WHEN (count(1) <> 0) THEN struct((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM (SELECT DISTINCT t1._1._1 AS _1, t1._1._2 AS _2 FROM t1) AS t0) AS d1, (SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM (SELECT DISTINCT t1._2._1 AS _1, t1._2._2 AS _2 FROM t1) AS t2) AS d2, count(CAST(1 AS INT)) AS tot) END AS value FROM t1
+------ end
+
+------ Test: countDistinct struct ungrouped
+SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM (SELECT DISTINCT t1._1 AS _1, t1._2 AS _2 FROM t1) AS t0
+------ end
+
+------ Test: countDistinct whole row
+SELECT count(DISTINCT t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
+------ end
+
 ------ Test: countIf expr
 SELECT count(CASE WHEN (NOT (t1.value <= CAST(0 AS INT))) THEN CAST(1 AS INT) END) AS value FROM t1 GROUP BY CAST(NULL AS INT)
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesSparkSqlGoldenSuite.golden
@@ -94,6 +94,38 @@ SELECT t1._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM t1 GROUP BY t1._1
 SELECT count(CAST(1 AS INT)) AS value FROM t1 GROUP BY CAST(NULL AS INT)
 ------ end
 
+------ Test: countDistinct array
+SELECT count(DISTINCT t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
+------ end
+
+------ Test: countDistinct group by
+SELECT t1._1 AS _1, count(DISTINCT t1._2) AS _2 FROM t1 GROUP BY t1._1
+------ end
+
+------ Test: countDistinct struct
+SELECT count(DISTINCT named_struct('_1', t1._1, '_2', t1._2)) AS value FROM t1 GROUP BY CAST(NULL AS INT)
+------ end
+
+------ Test: countDistinct struct multiple
+SELECT t1._1._1 AS key, count(DISTINCT t1._1) AS d1, count(DISTINCT t1._2) AS d2 FROM t1 GROUP BY t1._1._1
+------ end
+
+------ Test: countDistinct struct multiple and supported
+SELECT t1._1._1 AS key, count(DISTINCT t1._1) AS d1, count(DISTINCT t1._2) AS d2, count(CAST(1 AS INT)) AS tot FROM t1 GROUP BY t1._1._1
+------ end
+
+------ Test: countDistinct struct multiple and supported ungrouped
+SELECT CASE WHEN (count(1) <> 0) THEN named_struct('d1', count(DISTINCT t1._1), 'd2', count(DISTINCT t1._2), 'tot', count(CAST(1 AS INT))) END AS value FROM t1
+------ end
+
+------ Test: countDistinct struct ungrouped
+SELECT CASE WHEN (count(1) <> 0) THEN count(DISTINCT named_struct('_1', t1._1, '_2', t1._2)) END AS value FROM t1
+------ end
+
+------ Test: countDistinct whole row
+SELECT count(DISTINCT t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
+------ end
+
 ------ Test: countIf expr
 SELECT count(CASE WHEN (NOT (t1.value <= CAST(0 AS INT))) THEN CAST(1 AS INT) END) AS value FROM t1 GROUP BY CAST(NULL AS INT)
 ------ end

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
@@ -18,6 +18,7 @@ import com.choreograph.tyda.aggregates.boolAnd
 import com.choreograph.tyda.aggregates.boolOr
 import com.choreograph.tyda.aggregates.collect
 import com.choreograph.tyda.aggregates.count
+import com.choreograph.tyda.aggregates.countDistinct
 import com.choreograph.tyda.aggregates.countIf
 import com.choreograph.tyda.aggregates.countSome
 import com.choreograph.tyda.aggregates.max
@@ -117,17 +118,42 @@ trait DatasetAggregatesSuite extends DatasetSuite {
     ds => ds.groupByKey(_._1).aggregateValue(collect(_._2)).pairs.select(_._1, _._2.map(_.cast[Int] + 1))
   )
 
-  test[Int, Int]("min whole row", ds => ds.groupByKey(_ => lit(1)).aggregateValue(min).values)
-  test[Int, Long]("count whole row", ds => ds.groupByKey(_ => lit(1)).aggregateValue(count).values)
-  test[Boolean, Long]("countIf whole row", ds => ds.groupByKey(_ => lit(1)).aggregateValue(countIf).values)
-  test[Int, Long]("countIf expr", ds => ds.groupByKey(_ => lit(1)).aggregateValue(countIf(_ > 0)).values)
+  test[Option[Int], Long](
+    "countSome whole row",
+    ds => ds.groupByKey(_ => lit(1)).aggregateValue(countSome).values
+  )
+  test[Int, Int]("min whole row", ds => ds.groupByKey(_ => 1).aggregateValue(min).values)
+  test[Int, Long]("count whole row", ds => ds.groupByKey(_ => 1).aggregateValue(count).values)
+  test[Boolean, Long]("countIf whole row", ds => ds.groupByKey(_ => 1).aggregateValue(countIf).values)
+  test[Int, Long]("countIf expr", ds => ds.groupByKey(_ => 1).aggregateValue(countIf(_ > 0)).values)
   test[(Int, Int), (Int, Long)](
     "countIf group by",
     ds => ds.groupByKey(_._1).aggregateValue(countIf(_._2 > 0)).pairs
   )
-  test[Option[Int], Long](
-    "countSome whole row",
-    ds => ds.groupByKey(_ => lit(1)).aggregateValue(countSome).values
+  test[Int, Long]("countDistinct whole row", ds => ds.groupByKey(_ => 1).aggregateValue(countDistinct).values)
+  test[(Int, Int), (Int, Long)](
+    "countDistinct group by",
+    ds => ds.groupByKey(_._1).aggregateValue(countDistinct(_._2)).pairs
+  )
+  test[Pair, Long]("countDistinct struct", ds => ds.groupByKey(_ => 1).aggregateValue(countDistinct).values)
+  test[(Pair, Pair), (key: TinyByte, d1: Long, d2: Long)](
+    "countDistinct struct multiple",
+    ds => ds.groupByKey(_._1._1).aggregate(r => (d1 = countDistinct(r._1), d2 = countDistinct(r._2)))
+  )
+  test[(Pair, Pair), (key: TinyByte, d1: Long, d2: Long, tot: Long)](
+    "countDistinct struct multiple and supported",
+    ds =>
+      ds.groupByKey(_._1._1)
+        .aggregate(r => (d1 = countDistinct(r._1), d2 = countDistinct(r._2), tot = count(r)))
+  )
+  test[(Pair, Pair), Option[(d1: Long, d2: Long, tot: Long)]](
+    "countDistinct struct multiple and supported ungrouped",
+    ds => ds.aggregate(r => (d1 = countDistinct(r._1), d2 = countDistinct(r._2), tot = count(r)))
+  )
+  test[Pair, Option[Long]]("countDistinct struct ungrouped", ds => ds.aggregate(countDistinct))
+  test[Seq[Int], Long](
+    "countDistinct array",
+    ds => ds.groupByKey(_ => 1).aggregateValue(countDistinct).values
   )
   test[(TinyByte, Option[Int]), Long](
     "countSome expr",

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
@@ -44,6 +44,13 @@ private sealed trait ExprNode[T] extends Selectable {
     ExprNode.api.collect(this, [t] => lifted(_))
   }
 
+  /** Count the number of nodes in the expression tree that satisfy the
+    * predicate `f`.
+    *
+    * For details see [[com.choreograph.tyda.TreeApi.count]]
+    */
+  def count(f: ExprNode[?] => Boolean): Long = ExprNode.api.count(this, [t] => f(_))
+
   /** Transform the expression tree from the bottom up.
     *
     * For details see [[com.choreograph.tyda.TreeApi.transformUp]]
@@ -129,6 +136,16 @@ private object ExprNode extends ExprApi[ExprNode] {
   def makeProductUnsafe[P](exprs: Seq[ExprNode[?]], codec: Codec.Product[P]): ExprNode[P] =
     // TYPE SAFETY: All the values in exprs are of type ExprNode[?]
     new MakeProduct(Tuple.fromArray(exprs.toArray).asInstanceOf, codec)
+
+  def makeTupleUnsafe(exprs: Seq[ExprNode[?]]): ExprNode[Tuple] =
+    // TYPE SAFETY: All the values in exprs are of type ExprNode[?]
+    makeTuple(Tuple.fromArray(exprs.toArray).asInstanceOf)
+
+  def makeNamedTupleUnsafe(exprs: Seq[ExprNode[?]], names: Seq[String]): ExprNode[? <: AnyNamedTuple] = {
+    assert(exprs.size == names.size)
+    val fields = names.zip(exprs.map(_.codec)).map(Field.apply(_, _))
+    makeProductUnsafe(exprs, Codec.unsafeNamedTuple(fields))
+  }
 
   final case class Range(start: ExprNode[Int], end: ExprNode[Int]) extends ExprNode[Seq[Int]] {
     override def codec: Codec[Seq[Int]] = Codec[Seq[Int]]

--- a/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregate.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregate.scala
@@ -8,6 +8,9 @@ private object PrimitiveAggregate {
   final case class Collect[T: Codec]() extends PrimitiveAggregate[T, Seq[T]]
   final case class Count[T]() extends PrimitiveAggregate[T, Long]
   final case class CountSome[T]() extends PrimitiveAggregate[Option[T], Long]
+  final case class CountDistinct[T: Codec]() extends PrimitiveAggregate[T, Long] {
+    def inputCodec: Codec[T] = summon
+  }
   final case class BoolAnd() extends PrimitiveAggregate[Boolean, Boolean]
   final case class BoolOr() extends PrimitiveAggregate[Boolean, Boolean]
   final case class Min[T: Codec](comparable: Comparable[T]) extends PrimitiveAggregate[T, T]

--- a/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregateEvaluation.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregateEvaluation.scala
@@ -1,5 +1,7 @@
 package com.choreograph.tyda
 
+import scala.reflect.ClassTag
+
 import com.choreograph.tyda.Aggregator.AndThen
 import com.choreograph.tyda.Aggregator.Compose
 import com.choreograph.tyda.Aggregator.Reduce
@@ -12,6 +14,10 @@ private[tyda] object PrimitiveAggregateEvaluation {
         Compose(Seq(_), Reduce[Seq[From]](_ ++ _))
       case PrimitiveAggregate.Count() => Compose(_ => 1L, Reduce[Long](_ + _))
       case PrimitiveAggregate.CountSome() => Compose(t => if t.isDefined then 1L else 0L, Reduce[Long](_ + _))
+      case countDistinct: PrimitiveAggregate.CountDistinct[?] =>
+        given Codec[From] = countDistinct.inputCodec
+        given Codec[Set[From]] = Codec.iterable[From, Set[From]]
+        AndThen(Compose(Set(_), Reduce[Set[From]](_ ++ _)), _.size.toLong)
       case PrimitiveAggregate.BoolAnd() => Reduce[Boolean](_ && _)
       case PrimitiveAggregate.BoolOr() => Reduce[Boolean](_ || _)
       case PrimitiveAggregate.Min(comparable) => Reduce(comparableToOrd(comparable).min)(using agg.codec)

--- a/tyda/src/main/scala/com/choreograph/tyda/TreeApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/TreeApi.scala
@@ -101,6 +101,9 @@ private[tyda] sealed trait TreeApi[Node, Base[_]] {
       (acc, base) => f(base).map(b => Continue(acc :+ b)).getOrElse(Continue(acc))
     )
 
+  final def count(value: Node, f: [t] => Base[t] => Boolean): Long =
+    fold(value)(0L)([t] => (acc, base) => if f(base) then Continue(acc + 1) else Continue(acc))
+
   /** Fold over the entire tree pre-order traversal. */
   final def fold[Acc](value: Node)(acc: Acc)(f: [t] => (Acc, Base[t]) => Control[Acc]): Acc = {
     lazy val visitor: FoldVisitor[Acc] = [t] =>

--- a/tyda/src/main/scala/com/choreograph/tyda/aggregates.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/aggregates.scala
@@ -3,10 +3,12 @@ package com.choreograph.tyda
 import scala.annotation.unused
 
 import com.choreograph.tyda.Expr.AsExpr
+import com.choreograph.tyda.Groupable
 import com.choreograph.tyda.PrimitiveAggregate.BoolAnd
 import com.choreograph.tyda.PrimitiveAggregate.BoolOr
 import com.choreograph.tyda.PrimitiveAggregate.Collect
 import com.choreograph.tyda.PrimitiveAggregate.Count
+import com.choreograph.tyda.PrimitiveAggregate.CountDistinct
 import com.choreograph.tyda.PrimitiveAggregate.CountSome
 import com.choreograph.tyda.PrimitiveAggregate.Max
 import com.choreograph.tyda.PrimitiveAggregate.MaxBy
@@ -63,6 +65,17 @@ object aggregates {
     * predicate is true.
     */
   def countIf[T](f: Expr[T] => Expr[Boolean]): Expr[T] => AggregateExpr[Long] = f.andThen(countIf)
+
+  /** AggregateExpr counting the number of distinct values.
+    */
+  def countDistinct[T: Groupable](e: Expr[T]): AggregateExpr[Long] =
+    aggregate(e, CountDistinct()(using e.codec))
+
+  /** AggregateExpr counting the number of distinct values of specified
+    * [[Expr]].
+    */
+  def countDistinct[T, R: Groupable, I: AsExpr.Of[R]](f: Expr[T] => I): Expr[T] => AggregateExpr[Long] =
+    f.andThen(AsExpr(_)).andThen(countDistinct)
 
   /** AggregateExpr returning true if all values are true.
     */


### PR DESCRIPTION
This adds support for distinct count aggregate. The implementation is
straight forward except for that BigQuery does not support distinct
aggregates on structs and arrays. So in order to support BigQuery a
rewrite rule is added that rewrite such quries to use `SELECT DISTINCT`
and the normal count and join the result when there are multiple
aggregates.

This translation might not be optimal as join are quite expensive. In
some future iteration we might want to look closer at how Spark rewrites
it internally https://github.com/apache/spark/blob/50514c5271e0fae3f2546c4edea9da8ee3323344/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregates.scala
But it not clear that possible to do on BigQuery as it uses per
aggregate FILTER clause, which I don't think BigQuery currently
supports.
