### PR TITLE
Extract catalystType from CodecToEncoder

### DIFF
--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToCatalystType.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToCatalystType.scala
@@ -1,0 +1,54 @@
+package com.choreograph.tyda.spark
+
+import org.apache.spark.sql.types.*
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Field
+import com.choreograph.tyda.Forbidden
+import com.choreograph.tyda.shapeless3extras.mapConst
+
+private object CodecToCatalystType {
+
+  def catalystType[T](codec: Codec[T]): DataType =
+    codec match {
+      case Codec.Byte => ByteType
+      case Codec.Short => ShortType
+      case Codec.Int => IntegerType
+      case Codec.Long => LongType
+      case Codec.Float => FloatType
+      case Codec.Double => DoubleType
+      case Codec.Boolean => BooleanType
+      case Codec.String => StringType
+      case Codec.Bytes => BinaryType
+      case Codec.Decimal(precision, scale) => DecimalType(precision, scale)
+      case Codec.TimestampMicros => TimestampType
+      case Codec.DurationMicros => DayTimeIntervalType()
+      case Codec.Date => DateType
+      case map: Codec.Map[?, ?] => MapType(catalystType(map.key), catalystType(map.value))
+      case Codec.Seq(element) => ArrayType(catalystType(element))
+      case Codec.Option(inner @ Codec.Option(_)) => StructType(Seq(StructField("value", catalystType(inner))))
+      case opt: Codec.Option[?] => catalystType(opt.element)
+      case Codec.Product(_, _, Some(_)) => StructType(Seq(StructField(Forbidden.column, NullType)))
+      case prod: Codec.Product[T] => structFromFields(prod.fields.mapConst[Field[?]]([t] => identity(_)))
+      case Codec.FromInjection(_, to) => catalystType(to)
+    }
+
+  def catalystStructType[T](codec: Codec.Product[T] | Codec.Sum[T, ?]): StructType =
+    codec match {
+      case prod: Codec.Product[T] => structFromFields(prod.fields.mapConst[Field[?]]([t] => identity(_)))
+      case sum: Codec.Sum[T, ?] => structFromFields(sum.reprFields)
+    }
+
+  private def structFromFields(fields: Seq[Field[?]]): StructType =
+    StructType(fields.map(field => StructField(field.name, catalystType(field.codec), nullable(field.codec))))
+
+  /* This implement to match Spark view of nullability where anything that can have a `null` in the jvm is
+   * considered nullable. In practice we only want types inside an Option to be nullable. */
+  private[spark] def nullable[T](codec: Codec[T]): Boolean =
+    codec match {
+      case Codec.String | Codec.Bytes | Codec.Product(_, _, _) | Codec.Seq(_) | Codec.Option(_) |
+          Codec.Map(_, _) => true
+      case _: Codec.Primitive[?] | Codec.Sum(_, _) => false
+      case Codec.FromInjection(_, to) => nullable(to)
+    }
+}

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToEncoder.scala
@@ -41,6 +41,9 @@ import com.choreograph.tyda.Forbidden
 import com.choreograph.tyda.Injection
 import com.choreograph.tyda.Variant
 import com.choreograph.tyda.shapeless3extras.mapConst
+import com.choreograph.tyda.spark.CodecToCatalystType.catalystStructType
+import com.choreograph.tyda.spark.CodecToCatalystType.catalystType
+import com.choreograph.tyda.spark.CodecToCatalystType.nullable
 
 /* This object currently contains code vendored from Spark 3.5.4 mainly from the files
  * https://github.com/apache/spark/blob/v3.5.4/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala
@@ -71,44 +74,6 @@ object CodecToEncoder {
       case Codec.Date => IntegerType
       case Codec.String | Codec.Seq(_) | Codec.Map(_, _) | Codec.Option(_) | Codec.Decimal(_, _) | Codec
             .Product(_, _, _) | Codec.FromInjection(_, _) => ObjectType(codec.classTag.runtimeClass)
-    }
-
-  private[tyda] def catalystType[T](codec: Codec[T]): DataType =
-    codec match {
-      case Codec.Byte => ByteType
-      case Codec.Short => ShortType
-      case Codec.Int => IntegerType
-      case Codec.Long => LongType
-      case Codec.Float => FloatType
-      case Codec.Double => DoubleType
-      case Codec.Boolean => BooleanType
-      case Codec.String => StringType
-      case Codec.Bytes => BinaryType
-      case Codec.Decimal(precision, scale) => DecimalType(precision, scale)
-      case Codec.TimestampMicros => TimestampType
-      case Codec.DurationMicros => DayTimeIntervalType()
-      case Codec.Date => DateType
-      case map: Codec.Map[?, ?] => MapType(catalystType(map.key), catalystType(map.value))
-      case Codec.Seq(element) => ArrayType(catalystType(element))
-      case Codec.Option(inner @ Codec.Option(_)) => StructType(Seq(StructField("value", catalystType(inner))))
-      case opt: Codec.Option[?] => catalystType(opt.element)
-      case Codec.Product(_, _, Some(_)) => StructType(Seq(StructField(Forbidden.column, NullType)))
-      case prod: Codec.Product[T] => structFromFields(prod.fields.mapConst[Field[?]]([t] => identity(_)))
-      case Codec.FromInjection(_, to) => catalystType(to)
-    }
-
-  private def sumSchema[T](sum: Codec.Sum[T, ?]): StructType = structFromFields(sum.reprFields)
-
-  private def structFromFields(fields: Seq[Field[?]]): StructType =
-    StructType(fields.map(field => StructField(field.name, catalystType(field.codec), nullable(field.codec))))
-
-  /* This implement to match Spark view of nullability where anything that can have a `null` in the jvm is
-   * considered nullable. In practice we only want types inside an Option to be nullable. */
-  private[spark] def nullable[T](codec: Codec[T]): Boolean =
-    codec match {
-      case _: Codec.Sum[T, ?] => false
-      case _: Codec.Decimal[?, ?] => false
-      case _ => jvmType(codec).isInstanceOf[ObjectType]
     }
 
   private def createSerializer[T](codec: Codec[T]): Expression = {
@@ -428,7 +393,7 @@ object CodecToEncoder {
           } else {
             val fields = prod.fields.mapConst([t] => identity(_))
             val row =
-              createRowDeserializer(path, fields, walkedTypePath, structFromFields(fields), topRow = topRow)
+              createRowDeserializer(path, fields, walkedTypePath, catalystStructType(prod), topRow = topRow)
             val clsRowProduct = classOf[RowProduct]
             val rowProduct =
               NewInstance(clsRowProduct, Seq(row), ObjectType(clsRowProduct), propagateNull = false)
@@ -450,7 +415,7 @@ object CodecToEncoder {
       walkedTypePath: WalkedTypePath,
       topRow: Boolean
   ): Expression = {
-    val row = createRowDeserializer(path, sum.reprFields, walkedTypePath, sumSchema(sum), topRow)
+    val row = createRowDeserializer(path, sum.reprFields, walkedTypePath, catalystStructType(sum), topRow)
     val rowEncoder = Literal.create(SumToRowEncoder(sum), ObjectType(classOf[SumToRowEncoder[?]]))
     Invoke(rowEncoder, "decode", jvmType(sum), Seq(row))
   }

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
@@ -50,7 +50,7 @@ import com.choreograph.tyda.rewrite.Nullable
 import com.choreograph.tyda.rewrite.PrimitiveAggregateAsFold
 import com.choreograph.tyda.shapeless3extras.mapConst
 import com.choreograph.tyda.shapeless3extras.tupleInstances
-import com.choreograph.tyda.spark.CodecToEncoder.catalystType
+import com.choreograph.tyda.spark.CodecToCatalystType.catalystType
 import com.choreograph.tyda.spark.PrimitiveAggregateOnSpark.CompatibleIntegral
 import com.choreograph.tyda.unreachable
 
@@ -97,7 +97,7 @@ private[spark] object ExprOnSpark {
   private def createUdf[T: Codec, U: Codec](f: (T, T) => U, arg1: Column, arg2: Column, name: String) = {
     val udf = ScalaUDF(
       function = f,
-      dataType = CodecToEncoder.catalystType(Codec[U]),
+      dataType = catalystType(Codec[U]),
       children = Seq(arg1.expr, arg2.expr),
       inputEncoders =
         Seq(CodecToEncoder.convertInternal(using Codec[T]), CodecToEncoder.convertInternal(using Codec[T]))
@@ -111,7 +111,7 @@ private[spark] object ExprOnSpark {
   private def createUdf[T: Codec, U: Codec](f: T => U, arg: Column) = {
     val udf = ScalaUDF(
       function = f,
-      dataType = CodecToEncoder.catalystType(Codec[U]),
+      dataType = catalystType(Codec[U]),
       children = Seq(arg.expr),
       inputEncoders = Seq(Some(CodecToEncoder.convertInternal(using Codec[T]))),
       outputEncoder = Some(CodecToEncoder.convertInternal(using Codec[U]))
@@ -122,7 +122,7 @@ private[spark] object ExprOnSpark {
   private def createUdf[U: Codec](f: () => U, name: Option[String]) = {
     val udf = ScalaUDF(
       function = f,
-      dataType = CodecToEncoder.catalystType(Codec[U]),
+      dataType = catalystType(Codec[U]),
       children = Seq(),
       outputEncoder = Some(CodecToEncoder.convertInternal(using Codec[U])),
       udfName = name
@@ -165,7 +165,7 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
       case ExprNode.MakeProduct(values, Codec.Product(_, _, Some(_))) =>
         struct(lit(null).as(Forbidden.column))
 
-      case ExprNode.None(_) => lit(null).cast(CodecToEncoder.catalystType(expr.codec))
+      case ExprNode.None(_) => lit(null).cast(catalystType(expr.codec))
       case ExprNode.MakeProduct(values, codec) =>
         val fieldExprs = tupleInstances(values).mapConst([t] => convert(_))
         val names = codec.fields.mapConst[String]([t] => _.name)
@@ -177,7 +177,7 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
       case ExprNode.MakeSeq(values, _) =>
         val fieldExprs = values.map(convert(_))
         val arr = array(fieldExprs*)
-        if values.isEmpty then arr.cast(CodecToEncoder.catalystType(expr.codec)) else arr
+        if values.isEmpty then arr.cast(catalystType(expr.codec)) else arr
       case ExprNode.ConcatSeq(lhs, rhs) => concat(convert(lhs), (convert(rhs)))
       case ExprNode.MapSeq(seq, f) =>
         val seqCol = convert(seq)
@@ -229,7 +229,7 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
       case ExprNode.LessThanOrEqual(_, lhs, rhs) => convert(lhs) <= convert(rhs)
       case ExprNode.UpcastToIterable(e) => e.codec match {
           // The cast he is to rename the struct fields from key, value to _1, _2
-          case _: Codec.Map[?, ?] => map_entries(convert(e)).cast(CodecToEncoder.catalystType(expr.codec))
+          case _: Codec.Map[?, ?] => map_entries(convert(e)).cast(catalystType(expr.codec))
           case ArrayCodec(_) => convert(e)
           case codec => unreachable(s"UpcastToIterable only get codecs of Map and Iterable not $codec")
         }
@@ -242,8 +242,7 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
       case ExprNode.Coalesce(operands) => coalesce(operands.map(convert(_))*)
       case Nullable(ExprNode.KnownNotNull(e)) => convert(e)("value")
       case ExprNode.KnownNotNull(e) => convert(e)
-      case ExprNode.RaiseError(message, codec) =>
-        raise_error(convert(message)).cast(CodecToEncoder.catalystType(codec))
+      case ExprNode.RaiseError(message, codec) => raise_error(convert(message)).cast(catalystType(codec))
       case ExprNode.ScalarSubquery(ds) =>
         // TODO: When only supporting Spark 4.0+ we can use the improve subquery apis from
         // https://github.com/apache/spark/pull/48664 and plan this as a scalar subquery
@@ -286,15 +285,15 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
         call_function("element_at", convert(array), adjustedIdx)
       case ExprNode.Add(additive, lhs, rhs) => convert(lhs) + convert(rhs)
       case ExprNode.Quotient(CompatibleIntegral(), lhs, rhs) =>
-        call_function("div", convert(lhs), convert(rhs)).cast(CodecToEncoder.catalystType(expr.codec))
+        call_function("div", convert(lhs), convert(rhs)).cast(catalystType(expr.codec))
       case ExprNode.Quotient(integral, lhs, rhs) =>
         createUdf(integral.quot, convert(lhs), convert(rhs), s"$integral.quot")(using lhs.codec, lhs.codec)
-      case ExprNode.Cast(from, canCast) => convert(from).cast(CodecToEncoder.catalystType(expr.codec))
+      case ExprNode.Cast(from, canCast) => convert(from).cast(catalystType(expr.codec))
       case ExprNode.TryCast(from, canTryCast) =>
         /* TODO: Replace with public API in Spark 4.0.0+ it was exposed added in
          * https://github.com/apache/spark/pull/45796 */
         val e = convert(from).expr
-        val tryCast = Cast(e, CodecToEncoder.catalystType(expr.codec), None, EvalMode.TRY)
+        val tryCast = Cast(e, catalystType(expr.codec), None, EvalMode.TRY)
         val casted = new Column(tryCast)
         if from.codec == Codec.String then when(!convert(from).rlike("\\p{Cc}"), casted) else casted
       case ExprNode.TimestampToMicros(inner) => unix_micros(convert(inner))

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
@@ -31,6 +31,7 @@ import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Ord
 import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.TypeName
+import com.choreograph.tyda.spark.CodecToCatalystType.nullable
 import com.choreograph.tyda.staticAssert
 
 object CodecToEncoderSpecBase {
@@ -220,8 +221,7 @@ trait CodecToEncoderSpecBase extends AnyFunSuite with SharedSparkSession {
     test(s"schema test for ${TypeName.name[T]}") {
       val expected = expectedType match {
         case s: StructType => s
-        case other =>
-          StructType(Seq(StructField("value", other, nullable = CodecToEncoder.nullable(Codec[T]))))
+        case other => StructType(Seq(StructField("value", other, nullable = nullable(Codec[T]))))
       }
 
       val fromCodec = convert[T].schema

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/ExprEvaluationSuiteSpark.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/ExprEvaluationSuiteSpark.scala
@@ -16,6 +16,7 @@ import org.apache.spark.sql.types.StructType
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.CompiledExpr
 import com.choreograph.tyda.Expr
+import com.choreograph.tyda.spark.CodecToCatalystType.catalystType
 import com.choreograph.tyda.testsuites.ExprEvaluationSuite
 
 /* This suite evaluates expressions without doing creating a full plan.
@@ -68,7 +69,7 @@ class ExprEvaluationSuiteSpark extends ExprEvaluationSuite, SharedSparkSession {
       case _ =>
     }
     val deserializer = createDeserializer[To](using compiled.codec)
-    val expectedType = CodecToEncoder.catalystType(compiled.codec)
+    val expectedType = catalystType(compiled.codec)
     assert(
       withAllNullable(sparkExpr.dataType) == withAllNullable(expectedType),
       s"Got\n${sparkExpr.dataType} but expected\n${expectedType}"


### PR DESCRIPTION
This extracts the Codec to catalystType logic to a separate object. This
is an preparation from for Spark 4 and was extracted from #16.

As part of this `nullable` can no longer be implemented using jvmType
and is therefore change to have more explicit logic that should have the
same results.
