### PR TITLE
Add concat aggregate for Seq

### DIFF
--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/explain.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/explain.scala
@@ -111,6 +111,7 @@ private[tyda] def explain(anyCompiled: AnyCompiledExpr): String =
 
 private def explainPrimitiveAggregate(primitive: PrimitiveAggregate[?, ?], arg: String): String =
   primitive match {
+    case PrimitiveAggregate.SeqConcat() => s"concat($arg)"
     case PrimitiveAggregate.Collect() => s"collect($arg)"
     case PrimitiveAggregate.Count() => s"count($arg)"
     case PrimitiveAggregate.CountSome() => s"countSome($arg)"

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/PrimitiveAggregateOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/PrimitiveAggregateOnSpark.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.functions.bool_and
 import org.apache.spark.sql.functions.bool_or
 import org.apache.spark.sql.functions.collect_list
 import org.apache.spark.sql.functions.count
+import org.apache.spark.sql.functions.flatten
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.functions.max_by
@@ -27,6 +28,7 @@ private[spark] object PrimitiveAggregateOnSpark {
     agg match {
       // Sparks collect_list will filter out nulls, so can not be used for Option
       case PrimitiveAggregate.Collect() if !cf.codec.isInstanceOf[Codec.Option[?]] => collect_list(cf.row)
+      case PrimitiveAggregate.SeqConcat() => flatten(collect_list(cf.row))
       case PrimitiveAggregate.Count() => count(lit(1))
       case PrimitiveAggregate.CountSome() => count(cf.row)
       case PrimitiveAggregate.BoolAnd() => bool_and(cf.row)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -936,6 +936,11 @@ private def primitiveAggregate[T: Codec](
       if shouldWrapArrayElement(Codec[T], dialect.ddl) then
         simpleAggregate(dialect.collectFunction, wrapArrayElement(arg, dialect))
       else simple(dialect.collectFunction)
+    case PrimitiveAggregate.SeqConcat() => dialect.arrayConcatAgg match {
+        case SqlDialect.ArrayConcatAgg.Function(name) => simpleAggregate(name, arg)
+        case SqlDialect.ArrayConcatAgg.FlattenCollect(flatten) =>
+          Right(SqlExpr.Function(flatten, Seq(SqlExpr.Function(dialect.collectFunction, Seq(arg)))))
+      }
     case PrimitiveAggregate.Reduce(_) =>
       Left(DatasetToSqlError.RequiresUdfCapability("Reduce is not supported on SQL"))
   }

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -23,6 +23,7 @@ import com.choreograph.tyda.sql.DdlDialect.DurationSupport
 final case class SqlDialect(
     arrayDistinct: SqlDialect.ArrayDistinct,
     arrayConcat: String,
+    arrayConcatAgg: SqlDialect.ArrayConcatAgg,
     arrayElement: SqlDialect.ArrayElement,
     arrayJoin: String,
     arraySize: String,
@@ -108,6 +109,23 @@ object SqlDialect {
       * to be filtered out to have correct behavior.
       */
     case Function(name: String, isChunked: Boolean)
+  }
+
+  enum ArrayConcatAgg {
+
+    /** Aggregate directly using a native function. e.g.
+      * ```
+      * array_concat_agg(array_column)
+      * ```
+      */
+    case Function(name: String)
+
+    /** Aggregate by collecting into a nested array and then flattening it. e.g.
+      * ```
+      * flatten(collect_list(array_column))
+      * ```
+      */
+    case FlattenCollect(flatten: String)
   }
 
   enum Values {
@@ -399,6 +417,7 @@ object SqlDialect {
     startsWithFunction = "STARTS_WITH",
     arrayDistinct = ArrayDistinct.Subquery("array", "unnest"),
     arrayConcat = "array_concat",
+    arrayConcatAgg = ArrayConcatAgg.Function("array_concat_agg"),
     arrayElement = ArrayElement.Braces,
     arrayJoin = "array_to_string",
     arraySize = "array_length",
@@ -471,6 +490,7 @@ object SqlDialect {
     startsWithFunction = "startswith",
     arrayDistinct = ArrayDistinct.Function("array_distinct"),
     arrayConcat = "concat",
+    arrayConcatAgg = ArrayConcatAgg.FlattenCollect("flatten"),
     arrayElement = ArrayElement.Function("element_at"),
     arrayJoin = "array_join",
     arraySize = "size",

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
@@ -90,6 +90,10 @@ SELECT array_agg(t1._2) AS value FROM t1 GROUP BY t1._1
 SELECT array_agg(t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
 ------ end
 
+------ Test: concat seq
+SELECT array_concat_agg(t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
+------ end
+
 ------ Test: count group by
 SELECT t1._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM t1 GROUP BY t1._1
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
@@ -90,8 +90,20 @@ SELECT array_agg(t1._2) AS value FROM t1 GROUP BY t1._1
 SELECT array_agg(t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
 ------ end
 
+------ Test: concat and map
+SELECT array((SELECT (CAST(c0 AS INT) + CAST(1 AS INT)) FROM unnest(t0.value) AS c0)) AS value FROM (SELECT array_concat_agg(t1._2) AS value FROM t1 GROUP BY t1._1) AS t0
+------ end
+
+------ Test: concat column
+SELECT array_concat_agg(t1._2) AS value FROM t1 GROUP BY t1._1
+------ end
+
 ------ Test: concat seq
 SELECT array_concat_agg(t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
+------ end
+
+------ Test: concat seq by group
+SELECT t1._1 AS _1, array_concat_agg(t1._2) AS _2 FROM t1 GROUP BY t1._1
 ------ end
 
 ------ Test: count group by

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesSparkSqlGoldenSuite.golden
@@ -90,8 +90,20 @@ SELECT collect_list(t1._2) AS value FROM t1 GROUP BY t1._1
 SELECT collect_list(t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
 ------ end
 
+------ Test: concat and map
+SELECT transform(flatten(collect_list(t1._2)), c0 -> (CAST(c0 AS INT) + CAST(1 AS INT))) AS value FROM t1 GROUP BY t1._1
+------ end
+
+------ Test: concat column
+SELECT flatten(collect_list(t1._2)) AS value FROM t1 GROUP BY t1._1
+------ end
+
 ------ Test: concat seq
 SELECT flatten(collect_list(t1.value)) AS value FROM t1 GROUP BY CAST(NULL AS INT)
+------ end
+
+------ Test: concat seq by group
+SELECT t1._1 AS _1, flatten(collect_list(t1._2)) AS _2 FROM t1 GROUP BY t1._1
 ------ end
 
 ------ Test: count group by

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesSparkSqlGoldenSuite.golden
@@ -90,6 +90,10 @@ SELECT collect_list(t1._2) AS value FROM t1 GROUP BY t1._1
 SELECT collect_list(t1.value) AS value FROM t1 GROUP BY CAST(NULL AS INT)
 ------ end
 
+------ Test: concat seq
+SELECT flatten(collect_list(t1.value)) AS value FROM t1 GROUP BY CAST(NULL AS INT)
+------ end
+
 ------ Test: count group by
 SELECT t1._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM t1 GROUP BY t1._1
 ------ end

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
@@ -17,6 +17,7 @@ import com.choreograph.tyda.SumMagnet
 import com.choreograph.tyda.aggregates.boolAnd
 import com.choreograph.tyda.aggregates.boolOr
 import com.choreograph.tyda.aggregates.collect
+import com.choreograph.tyda.aggregates.concat
 import com.choreograph.tyda.aggregates.count
 import com.choreograph.tyda.aggregates.countIf
 import com.choreograph.tyda.aggregates.countSome
@@ -106,6 +107,7 @@ trait DatasetAggregatesSuite extends DatasetSuite {
     "collect Option Seq",
     ds => ds.groupByKey(_ => lit(1)).aggregateValue(collect).values
   )
+  test[Seq[Int], Seq[Int]]("concat seq", ds => ds.groupByKey(_ => 1).aggregateValue(concat).values)
   test[Option[Int], Option[Option[Long]]]("aggregate nested Option", ds => ds.aggregate(sum))
   test[Pair, Seq[TinyByte]]("collect column", ds => ds.groupByKey(_._1).aggregateValue(collect(_._2)).values)
   test[Pair, Seq[Int]](

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
@@ -31,6 +31,7 @@ import com.choreograph.tyda.functions.lit
 import com.choreograph.tyda.functions.some
 import com.choreograph.tyda.functions.tuple
 import com.choreograph.tyda.functions.when
+import com.choreograph.tyda.testsuites.DatasetSuite.TinyByte
 
 object DatasetAggregatesSuite {
   enum EnumWithOrdering {
@@ -52,12 +53,14 @@ object DatasetAggregatesSuite {
 
   given smallFloat: Arbitrary[Float] = Arbitrary.between(0, 1)
   given smallDouble: Arbitrary[Double] = Arbitrary.between(0, 1)
+
+  type PairSeq = (TinyByte, Seq[TinyByte])
 }
 
 // Testsuite focusing on aggregates that will compare a Dataset backend to a reference implementation.
 trait DatasetAggregatesSuite extends DatasetSuite {
-  import DatasetAggregatesSuite.{EnumWithOrdering, Inner, Outer}
-  import DatasetSuite.{Pair, TinyByte}
+  import DatasetAggregatesSuite.{EnumWithOrdering, Inner, Outer, PairSeq}
+  import DatasetSuite.Pair
 
   given Ordering[Pair] = Ordering.by(_._1)
 
@@ -108,6 +111,12 @@ trait DatasetAggregatesSuite extends DatasetSuite {
     ds => ds.groupByKey(_ => lit(1)).aggregateValue(collect).values
   )
   test[Seq[Int], Seq[Int]]("concat seq", ds => ds.groupByKey(_ => 1).aggregateValue(concat).values)
+  test[PairSeq, Seq[TinyByte]]("concat column", ds => ds.groupByKey(_._1).aggregateValue(concat(_._2)).values)
+  test[PairSeq, PairSeq]("concat seq by group", ds => ds.groupByKey(_._1).aggregateValue(concat(_._2)).pairs)
+  test[PairSeq, Seq[Int]](
+    "concat and map",
+    ds => ds.groupByKey(_._1).aggregateValue(concat(_._2)).values.select(_.map(_.cast[Int] + 1))
+  )
   test[Option[Int], Option[Option[Long]]]("aggregate nested Option", ds => ds.aggregate(sum))
   test[Pair, Seq[TinyByte]]("collect column", ds => ds.groupByKey(_._1).aggregateValue(collect(_._2)).values)
   test[Pair, Seq[Int]](

--- a/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregate.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregate.scala
@@ -20,6 +20,7 @@ private object PrimitiveAggregate {
       extends PrimitiveAggregate[(V, O), V] {
     def inputCodec: Codec[(V, O)] = summon
   }
+  final case class SeqConcat[T]()(using Codec[Seq[T]]) extends PrimitiveAggregate[Seq[T], Seq[T]]
   final case class Reduce[T: Codec](f: (T, T) => T) extends PrimitiveAggregate[T, T]
   final case class Sum[T, R: Codec](magnet: SumMagnet.Aux[T, R]) extends PrimitiveAggregate[T, R]
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregateEvaluation.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/PrimitiveAggregateEvaluation.scala
@@ -44,6 +44,9 @@ private[tyda] object PrimitiveAggregateEvaluation {
       case PrimitiveAggregate.Sum(magnet) =>
         given Codec[To] = magnet.codec
         make(Compose(magnet.toResult, Reduce(magnet.add)))
+      case PrimitiveAggregate.SeqConcat() =>
+        given Codec[To] = agg.codec
+        make(Reduce[From](_ ++ _))
     }
 
   def minByAggregator[V, O](

--- a/tyda/src/main/scala/com/choreograph/tyda/aggregates.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/aggregates.scala
@@ -13,12 +13,23 @@ import com.choreograph.tyda.PrimitiveAggregate.MaxBy
 import com.choreograph.tyda.PrimitiveAggregate.Min
 import com.choreograph.tyda.PrimitiveAggregate.MinBy
 import com.choreograph.tyda.PrimitiveAggregate.Reduce
+import com.choreograph.tyda.PrimitiveAggregate.SeqConcat
 import com.choreograph.tyda.PrimitiveAggregate.Sum
 import com.choreograph.tyda.functions.tuple
 
 object aggregates {
   private def aggregate[T, R](node: Expr[T], agg: PrimitiveAggregate[T, R]): AggregateExpr[R] =
     AggregateExpr.lift(ExprNode.Aggregate(Expr.unlift(node), agg))
+
+  /** AggregateExpr concatenating all [[Seq]] values into a single [[Seq]].
+    */
+  def concat[T]: Expr[Seq[T]] => AggregateExpr[Seq[T]] = e => aggregate(e, SeqConcat()(using e.codec))
+
+  /** AggregateExpr concatenating all [[Seq]] values of specified [[Expr]] into
+    * a single [[Seq]].
+    */
+  def concat[T, R, I: AsExpr.Of[Seq[R]]](f: Expr[T] => I): Expr[T] => AggregateExpr[Seq[R]] =
+    concat[R].compose(f.andThen(AsExpr(_)))
 
   /** AggregateExpr collecting all values into a [[Seq]].
     */


### PR DESCRIPTION
Seems like this is not somthing that builtin to Spark. But exists in
bigquery and is easily implemented in other engines.
