### PR TITLE
Redefine RowProduct canEqual

### DIFF
--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToEncoder.scala
@@ -561,10 +561,4 @@ object CodecToEncoder {
       WalkedTypePath()
     )
   }
-
-  private[spark] final class RowProduct(row: Row) extends Product, Serializable {
-    def productArity: Int = row.length
-    def productElement(n: Int): Any = row.get(n)
-    def canEqual(that: Any): Boolean = that.isInstanceOf[RowProduct]
-  }
 }

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/RowProduct.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/RowProduct.scala
@@ -1,0 +1,10 @@
+package com.choreograph.tyda.spark
+
+import org.apache.spark.sql.Row
+
+/** Needs to be java public since it used in spark expressions. */
+private[spark] final class RowProduct(row: Row) extends Product, Serializable {
+  def productArity: Int = row.length
+  def productElement(n: Int): Any = row.get(n)
+  def canEqual(that: Any): Boolean = false
+}


### PR DESCRIPTION
Extracted from https://github.com/unum-io/tyda/pull/16

Since we are not implementing equals there is no reason to pretend can
RowProducts can be compared using equals.
