### PR TITLE
Add Binary type to tyda

### DIFF
--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/ExprEvaluation.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/ExprEvaluation.scala
@@ -7,6 +7,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.ReaderConfig
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import com.github.plokhotnyuk.jsoniter_scala.core.writeToString
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.CanCast
 import com.choreograph.tyda.CanTryCast
 import com.choreograph.tyda.Codec
@@ -237,6 +238,7 @@ object ExprEvaluation {
         case ExprNode.MicrosToDuration(inner) => impl(inner).andThen(Duration.fromMicros)
         case ExprNode.DateToDays(inner) => impl(inner).andThen(_.daysSinceEpoch)
         case ExprNode.DaysToDate(inner) => impl(inner).andThen(Date.fromDays)
+        case ExprNode.BytesLength(inner) => impl(inner).andThen(_.length)
         case ExprNode.MakeMap(pairs) => from => {
             val seq = impl(pairs)(from)
             val duplicates = seq
@@ -288,6 +290,7 @@ object ExprEvaluation {
       case CanCast.ShortToString => _.toString
       case CanCast.IntToString => _.toString
       case CanCast.LongToString => _.toString
+      case CanCast.StringToBytes => Binary.fromString
       case CanCast.DecimalToFloat() => _.toFloat
       case CanCast.DecimalToDouble() => _.toDouble
       case cast @ CanCast.DecimalToDecimal() =>

--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/explain.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/explain.scala
@@ -190,6 +190,7 @@ private def explainLambdaBody[T](expr: ExprNode[T], args: Map[ExprNode.Reference
       case ExprNode.MicrosToDuration(inner) => s"microsToDuration(${body(inner)})"
       case ExprNode.DateToDays(inner) => s"${body(inner)}.toDays"
       case ExprNode.DaysToDate(inner) => s"daysToDate(${body(inner)})"
+      case ExprNode.BytesLength(inner) => s"${body(inner)}.length"
       case ExprNode.ToRepr(inner, _) => s"asRepr(${body(inner)})"
       case ExprNode.FromRepr(inner, _) => s"fromRepr(${body(inner)})"
       case ExprNode.MakeMap(pairs) => s"makeMap(${body(pairs)})"

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
@@ -15,6 +15,7 @@ import org.apache.spark.sql.functions.endswith
 import org.apache.spark.sql.functions.filter
 import org.apache.spark.sql.functions.from_json
 import org.apache.spark.sql.functions.isnan
+import org.apache.spark.sql.functions.length
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.functions.map_contains_key
 import org.apache.spark.sql.functions.map_entries
@@ -278,6 +279,7 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
           lit(BigDecimal(1000000))).cast(catalystType(Codec[Duration]))
       case ExprNode.DateToDays(inner) => unix_date(convert(inner))
       case ExprNode.DaysToDate(inner) => date_from_unix_date(convert(inner))
+      case ExprNode.BytesLength(inner) => length(convert(inner))
       case ExprNode.ToRepr(inner, _) => convert(inner)
       case ExprNode.FromRepr(inner, _) => convert(inner)
       case ExprNode.MakeMap(pairs) => map_from_entries(convert(pairs))

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/DdlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/DdlDialect.scala
@@ -16,7 +16,8 @@ final case class DdlDialect(
      * nested arrays should work. */
     supportsArrayAsArrayElement: Boolean = true,
     floatType: String = "FLOAT",
-    doubleType: String = "DOUBLE"
+    doubleType: String = "DOUBLE",
+    bytesType: String = "BINARY"
 )
 
 object DdlDialect {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -485,6 +485,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
       case ExprNode.DaysToDate(value) => dialect.makeDate match {
           case SqlDialect.MakeDate.Function(name) => inner(value).map(v => SqlExpr.Function(name, Seq(v)))
         }
+      case ExprNode.BytesLength(value) => inner(value).map(b => SqlExpr.Function(dialect.bytesLength, Seq(b)))
       case ExprNode.Udf(_, _, _) =>
         Left(DatasetToSqlError.RequiresUdfCapability("UDFs are not supported on SQL"))
       case ExprNode.ToRepr(expr, _) => inner(expr)
@@ -949,6 +950,7 @@ private def literalToSqlExpr[T](value: T, codec: Codec.Primitive[T], dialect: Sq
     case Codec.String => SqlExpr.LiteralString(value.toString)
     case Codec.Bytes => dialect.binaryLiteral match {
         case SqlDialect.BinaryLiteral.HexString => SqlExpr.LiteralHexString(value)
+        case SqlDialect.BinaryLiteral.ByteEscapeString => SqlExpr.LiteralByteEscapeString(value)
       }
     case Codec.Boolean => SqlExpr.LiteralBool(value)
     case Codec.TimestampMicros => dialect.makeTimestamp match {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -29,6 +29,7 @@ final case class SqlDialect(
     binaryLiteral: SqlDialect.BinaryLiteral,
     boolAndFunction: String,
     boolOrFunction: String,
+    bytesLength: String,
     collectFunction: String,
     countIfFunction: String,
     ddl: DdlDialect,
@@ -267,6 +268,14 @@ object SqlDialect {
       * ```
       */
     case HexString
+
+    /** A binary literal is represented as a byte string with `\x` escapes. e.g.
+      * ```
+      * B'\x0A\x0B\x0C'
+      * ```
+      * Used by BigQuery.
+      */
+    case ByteEscapeString
   }
 
   enum Range {
@@ -345,9 +354,10 @@ object SqlDialect {
     arrayElement = ArrayElement.Braces,
     arraySize = "array_length",
     arrayHigherOrderFunctions = ArrayHigherOrderFunctions.Subquery("array", "unnest"),
-    binaryLiteral = BinaryLiteral.HexString,
+    binaryLiteral = BinaryLiteral.ByteEscapeString,
     boolAndFunction = "logical_and",
     boolOrFunction = "logical_or",
+    bytesLength = "byte_length",
     collectFunction = "array_agg",
     countIfFunction = "countif",
     ddl = DdlDialect(
@@ -359,6 +369,7 @@ object SqlDialect {
       emptyStructFieldType = "BOOL",
       floatType = "FLOAT64",
       doubleType = "FLOAT64",
+      bytesType = "BYTES",
       supportsArrayAsArrayElement = false
     ),
     errorFunction = "error",
@@ -413,6 +424,7 @@ object SqlDialect {
     binaryLiteral = BinaryLiteral.HexString,
     boolAndFunction = "bool_and",
     boolOrFunction = "bool_or",
+    bytesLength = "length",
     collectFunction = "collect_list",
     countIfFunction = "count_if",
     ddl = DdlDialect.Spark,

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ToDdl.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ToDdl.scala
@@ -115,7 +115,7 @@ object ToDdl {
           case DdlDialect.DurationSupport.Long => toNullableDdlType(Codec.Long, dialect)
         }
       case Codec.Date => DdlType.Primitive("DATE")
-      case Codec.Bytes => DdlType.Primitive("BINARY")
+      case Codec.Bytes => DdlType.Primitive(dialect.bytesType)
 
       case Codec.Seq(given Codec[e]) =>
         val element = if shouldWrapArrayElement(Codec[e], dialect) then Codec[(value: e)] else Codec[e]

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
@@ -10,6 +10,7 @@ private[sql] enum SqlExpr {
   case Ident(name: Identifier)
   case LiteralString(value: String)
   case LiteralHexString(value: Array[Byte])
+  case LiteralByteEscapeString(value: Array[Byte])
   case LiteralNumeric(value: String)
   case LiteralBool(value: Boolean)
   case LiteralNull

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
@@ -54,6 +54,10 @@ private[tyda] final case class SqlWriter(writer: Writer) {
         write("X'")
         value.foreach(b => write(f"$b%02x"))
         write("'")
+      case SqlExpr.LiteralByteEscapeString(value) =>
+        write("B'")
+        value.foreach(b => write(f"\\x$b%02x"))
+        write("'")
       case SqlExpr.LiteralNumeric(value) => write(value)
       case SqlExpr.LiteralBool(value) => if value then write("TRUE") else write("FALSE")
       case SqlExpr.LiteralNull => write("NULL")

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -506,8 +506,8 @@ SELECT CAST('20.00' AS DECIMAL) AS value FROM t1
 SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d FROM t1
 ------ end
 
------- Test: create literal ArraySeq(1, 2, 3) com.choreograph.tyda.Binary$package.Binary
-SELECT B'\x01\x02\x03' AS value FROM t1
+------ Test: create literal ArraySeq(0, -54, -2, -70, -66) com.choreograph.tyda.Binary$package.Binary
+SELECT B'\x00\xca\xfe\xba\xbe' AS value FROM t1
 ------ end
 
 ------ Test: create literal List() scala.collection.immutable.List[scala.Int]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -250,6 +250,10 @@ SELECT ((NOT t1._1) = (NOT t1._2)) AS value FROM t1
 SELECT (t1._1 OR t1._2) AS value FROM t1
 ------ end
 
+------ Test: bytes length
+SELECT byte_length(t1.value) AS value FROM t1
+------ end
+
 ------ Test: cast com.choreograph.tyda.Decimal$package.Decimal[10, 0] to com.choreograph.tyda.Decimal$package.Decimal[20, 5]
 SELECT CAST(t1.value AS DECIMAL) AS value FROM t1
 ------ end
@@ -272,6 +276,10 @@ SELECT CAST(t1.value AS FLOAT64) AS value FROM t1
 
 ------ Test: cast com.choreograph.tyda.Decimal$package.Decimal[38, 30] to scala.Float
 SELECT CAST(t1.value AS FLOAT64) AS value FROM t1
+------ end
+
+------ Test: cast java.lang.String to com.choreograph.tyda.Binary$package.Binary
+SELECT CAST(t1.value AS BYTES) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Byte to com.choreograph.tyda.Decimal$package.Decimal[10, 2]
@@ -496,6 +504,10 @@ SELECT CAST('20.00' AS DECIMAL) AS value FROM t1
 
 ------ Test: create literal A com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
 SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d FROM t1
+------ end
+
+------ Test: create literal ArraySeq(1, 2, 3) com.choreograph.tyda.Binary$package.Binary
+SELECT B'\x01\x02\x03' AS value FROM t1
 ------ end
 
 ------ Test: create literal List() scala.collection.immutable.List[scala.Int]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -506,8 +506,8 @@ SELECT CAST('20.00' AS DECIMAL(13,2)) AS value FROM t1
 SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT NOT NULL>) AS c, CAST(NULL AS STRUCT<i INT NOT NULL>) AS d FROM t1
 ------ end
 
------- Test: create literal ArraySeq(1, 2, 3) com.choreograph.tyda.Binary$package.Binary
-SELECT X'010203' AS value FROM t1
+------ Test: create literal ArraySeq(0, -54, -2, -70, -66) com.choreograph.tyda.Binary$package.Binary
+SELECT X'00cafebabe' AS value FROM t1
 ------ end
 
 ------ Test: create literal List() scala.collection.immutable.List[scala.Int]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -250,6 +250,10 @@ SELECT ((NOT t1._1) = (NOT t1._2)) AS value FROM t1
 SELECT (t1._1 OR t1._2) AS value FROM t1
 ------ end
 
+------ Test: bytes length
+SELECT length(t1.value) AS value FROM t1
+------ end
+
 ------ Test: cast com.choreograph.tyda.Decimal$package.Decimal[10, 0] to com.choreograph.tyda.Decimal$package.Decimal[20, 5]
 SELECT CAST(t1.value AS DECIMAL(20,5)) AS value FROM t1
 ------ end
@@ -272,6 +276,10 @@ SELECT CAST(t1.value AS DOUBLE) AS value FROM t1
 
 ------ Test: cast com.choreograph.tyda.Decimal$package.Decimal[38, 30] to scala.Float
 SELECT CAST(t1.value AS FLOAT) AS value FROM t1
+------ end
+
+------ Test: cast java.lang.String to com.choreograph.tyda.Binary$package.Binary
+SELECT CAST(t1.value AS BINARY) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Byte to com.choreograph.tyda.Decimal$package.Decimal[10, 2]
@@ -496,6 +504,10 @@ SELECT CAST('20.00' AS DECIMAL(13,2)) AS value FROM t1
 
 ------ Test: create literal A com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
 SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT NOT NULL>) AS c, CAST(NULL AS STRUCT<i INT NOT NULL>) AS d FROM t1
+------ end
+
+------ Test: create literal ArraySeq(1, 2, 3) com.choreograph.tyda.Binary$package.Binary
+SELECT X'010203' AS value FROM t1
 ------ end
 
 ------ Test: create literal List() scala.collection.immutable.List[scala.Int]

--- a/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
@@ -3,7 +3,7 @@ SELECT CASE WHEN (count(1) <> 0) THEN min(t0._2) END AS value FROM (SELECT table
 ------ end
 
 ------ Test: bytes literal
-SELECT X'00cafebabe' AS value
+SELECT B'\x00\xca\xfe\xba\xbe' AS value
 ------ end
 
 ------ Test: distinct before select

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -18,6 +18,7 @@ import org.scalactic.Equality
 import org.scalatest.funsuite.AnyFunSuite
 
 import com.choreograph.tyda.Arbitrary
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.CanCast
 import com.choreograph.tyda.CanTryCast
 import com.choreograph.tyda.Codec
@@ -165,6 +166,7 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testHasSameBehavior[(Int, Int), (Int, Int)]("identity tuple", identity, identity)
   testHasSameBehavior[(Boolean, Boolean), Boolean]("boolean and", t => t._1 && t._2, t => t._1 && t._2)
   testHasSameBehavior[(Boolean, Boolean), Boolean]("boolean or", t => t._1 || t._2, t => t._1 || t._2)
+  testHasSameBehavior[Binary, Int]("bytes length", _.length, _.length)
   testHasSameBehavior[(Boolean, Boolean), Boolean](
     "boolean not and equals",
     t => !t._1 == !t._2,
@@ -1020,6 +1022,8 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testCast[Int, String](_.toString)
   testCast[Long, String](_.toString)
 
+  testCast[String, Binary](Binary.fromString)
+
   testCast[Float, Double](_.toDouble)
   testCast[Double, Float](_.toFloat)
 
@@ -1147,6 +1151,7 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testLiteralCreation[Duration](Duration.fromMicros(1))
   testLiteralCreation[Option[Duration]](None)
   testLiteralCreation[Date](Date.fromDays(1))
+  testLiteralCreation[Binary](Binary.fromArray(Array(1, 2, 3)))
 
   testHasSameBehavior[Timestamp, Long]("Timestamp toMicros", _.toMicros, _.toMicros)
   {

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -1151,7 +1151,7 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testLiteralCreation[Duration](Duration.fromMicros(1))
   testLiteralCreation[Option[Duration]](None)
   testLiteralCreation[Date](Date.fromDays(1))
-  testLiteralCreation[Binary](Binary.fromArray(Array(1, 2, 3)))
+  testLiteralCreation[Binary](Binary.fromArray(Array(0x00, 0xca, 0xfe, 0xba, 0xbe).map(_.toByte)))
 
   testHasSameBehavior[Timestamp, Long]("Timestamp toMicros", _.toMicros, _.toMicros)
   {

--- a/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
@@ -1,0 +1,47 @@
+package com.choreograph.tyda
+
+import java.nio.charset.StandardCharsets
+
+import scala.collection.immutable.ArraySeq
+
+/** An immutable sequence of bytes with value semantics.
+  *
+  * In SQL backends this corresponds to the `BINARY` / `BYTES` type.
+  */
+opaque type Binary = ArraySeq.ofByte
+
+object Binary {
+
+  /** An empty `Binary` value. */
+  val empty: Binary = new ArraySeq.ofByte(Array.emptyByteArray)
+
+  /** Create a `Binary` from an `Array[Byte]`.
+    *
+    * The array is copied so that subsequent mutations do not affect the result.
+    */
+  def fromArray(bytes: Array[Byte]): Binary = new ArraySeq.ofByte(bytes.clone())
+
+  /** Encode a `String` to its UTF-8 byte representation. */
+  def fromString(str: String): Binary = new ArraySeq.ofByte(str.getBytes(StandardCharsets.UTF_8))
+
+  extension (b: Binary) {
+
+    /** Returns the number of bytes. */
+    def length: Int = b.length
+  }
+
+  private object BinaryToArray extends Injection[Binary, Array[Byte]] {
+    def apply(b: Binary): Array[Byte] = b.toArray
+    def invert(arr: Array[Byte]): Binary = new ArraySeq.ofByte(arr)
+  }
+
+  given codec: Codec[Binary] = Codec.fromInjection(BinaryToArray, Codec.Bytes)
+
+  given arbitrary: Arbitrary[Binary] =
+    for {
+      size <- Arbitrary.between(0, 20)
+      arr <- Arbitrary.bytes(size)
+    } yield ArraySeq.ofByte(arr)
+
+  given Groupable[Binary] = Groupable.derived
+}

--- a/tyda/src/main/scala/com/choreograph/tyda/CanCast.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/CanCast.scala
@@ -39,6 +39,8 @@ object CanCast {
   private[tyda] case object IntToString extends CanCast[Int, String]
   private[tyda] case object LongToString extends CanCast[Long, String]
 
+  private[tyda] case object StringToBytes extends CanCast[String, Binary]
+
   private[tyda] final case class DecimalToFloat[P <: Int, S <: Int]() extends CanCast[Decimal[P, S], Float]
   private[tyda] final case class DecimalToDouble[P <: Int, S <: Int]() extends CanCast[Decimal[P, S], Double]
 
@@ -96,6 +98,8 @@ object CanCast {
   given shortToString: CanCast[Short, String] = ShortToString
   given intToString: CanCast[Int, String] = IntToString
   given longToString: CanCast[Long, String] = LongToString
+
+  given stringToBytes: CanCast[String, Binary] = StringToBytes
 
   given decimalToFloat[P <: Int, S <: Int]: CanCast[Decimal[P, S], Float] = DecimalToFloat()
   given decimalToDouble[P <: Int, S <: Int]: CanCast[Decimal[P, S], Double] = DecimalToDouble()

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
@@ -594,6 +594,12 @@ trait ExprApi[Expr[T]] {
     def toDays: Expr[Int] = lift(ExprNode.DateToDays(unlift(date)))
   }
 
+  extension (bytes: Expr[Binary]) {
+
+    /** Returns the number of bytes. */
+    def length: Expr[Int] = lift(ExprNode.BytesLength(unlift(bytes)))
+  }
+
   extension [T, C <: Seq[T]](seq: Expr[C]) {
 
     /** Returns the size of the sequence.

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
@@ -440,6 +440,10 @@ private object ExprNode extends ExprApi[ExprNode] {
     override def codec: Codec[Date] = Codec[Date]
   }
 
+  final case class BytesLength(bytes: ExprNode[Binary]) extends ExprNode[Int] {
+    override def codec: Codec[Int] = Codec[Int]
+  }
+
   final case class ToRepr[P, Repr](expr: ExprNode[P], injectionCodec: Codec.FromInjection[P, Repr])
       extends ExprNode[Repr] {
     override def codec: Codec[Repr] = injectionCodec.to


### PR DESCRIPTION
This is a type that will be encoded as the query engine native binary
type. We add the wrapper type over using Array[Byte]/IArray[Byte] to
avoid having classes with reference equality in our models.

This leaverage the existing binary support that was partly implemented
to support BigInt. But we needed to fix the literal generation to be
valid for BigQuery as that seems to have been untest until now.
