### PR TITLE
Support (de)serialization to arrow based on Codec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p tyda-big-query/target tyda-rewrite/target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
+        run: mkdir -p tyda-big-query/target tyda-rewrite/target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-arrow/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar tyda-big-query/target tyda-rewrite/target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
+        run: tar cf targets.tar tyda-big-query/target tyda-rewrite/target tyda-parquet/target tyda-metadata/target tyda-iterator/target tyda-job/target tyda-arrow/target tyda-collection/target tyda-json/target tyda/target tyda-sql/target tyda-job-test/target tyda-table/target tyda-meta/target tyda-spark/target tyda-repl/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))

--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,7 @@ lazy val root = (project in file("."))
     scalafixRules,
     scalafixTests,
     tyda,
+    tydaArrow,
     tydaBigQuery,
     tydaCollection,
     tydaDocs,
@@ -235,6 +236,16 @@ lazy val tyda = (project in file("tyda"))
         }
         .taskValue
   )
+
+lazy val tydaArrow = (project in file("tyda-arrow"))
+  .settings(commonSettings)
+  .settings(Dependencies.tydaArrow)
+  .settings(
+    Test / javaOptions ++= Seq("--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"),
+    Test / fork := true
+  )
+  .dependsOn(scalafixRules % ScalafixConfig)
+  .dependsOn(tyda)
 
 lazy val tydaJson = (project in file("tyda-json"))
   .settings(commonSettings)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,11 +6,13 @@ import sbt.*
 import Keys.*
 
 object Dependencies {
+  val arrowVersion = "18.3.0"
   val scala3Version = "3.7.4"
   val sparkVersion = "3.5.1"
   val jsoniterVersion = "2.38.6"
 
   object TestDeps {
+    val arrowNetty = CompileDeps.arrowNetty % Test
     val scalatest = CompileDeps.scalatest % Test
     val commonsIo = CompileDeps.commonsIo % Test
     val sparkSql = (CompileDeps.sparkSql % Test).exclude("org.scala-lang.modules", "scala-xml_2.13")
@@ -20,6 +22,9 @@ object Dependencies {
   }
 
   object CompileDeps {
+    val arrowVector = "org.apache.arrow" % "arrow-vector" % arrowVersion
+    val arrowCData = "org.apache.arrow" % "arrow-c-data" % arrowVersion
+    val arrowNetty = "org.apache.arrow" % "arrow-memory-netty" % arrowVersion
     val shapeless3 = "org.typelevel" %% "shapeless3-deriving" % "3.6.0"
     val jsoniterCore = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % jsoniterVersion
     val scalatest = "org.scalatest" %% "scalatest" % "3.2.19"
@@ -51,6 +56,9 @@ object Dependencies {
   )
 
   val tyda = libraryDependencies ++= Seq(TestDeps.scalatest, CompileDeps.shapeless3)
+
+  val tydaArrow = libraryDependencies ++=
+    Seq(CompileDeps.arrowCData, CompileDeps.arrowVector, TestDeps.scalatest, TestDeps.arrowNetty)
 
   val tydaRewrite = libraryDependencies ++= Seq(TestDeps.scalatest)
 

--- a/tyda-arrow/src/main/scala/com/choreograph/tyda/arrow/ArrowDeserializer.scala
+++ b/tyda-arrow/src/main/scala/com/choreograph/tyda/arrow/ArrowDeserializer.scala
@@ -1,0 +1,158 @@
+package com.choreograph.tyda.arrow
+
+import java.io.ByteArrayInputStream
+
+import scala.collection.AbstractIterator
+import scala.collection.Factory
+import scala.util.Using
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.BitVector
+import org.apache.arrow.vector.DateDayVector
+import org.apache.arrow.vector.DecimalVector
+import org.apache.arrow.vector.DurationVector
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.Float4Vector
+import org.apache.arrow.vector.Float8Vector
+import org.apache.arrow.vector.IntVector
+import org.apache.arrow.vector.SmallIntVector
+import org.apache.arrow.vector.TimeStampMicroTZVector
+import org.apache.arrow.vector.TinyIntVector
+import org.apache.arrow.vector.VarBinaryVector
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.complex.ListVector
+import org.apache.arrow.vector.complex.MapVector
+import org.apache.arrow.vector.complex.StructVector
+import org.apache.arrow.vector.ipc.ArrowReader
+import org.apache.arrow.vector.ipc.ArrowStreamReader
+import org.apache.arrow.vector.util.Text
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Date
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Duration
+import com.choreograph.tyda.Timestamp
+
+private[tyda] object ArrowDeserializer {
+  private type Deserializer[T] = Int => T
+
+  def fromIpcBytes[T: Codec](bytes: Array[Byte], allocator: BufferAllocator)[R](use: Iterator[T] => R): R = {
+    val in = ByteArrayInputStream(bytes)
+    val reader = ArrowStreamReader(in, allocator)
+    Using.resource(reader)(reader => use(fromReader[T](reader)))
+  }
+
+  def fromVector[T: Codec](vector: FieldVector): Iterator[T] = {
+    val deserializer = create(Codec[T], vector)
+    (0 until vector.getValueCount).iterator.map(deserializer)
+  }
+
+  private def fromReader[T: Codec](reader: ArrowReader): Iterator[T] = {
+    val root = reader.getVectorSchemaRoot()
+    val deserializer = create(Codec[T], root)
+    new AbstractIterator[T] {
+      var index = 0
+      var eos = false
+      def hasNext: Boolean = {
+        while (!eos && index >= root.getRowCount) {
+          index = 0
+          eos = !reader.loadNextBatch()
+        }
+        index < root.getRowCount
+      }
+
+      def next: T = {
+        if !hasNext then Iterator.empty.next
+        index += 1
+        deserializer(index - 1)
+      }
+    }
+  }
+
+  private def support[T](vector: FieldVector)(supported: PartialFunction[FieldVector, Deserializer[T]]) =
+    supported.applyOrElse(
+      vector,
+      _ => throw new IllegalArgumentException(s"Unsupported vector type: ${vector.getClass.getSimpleName}")
+    )
+
+  private def create[T](codec: Codec[T], root: VectorSchemaRoot): Deserializer[T] =
+    codec match {
+      case p @ Codec.Product(_, _, _) => product(p, root.getVector)
+      case Codec.FromInjection(inj, to) =>
+        val inner = create(to, root)
+        index => inj.invert(inner(index))
+      case codec => create[T](codec, root.getVector(0))
+    }
+
+  private def create[T](codec: Codec[T], vector: FieldVector): Deserializer[T] =
+    codec match {
+      case Codec.Boolean => support(vector) { case v: BitVector => index => v.get(index) > 0 }
+      case Codec.Byte => support(vector) { case v: TinyIntVector => v.get }
+      case Codec.Short => support(vector) { case v: SmallIntVector => index => v.get(index) }
+      case Codec.Int => support(vector) { case v: IntVector => v.get }
+      case Codec.Long => support(vector) { case v: BigIntVector => v.get }
+      case Codec.Float => support(vector) { case v: Float4Vector => v.get }
+      case Codec.Double => support(vector) { case v: Float8Vector => v.get }
+      case Codec.String => support(vector) { case v: VarCharVector => index => Text.decode(v.get(index)) }
+      case decimal @ Codec.Decimal(_, _) => support(vector) { case v: DecimalVector =>
+          index =>
+            val value = BigDecimal(v.getObject(index))
+            Decimal(using decimal.valid)(value).getOrElse {
+              throw new RuntimeException(s"Unable to represent $value as ${decimal.valid}")
+            }
+        }
+      case Codec.Date => support(vector) { case v: DateDayVector => index => Date.fromDays(v.get(index)) }
+      case Codec.TimestampMicros => support(vector) { case v: TimeStampMicroTZVector =>
+          index => Timestamp.fromMicros(v.get(index))
+        }
+      case Codec.DurationMicros => support(vector) { case v: DurationVector =>
+          index => Duration.fromMicros(DurationVector.get(v.getDataBuffer, index))
+        }
+      case Codec.Bytes => support(vector) { case v: VarBinaryVector => v.get }
+      case Codec.Option(innerCodec @ Codec.Option(_)) => support(vector) { case v: StructVector =>
+          val inner = create(innerCodec, v.getChild("value"))
+          index => Option.when(!v.isNull(index))(inner(index))
+        }
+      case Codec.Option(innerCodec) =>
+        val inner = create(innerCodec, vector)
+        index => Option.when(!vector.isNull(index))(inner(index))
+      case Codec.Seq(element: Codec[t]) => iterable(create(element, _), summon[Factory[t, Vector[t]]], vector)
+      case map @ Codec.Map(_, _) => mapDeserializer(map, vector)
+      case p @ Codec.Product(_, _, _) => support(vector) { case v: StructVector => product(p, v.getChild) }
+      case Codec.FromInjection(inj, innerCodec) =>
+        val inner = create(innerCodec, vector)
+        index => inj.invert(inner(index))
+    }
+
+  private def iterable[T, C <: Iterable[T]](
+      createElement: FieldVector => Deserializer[T],
+      factory: Factory[T, C],
+      vector: FieldVector
+  ): Deserializer[C] =
+    support(vector) { case v: ListVector =>
+      val element = createElement(v.getDataVector)
+      index => {
+        val start = v.getElementStartIndex(index)
+        val end = v.getElementEndIndex(index)
+        factory.fromSpecific((start until end).iterator.map(element))
+      }
+    }
+
+  private def mapDeserializer[K, V](map: Codec.Map[K, V], vector: FieldVector): Deserializer[Map[K, V]] =
+    iterable(
+      support(_) { case v: StructVector =>
+        val key = create(map.key, v.getChild(MapVector.KEY_NAME))
+        val value = create(map.value, v.getChild(MapVector.VALUE_NAME))
+        index => (key(index), value(index))
+      },
+      summon,
+      vector
+    )
+
+  private def product[T](codec: Codec.Product[T], getFieldVector: String => FieldVector): Deserializer[T] = {
+    val fieldDeserializer = codec.fields.mapK([t] => f => create(f.codec, getFieldVector(f.name)))
+    index => fieldDeserializer.construct([t] => _(index))
+  }
+}

--- a/tyda-arrow/src/main/scala/com/choreograph/tyda/arrow/ArrowSerializer.scala
+++ b/tyda-arrow/src/main/scala/com/choreograph/tyda/arrow/ArrowSerializer.scala
@@ -1,0 +1,182 @@
+package com.choreograph.tyda.arrow
+
+import java.io.ByteArrayOutputStream
+
+import scala.util.Using
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.BitVector
+import org.apache.arrow.vector.DateDayVector
+import org.apache.arrow.vector.DecimalVector
+import org.apache.arrow.vector.DurationVector
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.Float4Vector
+import org.apache.arrow.vector.Float8Vector
+import org.apache.arrow.vector.IntVector
+import org.apache.arrow.vector.SmallIntVector
+import org.apache.arrow.vector.TimeStampMicroTZVector
+import org.apache.arrow.vector.TinyIntVector
+import org.apache.arrow.vector.VarBinaryVector
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.complex.ListVector
+import org.apache.arrow.vector.complex.MapVector
+import org.apache.arrow.vector.complex.StructVector
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
+import org.apache.arrow.vector.util.Text
+
+import com.choreograph.tyda.Codec
+
+private[tyda] object ArrowSerializer {
+  private type Serializer[T] = Function2[Int, T, Unit]
+
+  def toIpcBytes[T: Codec](data: Seq[T], allocator: BufferAllocator): Array[Byte] =
+    Using.resource(VectorSchemaRoot.create(CodecToArrowSchema.convert[T], allocator)) { root =>
+      root.allocateNew()
+      val serializer = create[T](Codec[T], root)
+      root.setRowCount(data.size)
+      data.zipWithIndex.foreach { case (value, index) => serializer(index, value) }
+      // For collections like Seq, we only know the size of nested data vectors after serialization.
+      // Arrow doesn't automatically update value counts during writes, so we call setRowCount again
+      // to synchronize all vector metadata based on the actual serialized data.
+      root.setRowCount(data.size)
+
+      val out = new ByteArrayOutputStream()
+      Using.resource(new ArrowStreamWriter(root, null, out)) { writer =>
+        writer.start()
+        writer.writeBatch()
+        writer.end()
+        out.toByteArray
+      }
+    }
+
+  def toVector[T: Codec](it: Iterator[T], allocator: BufferAllocator): FieldVector = {
+    val vector = CodecToArrowSchema.field("value", nullable = false, Codec[T]).createVector(allocator)
+    val knownSize = it.knownSize
+    if knownSize != -1 then vector.setInitialCapacity(knownSize)
+    vector.allocateNew()
+    val serializer = create(Codec[T], vector)
+    val lastIndex = it
+      .zipWithIndex
+      .map { case (value, index) =>
+        serializer(index, value)
+        index
+      }
+      .fold(-1)((_, index) => index)
+    vector.setValueCount(lastIndex + 1)
+    vector
+  }
+
+  private def support[T](vector: FieldVector)(supported: PartialFunction[FieldVector, Serializer[T]]) =
+    supported.applyOrElse(
+      vector,
+      _ => throw new IllegalArgumentException(s"Unsupported vector type: ${vector.getClass.getSimpleName}")
+    )
+
+  private def create[T](codec: Codec[T], root: VectorSchemaRoot): Serializer[T] =
+    codec match {
+      case p @ Codec.Product(_, _, _) => product(p, root.getVector)
+      case Codec.FromInjection(inj, innerCodec) =>
+        val inner = create(innerCodec, root)
+        (index, value) => inner(index, inj(value))
+      case _ => create[T](codec, root.getVector(0))
+    }
+
+  private def create[T](codec: Codec[T], vector: FieldVector): Serializer[T] =
+    codec match {
+      case Codec.Boolean => support(vector) { case v: BitVector =>
+          (index, value) => v.setSafe(index, if (value) 1 else 0)
+        }
+      case Codec.Byte => support(vector) { case v: TinyIntVector => v.setSafe }
+      case Codec.Short => support(vector) { case v: SmallIntVector => v.setSafe }
+      case Codec.Int => support(vector) { case v: IntVector => v.setSafe }
+      case Codec.Long => support(vector) { case v: BigIntVector => v.setSafe }
+      case Codec.Float => support(vector) { case v: Float4Vector => v.setSafe }
+      case Codec.Double => support(vector) { case v: Float8Vector => v.setSafe }
+      case Codec.String => support(vector) { case v: VarCharVector =>
+          (index, value) =>
+            val bytes = Text.encode(value)
+            v.setSafe(index, bytes, 0, bytes.limit())
+        }
+      case Codec.Decimal(_, _) => support(vector) { case v: DecimalVector =>
+          (index, value) => v.setSafe(index, value.toBigDecimal.bigDecimal)
+        }
+      case Codec.Date => support(vector) { case v: DateDayVector =>
+          (index, value) => v.setSafe(index, value.daysSinceEpoch)
+        }
+      case Codec.TimestampMicros => support(vector) { case v: TimeStampMicroTZVector =>
+          (index, value) => v.setSafe(index, value.toMicros)
+        }
+      case Codec.DurationMicros => support(vector) { case v: DurationVector =>
+          (index, value) => v.setSafe(index, value.toMicros)
+        }
+      case Codec.Bytes => support(vector) { case v: VarBinaryVector => v.setSafe }
+      case Codec.Option(innerCodec @ Codec.Option(_)) => support(vector) { case v: StructVector =>
+          val inner = create(innerCodec, v.getChild("value"))
+          (index, value) =>
+            value match {
+              case Some(value) =>
+                v.setIndexDefined(index)
+                inner(index, value)
+              case None => v.setNull(index)
+            }
+        }
+      case Codec.Option(innerCodec) =>
+        val inner = create(innerCodec, vector)
+        (index, value) =>
+          value match {
+            case Some(v) => inner(index, v)
+            case None => vector.setNull(index)
+          }
+      case Codec.Seq(element) => iterable(create(element, _), vector)
+      case map @ Codec.Map(_, _) => mapSerializer(map, vector)
+      case p @ Codec.Product(_, _, _) => support(vector) { case v: StructVector =>
+          val serializeFields = product(p, v.getChild)
+          (index, value) => {
+            v.setIndexDefined(index)
+            serializeFields(index, value)
+          }
+        }
+      case Codec.FromInjection(inj, innerCodec) =>
+        val inner = create(innerCodec, vector)
+        (index, value) => inner(index, inj(value))
+    }
+
+  private def iterable[T, C <: Iterable[T]](
+      createElement: FieldVector => Serializer[T],
+      vector: FieldVector
+  ): Serializer[C] =
+    support(vector) { case v: ListVector =>
+      val element = createElement(v.getDataVector)
+      (index, value) => {
+        val startIndex = v.startNewValue(index)
+        val it = value.iterator
+        var elementIndex = startIndex
+        while (it.hasNext) {
+          element(elementIndex, it.next())
+          elementIndex += 1
+        }
+        v.endValue(index, elementIndex - startIndex)
+      }
+    }
+
+  private def mapSerializer[K, V](map: Codec.Map[K, V], vector: FieldVector): Serializer[Map[K, V]] =
+    iterable(
+      support(_) { case v: StructVector =>
+        val keySerializer = create(map.key, v.getChild(MapVector.KEY_NAME))
+        val valueSerializer = create(map.value, v.getChild(MapVector.VALUE_NAME))
+        (index, kv) => {
+          keySerializer(index, kv._1)
+          valueSerializer(index, kv._2)
+        }
+      },
+      vector
+    )
+
+  private def product[T](codec: Codec.Product[T], getFieldVector: String => FieldVector): Serializer[T] = {
+    val fieldSerializers = codec.fields.mapK([t] => f => create(f.codec, getFieldVector(f.name)))
+    (index, value) =>
+      fieldSerializers.foldLeft(value)(())([t] => (_, fieldSer, fieldValue) => fieldSer(index, fieldValue))
+  }
+}

--- a/tyda-arrow/src/main/scala/com/choreograph/tyda/arrow/CodecToArrowSchema.scala
+++ b/tyda-arrow/src/main/scala/com/choreograph/tyda/arrow/CodecToArrowSchema.scala
@@ -1,0 +1,82 @@
+package com.choreograph.tyda.arrow
+
+import java.util.List as JList
+
+import scala.jdk.CollectionConverters.*
+
+import org.apache.arrow.vector.complex.MapVector
+import org.apache.arrow.vector.types.DateUnit
+import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.apache.arrow.vector.types.TimeUnit
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import org.apache.arrow.vector.types.pojo.Schema
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Field as TydaField
+import com.choreograph.tyda.shapeless3extras.mapConst
+
+private[tyda] object CodecToArrowSchema {
+  def convert[T: Codec]: Schema = {
+    val field = CodecToArrowSchema.field("value", nullable = false, Codec[T])
+    Codec[T] match {
+      case Codec.Product(_, _, _) => Schema(field.getChildren)
+      case Codec.Sum(_, _) => Schema(field.getChildren)
+      case Codec.FromInjection(_, inner) => convert(using inner)
+      case _: Codec[?] => Schema(JList.of(field))
+    }
+  }
+
+  private[arrow] def field(name: String, nullable: Boolean, codec: Codec[?]): Field =
+    codec match {
+      case p: Codec.Primitive[?] => Field(name, FieldType(nullable, toType(p), null), JList.of())
+      case Codec.Seq(inner) => Field(
+          name,
+          FieldType(nullable, ArrowType.List.INSTANCE, null),
+          JList.of(field("element", nullable = false, inner))
+        )
+      case _: Codec.SumAsString[?] => field(name, nullable, Codec.String)
+      case Codec.FromInjection(_, inner) => field(name, nullable, inner)
+      case Codec.Map(key, value) => Field(
+          name,
+          FieldType(nullable, ArrowType.Map(false), null),
+          JList.of(structField(
+            MapVector.DATA_VECTOR_NAME,
+            nullable = false,
+            Seq(TydaField(MapVector.KEY_NAME, key), TydaField(MapVector.VALUE_NAME, value))
+          ))
+        )
+      case Codec.Option(inner @ Codec.Option(_)) =>
+        structField(name, nullable = true, Seq(TydaField("value", inner)))
+
+      case Codec.Option(inner) => field(name, nullable = true, inner)
+      case Codec.Product(_, fields, _) =>
+        structField(name, nullable, fields.mapConst[TydaField[?]]([t] => identity(_)))
+      case s @ Codec.Sum(_, _) => structField(name, nullable, s.reprFields)
+    }
+
+  private def structField(name: String, nullable: Boolean, fields: Seq[TydaField[?]]): Field =
+    Field(
+      name,
+      FieldType(nullable, ArrowType.Struct.INSTANCE, null),
+      fields.map(f => field(f.name, nullable = false, f.codec)).asJava
+    )
+
+  private def toType(codec: Codec.Primitive[?]): ArrowType =
+    codec match {
+      case Codec.Boolean => ArrowType.Bool.INSTANCE
+      case Codec.Byte => ArrowType.Int(8, true)
+      case Codec.Short => ArrowType.Int(16, true)
+      case Codec.Int => ArrowType.Int(32, true)
+      case Codec.Long => ArrowType.Int(64, true)
+      case Codec.String => ArrowType.Utf8.INSTANCE
+      case Codec.Float => ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
+      case Codec.Double => ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
+      case Codec.Decimal(precision, scale) => ArrowType.Decimal(precision, scale, 128)
+      case Codec.Date => ArrowType.Date(DateUnit.DAY)
+      case Codec.TimestampMicros => ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC")
+      case Codec.DurationMicros => ArrowType.Duration(TimeUnit.MICROSECOND)
+      case Codec.Bytes => ArrowType.Binary.INSTANCE
+    }
+}

--- a/tyda-arrow/src/test/scala/com/choreograph/tyda/arrow/ArrowRoundTripSuite.scala
+++ b/tyda-arrow/src/test/scala/com/choreograph/tyda/arrow/ArrowRoundTripSuite.scala
@@ -1,0 +1,108 @@
+package com.choreograph.tyda.arrow
+
+import scala.reflect.Typeable
+import scala.util.Using
+
+import org.apache.arrow.memory.RootAllocator
+import org.scalactic.Equality
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.choreograph.tyda.Arbitrary
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Date
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Duration
+import com.choreograph.tyda.EnumStableHashCode
+import com.choreograph.tyda.Ord
+import com.choreograph.tyda.Timestamp
+import com.choreograph.tyda.TypeName
+
+object ArrowRoundTripSuite {
+  private final case class MyProduct(a: Option[Int], b: String, c: (Int, Option[Int]))
+      derives Arbitrary, Codec
+  private enum MyEnum extends EnumStableHashCode derives Arbitrary, Codec {
+    case A, B
+    case C(a: Int, b: Option[Int])
+    case D(a: Int, b: Option[Int])
+    case E
+    case F(prod: MyProduct)
+  }
+
+  def equalityFromOrd[T: Ord: Typeable]: Equality[T] =
+    new Equality[T] {
+      override def areEqual(a: T, b: Any): Boolean =
+        b match {
+          case b: T => Ord[T].equiv(a, b)
+          case _ => false
+        }
+    }
+
+  given Equality[Float] = equalityFromOrd[Float]
+  given Equality[Double] = equalityFromOrd[Double]
+}
+
+class ArrowRoundTripSuite extends AnyFunSuite, BeforeAndAfterAll {
+  import ArrowRoundTripSuite.{MyProduct, MyEnum, given}
+
+  val rootAllocator = new RootAllocator()
+
+  override def afterAll(): Unit = rootAllocator.close()
+
+  def testRoundTrip[T: {Arbitrary, Codec, TypeName, Equality}] = {
+    test(s"roundtrip vector for ${TypeName.name[T]}") {
+      val values = Vector.fill(100)(Arbitrary[T]())
+      val allocator = rootAllocator.newChildAllocator(TypeName.name[T], 0, Long.MaxValue)
+      val deserialized = Using.resource(allocator) { allocator =>
+        Using.resource(ArrowSerializer.toVector[T](values.iterator, allocator)) { serialized =>
+          ArrowDeserializer.fromVector[T](serialized).toSeq
+        }
+      }
+      assert(deserialized.size == values.size)
+      deserialized
+        .zip(values)
+        .zipWithIndex
+        .map { case ((value, expected), index) =>
+          assert(value === expected, s"Found value $value expected $expected at index $index")
+        }
+    }
+    test(s"roundtrip IPC for ${TypeName.name[T]}") {
+      val values = Vector.fill(100)(Arbitrary[T]())
+      val deserialized = Using.resource(new RootAllocator()) { allocator =>
+        val ipcBytes = ArrowSerializer.toIpcBytes[T](values, allocator)
+        ArrowDeserializer.fromIpcBytes[T](ipcBytes, allocator)(_.toIndexedSeq)
+      }
+      assert(deserialized.size == values.size)
+      deserialized
+        .zip(values)
+        .zipWithIndex
+        .map { case ((value, expected), index) =>
+          assert(value === expected, s"Found value $value expected $expected at index $index")
+        }
+    }
+  }
+
+  testRoundTrip[Boolean]
+  testRoundTrip[Byte]
+  testRoundTrip[Short]
+  testRoundTrip[Int]
+  testRoundTrip[Long]
+  testRoundTrip[Float]
+  testRoundTrip[Double]
+  testRoundTrip[String]
+  testRoundTrip[Decimal[38, 9]]
+  testRoundTrip[Date]
+  testRoundTrip[Timestamp]
+  testRoundTrip[Duration]
+  testRoundTrip[Option[Int]]
+  testRoundTrip[Option[Option[Int]]]
+  testRoundTrip[Seq[Int]]
+  testRoundTrip[Seq[Seq[Int]]]
+  testRoundTrip[Seq[(Int, Option[Int])]]
+  testRoundTrip[Map[String, Int]]
+  testRoundTrip[Map[(String, Int), (String, Option[Int])]]
+  testRoundTrip[Map[Seq[String], Seq[Int]]]
+  testRoundTrip[(Int, Option[Int])]
+  testRoundTrip[MyProduct]
+  testRoundTrip[MyEnum]
+}


### PR DESCRIPTION
This MR adds basic (de)serialization for arrow. It was originally
written last summer when I explored a datafusion backend. But I never
got around to creating a MR for them. I confident that we will
eventually merge something like this, so I think we should consider
merging it now so that we do not need to keep updating out of tree code.

The apis might need some work, but as they are just internal I think
that can be improved as we actually start using these.
