### PR TITLE
Optimize literal map lookup on Spark

### DIFF
--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/NonDeterministic.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/NonDeterministic.scala
@@ -1,0 +1,15 @@
+package com.choreograph.tyda.rewrite
+
+import com.choreograph.tyda.ExprNode
+
+private[tyda] object NonDeterministic {
+
+  /** Matches ExprNode instances that are non-deterministic, i.e. may return
+    * different values for different rows or invocations.
+    */
+  def unapply(expr: ExprNode[?]): Boolean =
+    expr match {
+      case ExprNode.Rand() => true
+      case _ => false
+    }
+}

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
@@ -42,10 +42,15 @@ import com.choreograph.tyda.CompiledExpr2
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
 import com.choreograph.tyda.Errors
+import com.choreograph.tyda.Expr
 import com.choreograph.tyda.ExprNode
 import com.choreograph.tyda.Forbidden
+import com.choreograph.tyda.TreeApi.Continue
+import com.choreograph.tyda.TreeApi.Skip
+import com.choreograph.tyda.TreeApi.Stop
 import com.choreograph.tyda.rewrite.ArrayCodec
 import com.choreograph.tyda.rewrite.IsNone
+import com.choreograph.tyda.rewrite.NonDeterministic
 import com.choreograph.tyda.rewrite.Nullable
 import com.choreograph.tyda.rewrite.PrimitiveAggregateAsFold
 import com.choreograph.tyda.shapeless3extras.mapConst
@@ -152,7 +157,7 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
   private def cfFromRef(ref: ExprNode.Reference[?]): ColumnFactory[?] =
     cfs.get(ref).getOrElse(Errors.failUnexpectedReference(ref, cfs.keys))
 
-  def convert(expr: ExprNode[?])(using spark: SparkSession): Column =
+  def convert[T](expr: ExprNode[T])(using spark: SparkSession): Column =
     expr match {
       case ExprNode.Select(ref: ExprNode.Reference[?], name) => cfFromRef(ref).column(name)
       case ExprNode.Select(p, name) => convert(p)(name)
@@ -314,6 +319,16 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
       case ExprNode.FromRepr(inner, _) => convert(inner)
       case ExprNode.MakeMap(pairs) => map_from_entries(convert(pairs))
       case ExprNode.MapEntries(map) => map_entries(convert(map))
+      // Workaround for https://github.com/apache/spark/issues/54646
+      // Spark does linear looks ups for maps which will be slow for large maps
+      // that do not depend on the row. So we manually plan it as a lookup instead.
+      // Remove after only using 4.2.x or later
+      case ExprNode.MapGet(map, key: ExprNode[k]) if isConstant(map) =>
+        given Codec[k] = key.codec
+        given Codec[T] = expr.codec
+        val evalMap = com.choreograph.tyda.Dataset.from(Seq(1)).select(_ => Expr.lift(map))
+        val literalMap = DatasetOnSpark(evalMap).head
+        createUdf(literalMap.get, convert(key))
       case ExprNode.MapGet(map, key) =>
         val mapCol = convert(map)
         val keyCol = convert(key)
@@ -326,4 +341,14 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
       case ExprNode.Rand() => rand()
       case ExprNode.IsNaN(operand) => isnan(convert(operand))
     }
+
+  // Check if a expression is the same for all rows
+  private def isConstant[T](expr: ExprNode[T]): Boolean =
+    expr.fold[Boolean](true)((_, node) =>
+      node match {
+        case ExprNode.Reference(_, _) | NonDeterministic() => Stop(false)
+        case ExprNode.ExistsSubquery(_) | ExprNode.ScalarSubquery(_) => Skip(true)
+        case _ => Continue(true)
+      }
+    )
 }

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/DatasetOnSparkSpec.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/DatasetOnSparkSpec.scala
@@ -144,4 +144,12 @@ class DatasetOnSparkSpec extends AnyFunSuite, SharedSparkSession, Eventually {
       assert(countCached(usesCache) == 0, "The dataset should be uncached")
     }
   }
+
+  test("perf of Map.get https://github.com/apache/spark/issues/54646") {
+    // If doing linear lookup in the map this tests will take a really long time.
+    val map = Dataset.FromSeq((0 until 100000).map(i => (i, i))).collect.toMap
+    val ds1 = Dataset.FromSeq(0 until 100000)
+    val lookups = ds1.select(v => map.get(v))
+    val _ = DatasetOnSpark(lookups).collect()
+  }
 }

--- a/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
@@ -2,6 +2,10 @@
 SELECT t1.value AS value FROM t1 WHERE (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1.value) FROM unnest(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(t2.value) END AS value FROM t2), CAST([] AS ARRAY<TINYINT>))) AS c0))) AS c1)
 ------ end
 
+------ Test: collect toMap lookup
+SELECT t1.value AS _1, (SELECT c2.value FROM unnest(CASE WHEN (array_length(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(struct(t0._1 AS _1, t0._2 AS _2)) END AS value FROM (SELECT t2._1 AS _1, max(t2._2) AS _2 FROM t2 GROUP BY t2._1) AS t0), CAST([] AS ARRAY<STRUCT<_1 TINYINT,_2 INT>>))) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(struct(t2._1 AS _1, t2._2 AS _2)) END AS value FROM (SELECT t2._1 AS _1, max(t2._2) AS _2 FROM t2 GROUP BY t2._1) AS t2), CAST([] AS ARRAY<STRUCT<_1 TINYINT,_2 INT>>))) AS c0))) AS c1)))) THEN CAST(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(struct(t4._1 AS _1, t4._2 AS _2)) END AS value FROM (SELECT t2._1 AS _1, max(t2._2) AS _2 FROM t2 GROUP BY t2._1) AS t4), CAST([] AS ARRAY<STRUCT<_1 TINYINT,_2 INT>>)) AS ARRAY<STRUCT<key TINYINT,value INT>>) ELSE error('Duplicate keys found') END) AS c2 WHERE (c2.key = t1.value)) AS _2 FROM t1
+------ end
+
 ------ Test: count subquery
 SELECT t1.value AS value FROM t1 WHERE (NOT (t1.value <= coalesce((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM t2), CAST(0 AS BIGINT))))
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetSubquerySparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetSubquerySparkSqlGoldenSuite.golden
@@ -2,6 +2,10 @@
 SELECT t1.value AS value FROM t1 WHERE aggregate(transform(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN collect_list(t2.value) END AS value FROM t2), CAST(array() AS ARRAY<TINYINT>)), c0 -> (c0 = t1.value)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3)
 ------ end
 
+------ Test: collect toMap lookup
+SELECT t1.value AS _1, element_at(map_from_entries(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN collect_list(named_struct('_1', t0._1, '_2', t0._2)) END AS value FROM (SELECT t2._1 AS _1, max(t2._2) AS _2 FROM t2 GROUP BY t2._1) AS t0), CAST(array() AS ARRAY<STRUCT<_1 TINYINT NOT NULL,_2 INT NOT NULL>>))), t1.value) AS _2 FROM t1
+------ end
+
 ------ Test: count subquery
 SELECT t1.value AS value FROM t1 WHERE (NOT (t1.value <= coalesce((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM t2), CAST(0 AS BIGINT))))
 ------ end

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSubquerySuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSubquerySuite.scala
@@ -18,4 +18,10 @@ trait DatasetSubquerySuite extends DatasetSuite {
   )
 
   test[Long, Long, Long]("count subquery", (ds1, ds2) => ds1.where(_ > ds2.count))
+
+  test[TinyByte, (TinyByte, Int), (TinyByte, Option[Int])](
+    "collect toMap lookup",
+    (ds1, ds2) =>
+      ds1.select(identity, v => ds2.groupByKey(_._1).aggregateValue(max(_._2)).pairs.collect.toMap.get(v))
+  )
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
@@ -717,12 +717,6 @@ trait ExprApi[Expr[T]] {
     /** Returns the value associated with the given key.
       *
       * Returns None if the key is not present in the map.
-      *
-      * Note: Spark currently has a performance problem with Map lookup
-      * (https://github.com/apache/spark/issues/54646) so this method is
-      * intended for use with small maps where the performance issue is not
-      * significant. TODO: remove this when the support a version of Spark with
-      * the performance issue fixed.
       */
     @targetName("mapGet")
     def get(key: Expr[K]): Expr[Option[V]] = lift(ExprNode.MapGet(unlift(map), unlift(key)))


### PR DESCRIPTION
This is fixed in later versions of Spark: https://github.com/apache/spark/issues/54646 but until then it might be worth having this workaround.
