### PR TITLE
Implement Dataset.orderBy

### DIFF
--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteBigQuery.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteBigQuery.scala
@@ -27,6 +27,7 @@ import com.choreograph.tyda.testsuites.BigQueryIntegrationTestEnvVariables
 import com.choreograph.tyda.testsuites.DatasetAggregatesSuite
 import com.choreograph.tyda.testsuites.DatasetBasicSuite
 import com.choreograph.tyda.testsuites.DatasetJoinSuite
+import com.choreograph.tyda.testsuites.DatasetOrderBySuite
 import com.choreograph.tyda.testsuites.DatasetReadBigQueryTableSuite
 import com.choreograph.tyda.testsuites.DatasetReadWriteSuite
 import com.choreograph.tyda.testsuites.DatasetSubquerySuite
@@ -65,6 +66,7 @@ class DatasetBasicSuiteBigQuery extends DatasetBasicSuite, BigQuerySuiteRunner
 class DatasetJoinSuiteBigQuery extends DatasetJoinSuite, BigQuerySuiteRunner
 class DatasetAggregatesSuiteBigQuery extends DatasetAggregatesSuite, BigQuerySuiteRunner
 class DatasetSubquerySuiteBigQuery extends DatasetSubquerySuite, BigQuerySuiteRunner
+class DatasetOrderBySuiteBigQuery extends DatasetOrderBySuite, BigQuerySuiteRunner
 abstract class DatasetReadWriteSuiteBigQuery extends DatasetReadWriteSuite, BigQuerySuiteRunner {
   override def includeReadTests: Boolean = false
 

--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/DatasetOnIterator.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/DatasetOnIterator.scala
@@ -17,14 +17,20 @@ import com.choreograph.tyda.CompiledExplodeExpr
 import com.choreograph.tyda.CompiledExpr
 import com.choreograph.tyda.CompiledExprOrExplode
 import com.choreograph.tyda.Dataset
+import com.choreograph.tyda.Date
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Duration
 import com.choreograph.tyda.Format
 import com.choreograph.tyda.HivePartitionParser
+import com.choreograph.tyda.Ord
+import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.iterator.AggregateExprEvaluation.aggregator
 import com.choreograph.tyda.iterator.ExprEvaluation.lambda
 import com.choreograph.tyda.json.CodecToJsoniter
 import com.choreograph.tyda.parquet.CodecParquetWriter
 import com.choreograph.tyda.parquet.CodecReadSupport
 import com.choreograph.tyda.shapeless3extras.tupleInstances
+import com.choreograph.tyda.unreachable
 
 object DatasetOnIterator {
   def perform[T](ds: Dataset.Action): Unit =
@@ -81,6 +87,9 @@ object DatasetOnIterator {
       case Dataset.Union(left, right) => apply(left) ++ apply(right)
       case Dataset.Cache(input) => apply(input).iterator
       case Dataset.Limit(input, n) => apply(input).take(n)
+      case Dataset.OrderBy(input, key: CompiledExpr[?, k]) =>
+        given Ordering[k] = ordFromCodec(key.codec)
+        apply(input).to(Vector).sortBy(lambda(key)).iterator
     }
 
   private def selectN[T, R <: Tuple](
@@ -193,4 +202,30 @@ object DatasetOnIterator {
       }
     }
   }
+
+  type Id[x] = x
+
+  private def ordFromCodec[T](codec: Codec[T]): Ord[T] =
+    codec match {
+      case Codec.Boolean => Ord[Boolean]
+      case Codec.Byte => Ord[Byte]
+      case Codec.Short => Ord[Short]
+      case Codec.Int => Ord[Int]
+      case Codec.Long => Ord[Long]
+      case Codec.Float => Ord[Float]
+      case Codec.Double => Ord[Double]
+      case Codec.String => Ord[String]
+      case _: Codec.Decimal[p, s] => Ord[Decimal[p, s]]
+      case Codec.Date => Ord.fromOrdering(using Ordering[Date])
+      case Codec.TimestampMicros => Ord.fromOrdering(using Ordering[Timestamp])
+      case Codec.DurationMicros => Ord.fromOrdering(using Ordering[Duration])
+      case Codec.Option(element: Codec[e]) =>
+        given Ord[e] = ordFromCodec(element)
+        Ord.sum[Option[e]]
+      case Codec.Product(_, fields, _) => Ord.product(using fields.mapK([t] => f => ordFromCodec(f.codec)))
+      case Codec.FromInjection(inj, to) =>
+        val ordering = Ordering.by(inj(_))(using ordFromCodec(to))
+        Ord.fromOrdering(using ordering)
+      case Codec.Seq(_) | Codec.Map(_, _) | Codec.Bytes => unreachable("Collections are not orderable")
+    }
 }

--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/DatasetOnIterator.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/DatasetOnIterator.scala
@@ -203,8 +203,6 @@ object DatasetOnIterator {
     }
   }
 
-  type Id[x] = x
-
   private def ordFromCodec[T](codec: Codec[T]): Ord[T] =
     codec match {
       case Codec.Boolean => Ord[Boolean]

--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/explain.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/explain.scala
@@ -65,6 +65,7 @@ private def children[T](ds: Dataset[T] | Dataset.Action): Seq[Dataset[?]] =
     case Dataset.Union(left, right) => Seq(left, right)
     case Dataset.Action.Write(input, _, _) => Seq(input)
     case Dataset.Limit(input, _) => Seq(input)
+    case Dataset.OrderBy(input, _) => Seq(input)
   }
 
 private type AnyCompiledExpr = CompiledExpr[?, ?] | CompiledExpr2[?, ?, ?] | CompiledExplodeExpr[?, ?] |
@@ -94,6 +95,7 @@ private def exprs[T](ds: Dataset[T] | Dataset.Action): Seq[AnyCompiledExpr] =
     case Dataset.Union(_, _) => Seq.empty
     case Dataset.Action.Write(_, _, _) => Seq.empty
     case Dataset.Limit(_, _) => Seq.empty
+    case Dataset.OrderBy(_, key) => Seq(key)
   }
 
 private[tyda] def explain(anyCompiled: AnyCompiledExpr): String =

--- a/tyda-iterator/src/test/scala/com/choreograph/tyda/iterator/DatasetSuitesIterator.scala
+++ b/tyda-iterator/src/test/scala/com/choreograph/tyda/iterator/DatasetSuitesIterator.scala
@@ -2,6 +2,7 @@ package com.choreograph.tyda.iterator
 
 import com.choreograph.tyda.Format
 import com.choreograph.tyda.Runner
+import com.choreograph.tyda.testsuites.DatasetOrderBySuite
 import com.choreograph.tyda.testsuites.DatasetReadWriteSuite
 import com.choreograph.tyda.testsuites.DatasetSuite
 
@@ -9,6 +10,8 @@ private trait IteratorSuiteRunner extends DatasetSuite {
   override def reference: Runner = IteratorRunner
   def implementation: Runner = IteratorRunner
 }
+
+class DatasetOrderBySuiteIterator extends DatasetOrderBySuite, IteratorSuiteRunner
 
 class DatasetReadWriteParquetSuiteIterator extends DatasetReadWriteSuite, IteratorSuiteRunner {
   override def format = Format.Parquet

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
@@ -365,6 +365,9 @@ object DatasetOnSpark {
             """.stripMargin)
           }
           IntermediateDataset(toIntermediate(input).toDataset.limit(n))
+        case Dataset.OrderBy(input, key) =>
+          val (df, cf) = toIntermediate(input).toDataFrameAndColumnFactory
+          IntermediateDataset(df.sort(ExprOnSpark.resolved(cf, key)), cf)
       }
     // TYPE SAFETY: The type parameter of the key is the same as the value
     existingConversions.computeIfAbsent(ds, _ => compute).asInstanceOf[IntermediateDataset[T]]

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/DatasetSuiteSpark.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/DatasetSuiteSpark.scala
@@ -6,6 +6,7 @@ import com.choreograph.tyda.iterator.IteratorRunner
 import com.choreograph.tyda.testsuites.DatasetAggregatesSuite
 import com.choreograph.tyda.testsuites.DatasetBasicSuite
 import com.choreograph.tyda.testsuites.DatasetJoinSuite
+import com.choreograph.tyda.testsuites.DatasetOrderBySuite
 import com.choreograph.tyda.testsuites.DatasetReadBigQueryTableSuite
 import com.choreograph.tyda.testsuites.DatasetReadWriteSuite
 import com.choreograph.tyda.testsuites.DatasetSubquerySuite
@@ -20,6 +21,7 @@ class DatasetBasicSuiteSpark extends DatasetBasicSuite, SparkSuiteRunner
 class DatasetJoinSuiteSpark extends DatasetJoinSuite, SparkSuiteRunner
 class DatasetAggregatesSuiteSpark extends DatasetAggregatesSuite, SparkSuiteRunner
 class DatasetSubquerySuiteSpark extends DatasetSubquerySuite, SparkSuiteRunner
+class DatasetOrderBySuiteSpark extends DatasetOrderBySuite, SparkSuiteRunner
 class DatasetReadWriteParquetSuiteSpark extends DatasetReadWriteSuite, SparkSuiteRunner {
   override def format = Format.Parquet
 }

--- a/tyda-sparksql/src/test/scala/com/choreograph/tyda/sparksql/DatasetSuiteSparkSql.scala
+++ b/tyda-sparksql/src/test/scala/com/choreograph/tyda/sparksql/DatasetSuiteSparkSql.scala
@@ -17,6 +17,7 @@ import com.choreograph.tyda.sql.toSql
 import com.choreograph.tyda.testsuites.DatasetAggregatesSuite
 import com.choreograph.tyda.testsuites.DatasetBasicSuite
 import com.choreograph.tyda.testsuites.DatasetJoinSuite
+import com.choreograph.tyda.testsuites.DatasetOrderBySuite
 import com.choreograph.tyda.testsuites.DatasetReadWriteSuite
 import com.choreograph.tyda.testsuites.DatasetSubquerySuite
 import com.choreograph.tyda.testsuites.DatasetSuite
@@ -81,6 +82,7 @@ class DatasetBasicSuiteSparkSql extends DatasetBasicSuite, SparkSuiteRunner
 class DatasetJoinSuiteSparkSql extends DatasetJoinSuite, SparkSuiteRunner
 class DatasetAggregatesSuiteSparkSql extends DatasetAggregatesSuite, SparkSuiteRunner
 class DatasetSubquerySuiteSparkSql extends DatasetSubquerySuite, SparkSuiteRunner
+class DatasetOrderBySuiteSparkSql extends DatasetOrderBySuite, SparkSuiteRunner
 class DatasetReadWriteParquetSuiteSparkSql extends DatasetReadWriteSuite, SparkSuiteRunner {
   override def includeReadTests: Boolean = false
   override def format = Format.Parquet

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/DatasetUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/DatasetUnparser.scala
@@ -153,6 +153,7 @@ private def unparseDs[T](ds: Dataset[T], args: UnparserArgs): Result[SelectBuild
       case Dataset.SelectN(input, exprs) => inner(input).flatMap(_.selectN(exprs))
       case Dataset.Cache(input) => inner(input)
       case Dataset.Limit(input, n) => inner(input).flatMap(_.limit(n))
+      case Dataset.OrderBy(input, key) => inner(input).flatMap(_.orderBy(key))
       case Dataset.Union(left, right) => for {
           lhs <- inner(left)
           rhs <- inner(right)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -84,7 +84,7 @@ private final case class SelectBuilder[T, R](
     }
 
     // TODO: We always force a subquery after order by for simplicity. But in the future we might
-    // want to allow it to be comined with more operations.
+    // want to allow it to be combined with more operations.
     ordered.flatMap(_.toSubquery)
   }
 
@@ -544,12 +544,12 @@ private final case class SelectBuilder[T, R](
     }
     def groupByToSqlExpr(compiled: CompiledExpr[T, ?]): Result[Seq[SqlExpr]] = {
       val node = compiled.expr.replace(compiled.arg, output)
-      flattenMakeStruct(node).map(simplifyAndToSqlExpr(_, ids, args)).sequence
+      flattenMakeStructAndRemoveLiterals(node).map(simplifyAndToSqlExpr(_, ids, args)).sequence
     }
 
     def orderByToSqlExpr(compiled: CompiledExpr[T, ?]): Result[Seq[SqlExpr]] = {
       val node = compiled.expr.replace(compiled.arg, output)
-      val nodes = flattenMakeStruct(node).flatMap(flattenForOrderBy(args.dialect, _))
+      val nodes = flattenMakeStructAndRemoveLiterals(node).flatMap(flattenForOrderBy(args.dialect, _))
       nodes.map(simplifyAndToSqlExpr(_, ids, args)).sequence
     }
 
@@ -742,27 +742,22 @@ private object SelectBuilder {
     }
 
   private def hasMakeProductAfterFlattening(newGroupBy: CompiledExpr[?, ?]): Boolean =
-    flattenMakeStruct(newGroupBy.expr).exists(_.exists {
+    flattenMakeStructAndRemoveLiterals(newGroupBy.expr).exists(_.exists {
       case ExprNode.MakeProduct(_, _) => true
       case ExprNode.MakeSome(Nullable(_)) => true
       case _ => false
     })
 
-  private def flattenMakeStruct(node: ExprNode[?]): Seq[ExprNode[?]] = {
+  private def flattenMakeStructAndRemoveLiterals(node: ExprNode[?]): Seq[ExprNode[?]] = {
     val exprs = simplifySelects(node)
       .fold(Seq.empty[ExprNode[?]])((acc, expr) =>
         expr match {
-          // Remove any MakeAdt nodes from the group by expressions as they are not needed and will
-          // be rejected by BigQuery for example.
           case ExprNode.MakeProduct(_, _) => Continue(acc)
+          case ExprNode.Literal(_, _) | ExprNode.None(_) => Skip(acc)
           // MakeSome are either no-op or make struct so we need to continue into them
           case ExprNode.MakeSome(_) => Continue(acc)
-          // MakeNone is never needed in group by
-          case ExprNode.None(_) => Continue(acc)
           // The as and from sum repr are just no-ops in the this backend
           case ExprNode.FromRepr(_, _) | ExprNode.ToRepr(_, _) => Continue(acc)
-          // Literals are not needed in group by as they are also in the select expressions
-          case ExprNode.Literal(_, _) => Skip(acc)
           // References to top level product will result as a make struct so we need to unpack them
           case expr @ ExprNode.Reference(_, _) => expr match {
               case StructFields(fields) => Skip(acc ++ fields)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -28,6 +28,7 @@ import com.choreograph.tyda.TreeApi.Continue
 import com.choreograph.tyda.TreeApi.Skip
 import com.choreograph.tyda.functions.lit
 import com.choreograph.tyda.rewrite.ArrayCodec
+import com.choreograph.tyda.rewrite.IsNone
 import com.choreograph.tyda.rewrite.Nullable
 import com.choreograph.tyda.rewrite.StructFields
 import com.choreograph.tyda.shapeless3extras.mapConst
@@ -54,6 +55,7 @@ private final case class SelectBuilder[T, R](
     groupBy: Option[CompiledExpr[T, ?]] = None,
     having: Option[CompiledExpr[T, Boolean]] = None,
     distinct: Boolean = false,
+    orderBy: Option[CompiledExpr[T, ?]] = None,
     limit: Option[Int] = None
 ) {
   import SelectBuilder.*
@@ -70,6 +72,21 @@ private final case class SelectBuilder[T, R](
     /* We wrap the limit in a subquery to make sure the order of operations is preserved when it's combined
      * with other operations that can change the number of rows (e.g. filters, joins, aggregates). */
     copy(limit = Some(n)).toSubquery
+
+  def orderBy[K](key: CompiledExpr[R, K]): Result[SelectBuilder[?, R]] = {
+    val ordered = select match {
+      // TODO: orderBy should be fine to combine with distinct. But it currently it leads to spark
+      // not resolving fully qualified column names in the order by clause.
+      case _ if distinct => toSubquery.flatMap(_.orderBy(key))
+      case CompiledAggregateExpr(arg, expr) =>
+        Right(copy(orderBy = Some(key.compose(CompiledExpr(arg, expr)))))
+      case compiled: CompiledExpr[T, R] => Right(copy(orderBy = Some(key.compose(compiled))))
+    }
+
+    // TODO: We always force a subquery after order by for simplicity. But in the future we might
+    // want to allow it to be comined with more operations.
+    ordered.flatMap(_.toSubquery)
+  }
 
   def select[R2](expr: CompiledExprOrExplode[R, R2]): Result[SelectBuilder[?, R2]] =
     if distinct || requiresSubqueryForSeqOps(expr) then toSubquery.flatMap(_.select(expr))
@@ -490,6 +507,7 @@ private final case class SelectBuilder[T, R](
             None,
             None,
             false,
+            None,
             None
           ) => return Right(query)
       case _ => ()
@@ -526,7 +544,13 @@ private final case class SelectBuilder[T, R](
     }
     def groupByToSqlExpr(compiled: CompiledExpr[T, ?]): Result[Seq[SqlExpr]] = {
       val node = compiled.expr.replace(compiled.arg, output)
-      flattenGroupBy(node).map(simplifyAndToSqlExpr(_, ids, args)).sequence
+      flattenMakeStruct(node).map(simplifyAndToSqlExpr(_, ids, args)).sequence
+    }
+
+    def orderByToSqlExpr(compiled: CompiledExpr[T, ?]): Result[Seq[SqlExpr]] = {
+      val node = compiled.expr.replace(compiled.arg, output)
+      val nodes = flattenMakeStruct(node).flatMap(flattenForOrderBy(args.dialect, _))
+      nodes.map(simplifyAndToSqlExpr(_, ids, args)).sequence
     }
 
     def compiledToSqlExpr(compiled: CompiledExpr[T, ?]): Result[SqlExpr] =
@@ -548,6 +572,7 @@ private final case class SelectBuilder[T, R](
       where <- where.map(compiledToSqlExpr).sequence
       groupBy <- groupBy.toSeq.map(groupByToSqlExpr).sequence.map(_.flatten)
       having <- having.map(compiledToSqlExpr).sequence
+      orderByExprs <- orderBy.toSeq.map(orderByToSqlExpr).sequence.map(_.flatten)
     } yield Query.Select(
       select = select,
       from = Some(from.from),
@@ -555,6 +580,7 @@ private final case class SelectBuilder[T, R](
       groupBy = groupBy,
       having = having,
       distinct = distinct,
+      orderBy = orderByExprs,
       limit = limit
     )
   }
@@ -571,6 +597,7 @@ private final case class SelectBuilder[T, R](
       groupBy.map(simplifySelects),
       having.map(simplifySelects),
       distinct,
+      orderBy.map(simplifySelects),
       limit
     )
 }
@@ -715,13 +742,13 @@ private object SelectBuilder {
     }
 
   private def hasMakeProductAfterFlattening(newGroupBy: CompiledExpr[?, ?]): Boolean =
-    flattenGroupBy(newGroupBy.expr).exists(_.exists {
+    flattenMakeStruct(newGroupBy.expr).exists(_.exists {
       case ExprNode.MakeProduct(_, _) => true
       case ExprNode.MakeSome(Nullable(_)) => true
       case _ => false
     })
 
-  private def flattenGroupBy(node: ExprNode[?]): Seq[ExprNode[?]] = {
+  private def flattenMakeStruct(node: ExprNode[?]): Seq[ExprNode[?]] = {
     val exprs = simplifySelects(node)
       .fold(Seq.empty[ExprNode[?]])((acc, expr) =>
         expr match {
@@ -747,6 +774,41 @@ private object SelectBuilder {
       .distinct
     // We need at least one group by expression to preserve correct behavior for empty inputs.
     if exprs.isEmpty then Seq(ExprNode.None(Codec.Int)) else exprs
+  }
+
+  private def flattenForOrderBy[T](dialect: SqlDialect, node: ExprNode[T]): Seq[ExprNode[?]] = {
+    def inner[A](node: ExprNode[A]): Option[Seq[ExprNode[?]]] =
+      node.codec match {
+        case codec @ (Codec.Float | Codec.Double)
+            if dialect.floatingOrder == SqlDialect.FloatingOrder.NaNFirst =>
+          val nanCheck = codec match {
+            case Codec.Float => ExprNode.IsNaN[Float](node)
+            case Codec.Double => ExprNode.IsNaN[Double](node)
+          }
+          Some(Seq(nanCheck, node))
+        case Codec.Product(_, fields, _) =>
+          val fieldsExpanded = fields.mapConst { [t] => f =>
+            val fieldNode = ExprNode.Select(node, f.name)
+            (expansion = inner(fieldNode), fieldNode = fieldNode)
+          }
+          val expansionNeeded = dialect.flattenStructInOrderBy || fieldsExpanded.exists(_.expansion.isDefined)
+          Option.when(expansionNeeded)(
+            fieldsExpanded.map((expansion, fieldNode) => expansion.getOrElse(Seq(fieldNode))).flatten
+          )
+        case Codec.Option(element: Codec[t]) =>
+          val nullCheck = !IsNone(node: ExprNode[Option[t]])
+          val innerNode = ExprNode.KnownNotNull(node: ExprNode[Option[t]])
+          element match {
+            case Codec.Option(_) if dialect.flattenStructInOrderBy =>
+              Some(nullCheck +: inner(innerNode).getOrElse(Seq(innerNode)))
+            // No need to perform extra null check on floats as nulls will already be first
+            case Codec.Float | Codec.Double => inner(innerNode)
+            case _ => inner(innerNode).map(nullCheck +: _)
+          }
+        case fi @ Codec.FromInjection(_, _) => inner(ExprNode.ToRepr(node, fi))
+        case _ => None
+      }
+    inner(node).getOrElse(Seq(node))
   }
 
   private def andThenRelaxed[T, R, A](

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -41,6 +41,7 @@ final case class SqlDialect(
     floatingAggregate: SqlDialect.FloatingAggregate,
     floatingCompare: SqlDialect.FloatingCompare,
     fromJson: SqlDialect.FromJsonSupport,
+    floatingOrder: SqlDialect.FloatingOrder,
     intergerSupport: SqlDialect.IntegerSupport,
     isNanFunction: String,
     makeArray: SqlDialect.MakeArray,
@@ -64,6 +65,9 @@ final case class SqlDialect(
     // BigQuery does not support EXCEPT DISTINCT when any SELECT column is of STRUCT type.
     // When false, the Distinct(LeftAntiJoin(_ == _)) pattern uses NOT EXISTS + DISTINCT instead.
     supportsExceptDistinctOnStructColumns: Boolean = true,
+    // BigQuery does not support struct types in ORDER BY at all, requiring individual fields to be
+    // listed explicitly.
+    flattenStructInOrderBy: Boolean = false,
     values: SqlDialect.Values,
     writeSupport: SqlDialect.WriteSupport,
     rand: String,
@@ -231,6 +235,20 @@ object SqlDialect {
     case NaNIsLargest
   }
 
+  enum FloatingOrder {
+
+    /** ORDER BY follows IEEE semantics: any comparison with NaN is false, so
+      * NaN can appear anywhere. An explicit IS_NAN() discriminator is added to
+      * ensure NaN sorts last.
+      */
+    case NaNFirst
+
+    /** ORDER BY follows the more common SQL semantics where NaN is considered
+      * larger than all other values.
+      */
+    case NaNLast
+  }
+
   enum FloatingAggregate {
     case NaNIsSmallestAndLargest
     case NaNIsLargest
@@ -385,6 +403,7 @@ object SqlDialect {
       extractArray = "json_query_array",
       extractObject = "json_query"
     ),
+    floatingOrder = FloatingOrder.NaNFirst,
     intergerSupport = IntegerSupport.OnlyBigInt,
     isNanFunction = "is_nan",
     makeArray = MakeArray.Brackets,
@@ -402,6 +421,7 @@ object SqlDialect {
     tryCast = "SAFE_CAST",
     useSubqueryToAvoidStructInGroupBy = true,
     supportsExceptDistinctOnStructColumns = false,
+    flattenStructInOrderBy = true,
     values = Values.SelectUnionAll,
     rand = "RAND",
     writeSupport = WriteSupport.ExportData,
@@ -439,6 +459,7 @@ object SqlDialect {
     floatingAggregate = FloatingAggregate.NaNIsLargest,
     floatingCompare = FloatingCompare.NaNIsLargest,
     fromJson = FromJsonSupport.Parser("from_json", Map("mode" -> "PERMISSIVE") ++ sparkJsonOptions),
+    floatingOrder = FloatingOrder.NaNLast,
     intergerSupport = IntegerSupport.AllSizes,
     isNanFunction = "isnan",
     makeArray = MakeArray.Function("array"),

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/Query.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/Query.scala
@@ -10,6 +10,7 @@ private[sql] enum Query {
       groupBy: Seq[SqlExpr],
       having: Option[SqlExpr],
       distinct: Boolean,
+      orderBy: Seq[SqlExpr] = Seq.empty,
       limit: Option[Int] = None
   )
   case Union(left: Query, right: Query, all: Boolean)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
@@ -89,13 +89,14 @@ private[tyda] final case class SqlWriter(writer: Writer) {
 
   def write(query: Query): Unit =
     query match {
-      case Query.Select(select, from, where, groupBy, having, distinct, limit) =>
+      case Query.Select(select, from, where, groupBy, having, distinct, orderBy, limit) =>
         val selectType = if distinct then "SELECT DISTINCT" else "SELECT"
         writeSql"$selectType $select"
         from.foreach(from => writeSql1" FROM $from")
         where.foreach(cond => writeSql1" WHERE $cond")
         if groupBy.nonEmpty then writeSql1" GROUP BY $groupBy"
         having.foreach(cond => writeSql1" HAVING $cond")
+        if orderBy.nonEmpty then writeSql1" ORDER BY $orderBy"
         limit.foreach(n => write(s" LIMIT $n"))
 
       case Query.Union(left, right, all) =>

--- a/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
@@ -38,76 +38,80 @@ SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS
 SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS _6, t1._7 AS _7 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5, t1._6, t1._7
 ------ end
 
------- Test: orderBy Option[Double]
+------ Test: orderBy Boolean, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Byte, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Date, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Decimal[Int,Int], input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Double, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
 ------ end
 
------- Test: orderBy Option[Int]
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy Option[Option[Int]]
-SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.value
------- end
-
------- Test: orderBy boolean
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy byte
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy date
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy decimal
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy deeply nested struct
-SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a.x, t1.a.y, t1.b
------- end
-
------- Test: orderBy double
+------ Test: orderBy Float, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
 ------ end
 
------- Test: orderBy float
+------ Test: orderBy Inner, input: ArraySeq()
+SELECT t1.x AS x, t1.y AS y FROM t1 ORDER BY t1.x, t1.y
+------ end
+
+------ Test: orderBy Int, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Long, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[AllNullable], input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.a, t1.value.b
+------ end
+
+------ Test: orderBy Option[Double], input: ArraySeq(List(None, Some(NaN), Some(Infinity), Some(-Infinity), Some(-0.0), Some(0.0)))
 SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
 ------ end
 
------- Test: orderBy int
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy long
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy nested nullable struct
+------ Test: orderBy Option[Inner], input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.x, t1.value.y
 ------ end
 
------- Test: orderBy nested struct
-SELECT t1.x AS x, t1.y AS y FROM t1 ORDER BY t1.x, t1.y
+------ Test: orderBy Option[Int], input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[Option[Int]], input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.value
+------ end
+
+------ Test: orderBy Outer, input: ArraySeq()
+SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a.x, t1.a.y, t1.b
+------ end
+
+------ Test: orderBy Short, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy String, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Timestamp, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
 ------ Test: orderBy nested struct inner field
 SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a.x, t1.a.y
------- end
-
------- Test: orderBy nullable struct with only null fields
-SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.a, t1.value.b
------- end
-
------- Test: orderBy short
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy string
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
 ------ Test: orderBy then distinct
@@ -132,10 +136,6 @@ SELECT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.valu
 
 ------ Test: orderBy then select
 SELECT t0._2 AS value FROM (SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1) AS t0
------- end
-
------- Test: orderBy timestamp
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
 ------ Test: orderBy tuple with struct

--- a/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
@@ -1,0 +1,143 @@
+------ Test: distinct then orderBy
+SELECT t0.value AS value FROM (SELECT DISTINCT t1.value AS value FROM t1) AS t0 ORDER BY t0.value
+------ end
+
+------ Test: filter then orderBy
+SELECT t1.value AS value FROM t1 WHERE (NOT (t1.value <= CAST(0 AS INT))) ORDER BY t1.value
+------ end
+
+------ Test: groupBy aggregate then orderBy
+SELECT t1._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM t1 GROUP BY t1._1 ORDER BY t1._1
+------ end
+
+------ Test: join then orderBy
+SELECT t1.value AS value FROM t1 JOIN t2 ON (t1.value = t2.value) ORDER BY t1.value
+------ end
+
+------ Test: orderBy 2 keys
+SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1, t1._2
+------ end
+
+------ Test: orderBy 3 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3 FROM t1 ORDER BY t1._1, t1._2, t1._3
+------ end
+
+------ Test: orderBy 4 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4
+------ end
+
+------ Test: orderBy 5 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5
+------ end
+
+------ Test: orderBy 6 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS _6 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5, t1._6
+------ end
+
+------ Test: orderBy 7 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS _6, t1._7 AS _7 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5, t1._6, t1._7
+------ end
+
+------ Test: orderBy Option[Double]
+SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
+------ end
+
+------ Test: orderBy Option[Int]
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[Option[Int]]
+SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.value
+------ end
+
+------ Test: orderBy boolean
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy byte
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy date
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy decimal
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy deeply nested struct
+SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a.x, t1.a.y, t1.b
+------ end
+
+------ Test: orderBy double
+SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
+------ end
+
+------ Test: orderBy float
+SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
+------ end
+
+------ Test: orderBy int
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy long
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy nested nullable struct
+SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.x, t1.value.y
+------ end
+
+------ Test: orderBy nested struct
+SELECT t1.x AS x, t1.y AS y FROM t1 ORDER BY t1.x, t1.y
+------ end
+
+------ Test: orderBy nested struct inner field
+SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a.x, t1.a.y
+------ end
+
+------ Test: orderBy nullable struct with only null fields
+SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.a, t1.value.b
+------ end
+
+------ Test: orderBy short
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy string
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy then distinct
+SELECT DISTINCT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.value) AS t0
+------ end
+
+------ Test: orderBy then filter
+SELECT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.value) AS t0 WHERE (NOT (t0.value <= CAST(0 AS INT)))
+------ end
+
+------ Test: orderBy then groupBy aggregate
+SELECT t0._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM (SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1) AS t0 GROUP BY t0._1
+------ end
+
+------ Test: orderBy then join
+SELECT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.value) AS t0 JOIN t2 ON (t0.value = t2.value)
+------ end
+
+------ Test: orderBy then limit
+SELECT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.value) AS t0 LIMIT 3
+------ end
+
+------ Test: orderBy then select
+SELECT t0._2 AS value FROM (SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1) AS t0
+------ end
+
+------ Test: orderBy timestamp
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy tuple with struct
+SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1.x, t1._1.y
+------ end

--- a/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
@@ -38,76 +38,80 @@ SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS
 SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS _6, t1._7 AS _7 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5, t1._6, t1._7
 ------ end
 
------- Test: orderBy Option[Double]
+------ Test: orderBy Boolean, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[Int]
+------ Test: orderBy Byte, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[Option[Int]]
+------ Test: orderBy Date, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy boolean
+------ Test: orderBy Decimal[Int,Int], input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy byte
+------ Test: orderBy Double, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy date
+------ Test: orderBy Float, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy decimal
+------ Test: orderBy Inner, input: ArraySeq()
+SELECT t1.x AS x, t1.y AS y FROM t1 ORDER BY t1.x, t1.y
+------ end
+
+------ Test: orderBy Int, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy deeply nested struct
+------ Test: orderBy Long, input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[AllNullable], input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[Double], input: ArraySeq(List(None, Some(NaN), Some(Infinity), Some(-Infinity), Some(-0.0), Some(0.0)))
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[Inner], input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[Int], input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[Option[Int]], input: ArraySeq()
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Outer, input: ArraySeq()
 SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a, t1.b
 ------ end
 
------- Test: orderBy double
+------ Test: orderBy Short, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy float
+------ Test: orderBy String, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy int
+------ Test: orderBy Timestamp, input: ArraySeq()
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy long
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy nested nullable struct
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy nested struct
-SELECT t1.x AS x, t1.y AS y FROM t1 ORDER BY t1.x, t1.y
 ------ end
 
 ------ Test: orderBy nested struct inner field
 SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a
------- end
-
------- Test: orderBy nullable struct with only null fields
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy short
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
------- end
-
------- Test: orderBy string
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
 ------ Test: orderBy then distinct
@@ -132,10 +136,6 @@ SELECT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.valu
 
 ------ Test: orderBy then select
 SELECT t0._2 AS value FROM (SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1) AS t0
------- end
-
------- Test: orderBy timestamp
-SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
 ------ Test: orderBy tuple with struct

--- a/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
@@ -1,0 +1,143 @@
+------ Test: distinct then orderBy
+SELECT t0.value AS value FROM (SELECT DISTINCT t1.value AS value FROM t1) AS t0 ORDER BY t0.value
+------ end
+
+------ Test: filter then orderBy
+SELECT t1.value AS value FROM t1 WHERE (NOT (t1.value <= CAST(0 AS INT))) ORDER BY t1.value
+------ end
+
+------ Test: groupBy aggregate then orderBy
+SELECT t1._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM t1 GROUP BY t1._1 ORDER BY t1._1
+------ end
+
+------ Test: join then orderBy
+SELECT t1.value AS value FROM t1 JOIN t2 ON (t1.value = t2.value) ORDER BY t1.value
+------ end
+
+------ Test: orderBy 2 keys
+SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1, t1._2
+------ end
+
+------ Test: orderBy 3 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3 FROM t1 ORDER BY t1._1, t1._2, t1._3
+------ end
+
+------ Test: orderBy 4 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4
+------ end
+
+------ Test: orderBy 5 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5
+------ end
+
+------ Test: orderBy 6 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS _6 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5, t1._6
+------ end
+
+------ Test: orderBy 7 keys
+SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS _6, t1._7 AS _7 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5, t1._6, t1._7
+------ end
+
+------ Test: orderBy Option[Double]
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[Int]
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy Option[Option[Int]]
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy boolean
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy byte
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy date
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy decimal
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy deeply nested struct
+SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a, t1.b
+------ end
+
+------ Test: orderBy double
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy float
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy int
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy long
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy nested nullable struct
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy nested struct
+SELECT t1.x AS x, t1.y AS y FROM t1 ORDER BY t1.x, t1.y
+------ end
+
+------ Test: orderBy nested struct inner field
+SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a
+------ end
+
+------ Test: orderBy nullable struct with only null fields
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy short
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy string
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy then distinct
+SELECT DISTINCT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.value) AS t0
+------ end
+
+------ Test: orderBy then filter
+SELECT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.value) AS t0 WHERE (NOT (t0.value <= CAST(0 AS INT)))
+------ end
+
+------ Test: orderBy then groupBy aggregate
+SELECT t0._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM (SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1) AS t0 GROUP BY t0._1
+------ end
+
+------ Test: orderBy then join
+SELECT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.value) AS t0 JOIN t2 ON (t0.value = t2.value)
+------ end
+
+------ Test: orderBy then limit
+SELECT t0.value AS value FROM (SELECT t1.value AS value FROM t1 ORDER BY t1.value) AS t0 LIMIT 3
+------ end
+
+------ Test: orderBy then select
+SELECT t0._2 AS value FROM (SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1) AS t0
+------ end
+
+------ Test: orderBy timestamp
+SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy tuple with struct
+SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 ORDER BY t1._1
+------ end

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/AllGoldenSuites.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/AllGoldenSuites.scala
@@ -4,6 +4,7 @@ import com.choreograph.tyda.Format
 import com.choreograph.tyda.testsuites.DatasetAggregatesSuite
 import com.choreograph.tyda.testsuites.DatasetBasicSuite
 import com.choreograph.tyda.testsuites.DatasetJoinSuite
+import com.choreograph.tyda.testsuites.DatasetOrderBySuite
 import com.choreograph.tyda.testsuites.DatasetSubquerySuite
 
 trait SparkSqlGoldenSuite {
@@ -19,6 +20,8 @@ class DatasetBasicSparkSqlGoldenSuite
 class DatasetJoinSparkSqlGoldenSuite extends DatasetSuiteAsGoldenSuite, SparkSqlGoldenSuite, DatasetJoinSuite
 class DatasetSubquerySparkSqlGoldenSuite
     extends DatasetSuiteAsGoldenSuite, SparkSqlGoldenSuite, DatasetSubquerySuite
+class DatasetOrderBySparkSqlGoldenSuite
+    extends DatasetSuiteAsGoldenSuite, SparkSqlGoldenSuite, DatasetOrderBySuite
 class DatasetReadWriteParquetSparkSqlGoldenSuite
     extends DatasetReadWriteSuiteAsGoldenSuite, SparkSqlGoldenSuite {
   override def format = Format.Parquet
@@ -40,6 +43,8 @@ class DatasetBasicBigQueryGoldenSuite
 class DatasetJoinBigQueryGoldenSuite extends DatasetSuiteAsGoldenSuite, BigQueryGoldenSuite, DatasetJoinSuite
 class DatasetSubqueryBigQueryGoldenSuite
     extends DatasetSuiteAsGoldenSuite, BigQueryGoldenSuite, DatasetSubquerySuite
+class DatasetOrderByBigQueryGoldenSuite
+    extends DatasetSuiteAsGoldenSuite, BigQueryGoldenSuite, DatasetOrderBySuite
 class DatasetReadWriteParquetBigQueryGoldenSuite
     extends DatasetReadWriteSuiteAsGoldenSuite, BigQueryGoldenSuite {
   override def format = Format.Parquet

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/DatasetSuiteAsGoldenSuite.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/DatasetSuiteAsGoldenSuite.scala
@@ -48,4 +48,21 @@ trait DatasetSuiteAsGoldenSuite extends DatasetSuite, SqlGoldenTestSuite {
       computation: Dataset[T] => Dataset[R],
       expectedError: String
   ): Unit = { testSqlOrSkip(name) { computation(Dataset.readTable[T, EmptyTuple]("t1").select(_._1)) } }
+
+  override def testOrdered[T: Arbitrary: Codec, R: Equality](
+      name: String,
+      computation: Dataset[T] => Dataset[R],
+      inputs: Seq[T]*
+  ): Unit = testSqlOrSkip(name) { computation(Dataset.readTable[T, EmptyTuple]("t1").select(_._1)) }
+
+  override def testOrdered[T1: Arbitrary: Codec, T2: Arbitrary: Codec, R: Equality](
+      name: String,
+      computation: (Dataset[T1], Dataset[T2]) => Dataset[R]
+  ): Unit =
+    testSqlOrSkip(name) {
+      computation(
+        Dataset.readTable[T1, EmptyTuple]("t1").select(_._1),
+        Dataset.readTable[T2, EmptyTuple]("t2").select(_._1)
+      )
+    }
 }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
@@ -1,0 +1,96 @@
+package com.choreograph.tyda.testsuites
+
+import com.choreograph.tyda.Arbitrary
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Date
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Timestamp
+import com.choreograph.tyda.aggregates.count
+import com.choreograph.tyda.testsuites.FloatingPointEquality.given
+
+object DatasetOrderBySuite {
+  final case class Inner(x: Int, y: String) derives Arbitrary, Codec
+  final case class Outer(a: Inner, b: Int) derives Arbitrary, Codec
+  final case class AllNullable(a: Option[Int], b: Option[String]) derives Arbitrary, Codec
+}
+
+trait DatasetOrderBySuite extends DatasetSuite {
+  import DatasetOrderBySuite.*
+
+  testOrdered[Int, Int]("orderBy int", _.orderBy(identity))
+  testOrdered[Long, Long]("orderBy long", _.orderBy(identity))
+  testOrdered[Short, Short]("orderBy short", _.orderBy(identity))
+  testOrdered[Byte, Byte]("orderBy byte", _.orderBy(identity))
+  testOrdered[Boolean, Boolean]("orderBy boolean", _.orderBy(identity))
+  testOrdered[Float, Float]("orderBy float", _.orderBy(identity))
+  testOrdered[Double, Double]("orderBy double", _.orderBy(identity))
+  testOrdered[String, String]("orderBy string", _.orderBy(identity))
+  testOrdered[Date, Date]("orderBy date", _.orderBy(identity))
+  testOrdered[Timestamp, Timestamp]("orderBy timestamp", _.orderBy(identity))
+  testOrdered[Decimal[38, 9], Decimal[38, 9]]("orderBy decimal", _.orderBy(identity))
+
+  testOrdered[Option[Int], Option[Int]]("orderBy Option[Int]", _.orderBy(identity))
+  testOrdered[Option[Double], Option[Double]](
+    "orderBy Option[Double]",
+    _.orderBy(identity),
+    Seq(
+      None,
+      Some(Double.NaN),
+      Some(Double.PositiveInfinity),
+      Some(Double.NegativeInfinity),
+      Some(-0.0),
+      Some(0.0)
+    )
+  )
+  testOrdered[Option[Inner], Option[Inner]]("orderBy nested nullable struct", _.orderBy(identity))
+  testOrdered[Option[AllNullable], Option[AllNullable]](
+    "orderBy nullable struct with only null fields",
+    _.orderBy(identity)
+  )
+  testOrdered[Option[Option[Int]], Option[Option[Int]]]("orderBy Option[Option[Int]]", _.orderBy(identity))
+
+  testOrdered[Inner, Inner]("orderBy nested struct", _.orderBy(identity))
+  testOrdered[Outer, Outer]("orderBy deeply nested struct", _.orderBy(identity))
+  testOrdered[Outer, Outer]("orderBy nested struct inner field", _.orderBy(_.a))
+  testOrdered[(Inner, Int), (Inner, Int)]("orderBy tuple with struct", _.orderBy(_._1))
+
+  testOrdered[(Int, Int), (Int, Int)]("orderBy 2 keys", _.orderBy(_._1, _._2))
+  testOrdered[(Int, Int, Int), (Int, Int, Int)]("orderBy 3 keys", _.orderBy(_._1, _._2, _._3))
+  testOrdered[(Int, Int, Int, Int), (Int, Int, Int, Int)]("orderBy 4 keys", _.orderBy(_._1, _._2, _._3, _._4))
+  testOrdered[(Int, Int, Int, Int, Int), (Int, Int, Int, Int, Int)](
+    "orderBy 5 keys",
+    _.orderBy(_._1, _._2, _._3, _._4, _._5)
+  )
+  testOrdered[(Int, Int, Int, Int, Int, Int), (Int, Int, Int, Int, Int, Int)](
+    "orderBy 6 keys",
+    _.orderBy(_._1, _._2, _._3, _._4, _._5, _._6)
+  )
+  testOrdered[(Int, Int, Int, Int, Int, Int, Int), (Int, Int, Int, Int, Int, Int, Int)](
+    "orderBy 7 keys",
+    _.orderBy(_._1, _._2, _._3, _._4, _._5, _._6, _._7)
+  )
+
+  testOrdered[Int, Int]("filter then orderBy", _.where(_ > 0).orderBy(identity))
+  testOrdered[Int, Int]("orderBy then filter", _.orderBy(identity).where(_ > 0))
+  testOrdered[Int, Int]("orderBy then limit", _.orderBy(identity).limit(3))
+  testOrdered[(Int, Int), Int]("orderBy then select", _.orderBy(_._1).select(_._2))
+  testOrdered[(Int, Long), (Int, Long)](
+    "groupBy aggregate then orderBy",
+    ds => ds.groupByKey(_._1).aggregateValue(count).pairs.orderBy(_._1)
+  )
+  test[(Int, Long), (Int, Long)](
+    "orderBy then groupBy aggregate",
+    ds => ds.orderBy(_._1).groupByKey(_._1).aggregateValue(count).pairs
+  )
+  testOrdered[Int, Int, Int](
+    "join then orderBy",
+    (ds1, ds2) => ds1.join(ds2, _ == _).select(_._1).orderBy(identity)
+  )
+  testOrdered[Int, Int, Int](
+    "orderBy then join",
+    (ds1, ds2) => ds1.orderBy(identity).join(ds2, _ == _).select(_._1)
+  )
+
+  testOrdered[Int, Int]("distinct then orderBy", _.distinct.orderBy(identity))
+  test[Int, Int]("orderBy then distinct", _.orderBy(identity).distinct)
+}

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
@@ -1,15 +1,16 @@
 package com.choreograph.tyda.testsuites
 
+import org.scalactic.Equality
+
 import com.choreograph.tyda.Arbitrary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
-import com.choreograph.tyda.Timestamp
+import com.choreograph.tyda.Orderable
 import com.choreograph.tyda.SimpleTypeName
+import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.aggregates.count
 import com.choreograph.tyda.testsuites.FloatingPointEquality.given
-import org.scalactic.Equality
-import com.choreograph.tyda.Orderable
 
 object DatasetOrderBySuite {
   private final case class Inner(x: Int, y: String) derives Arbitrary, Codec

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
@@ -5,52 +5,50 @@ import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Timestamp
+import com.choreograph.tyda.SimpleTypeName
 import com.choreograph.tyda.aggregates.count
 import com.choreograph.tyda.testsuites.FloatingPointEquality.given
+import org.scalactic.Equality
+import com.choreograph.tyda.Orderable
 
 object DatasetOrderBySuite {
-  final case class Inner(x: Int, y: String) derives Arbitrary, Codec
-  final case class Outer(a: Inner, b: Int) derives Arbitrary, Codec
-  final case class AllNullable(a: Option[Int], b: Option[String]) derives Arbitrary, Codec
+  private final case class Inner(x: Int, y: String) derives Arbitrary, Codec
+  private final case class Outer(a: Inner, b: Int) derives Arbitrary, Codec
+  private final case class AllNullable(a: Option[Int], b: Option[String]) derives Arbitrary, Codec
 }
 
 trait DatasetOrderBySuite extends DatasetSuite {
   import DatasetOrderBySuite.*
 
-  testOrdered[Int, Int]("orderBy int", _.orderBy(identity))
-  testOrdered[Long, Long]("orderBy long", _.orderBy(identity))
-  testOrdered[Short, Short]("orderBy short", _.orderBy(identity))
-  testOrdered[Byte, Byte]("orderBy byte", _.orderBy(identity))
-  testOrdered[Boolean, Boolean]("orderBy boolean", _.orderBy(identity))
-  testOrdered[Float, Float]("orderBy float", _.orderBy(identity))
-  testOrdered[Double, Double]("orderBy double", _.orderBy(identity))
-  testOrdered[String, String]("orderBy string", _.orderBy(identity))
-  testOrdered[Date, Date]("orderBy date", _.orderBy(identity))
-  testOrdered[Timestamp, Timestamp]("orderBy timestamp", _.orderBy(identity))
-  testOrdered[Decimal[38, 9], Decimal[38, 9]]("orderBy decimal", _.orderBy(identity))
+  def testOrderBy[T: Arbitrary: Codec: Equality: SimpleTypeName: Orderable](inputs: Seq[T]*): Unit =
+    testOrdered[T, T](s"orderBy ${SimpleTypeName.name}, input: ${inputs}", _.orderBy(identity), inputs*)
 
-  testOrdered[Option[Int], Option[Int]]("orderBy Option[Int]", _.orderBy(identity))
-  testOrdered[Option[Double], Option[Double]](
-    "orderBy Option[Double]",
-    _.orderBy(identity),
-    Seq(
-      None,
-      Some(Double.NaN),
-      Some(Double.PositiveInfinity),
-      Some(Double.NegativeInfinity),
-      Some(-0.0),
-      Some(0.0)
-    )
-  )
-  testOrdered[Option[Inner], Option[Inner]]("orderBy nested nullable struct", _.orderBy(identity))
-  testOrdered[Option[AllNullable], Option[AllNullable]](
-    "orderBy nullable struct with only null fields",
-    _.orderBy(identity)
-  )
-  testOrdered[Option[Option[Int]], Option[Option[Int]]]("orderBy Option[Option[Int]]", _.orderBy(identity))
+  testOrderBy[Int]()
+  testOrderBy[Long]()
+  testOrderBy[Short]()
+  testOrderBy[Byte]()
+  testOrderBy[Boolean]()
+  testOrderBy[Float]()
+  testOrderBy[Double]()
+  testOrderBy[String]()
+  testOrderBy[Date]()
+  testOrderBy[Timestamp]()
+  testOrderBy[Decimal[38, 9]]()
+  testOrderBy[Option[Int]]()
+  testOrderBy[Option[Double]](Seq(
+    None,
+    Some(Double.NaN),
+    Some(Double.PositiveInfinity),
+    Some(Double.NegativeInfinity),
+    Some(-0.0),
+    Some(0.0)
+  ))
+  testOrderBy[Option[Inner]]()
+  testOrderBy[Option[AllNullable]]()
+  testOrderBy[Option[Option[Int]]]()
+  testOrderBy[Inner]()
+  testOrderBy[Outer]()
 
-  testOrdered[Inner, Inner]("orderBy nested struct", _.orderBy(identity))
-  testOrdered[Outer, Outer]("orderBy deeply nested struct", _.orderBy(identity))
   testOrdered[Outer, Outer]("orderBy nested struct inner field", _.orderBy(_.a))
   testOrdered[(Inner, Int), (Inner, Int)]("orderBy tuple with struct", _.orderBy(_._1))
 

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSuite.scala
@@ -83,7 +83,9 @@ trait DatasetSuite extends AnyFunSuite {
 
   def implementation: Runner
 
-  private def checkSameResult[T](ds: Dataset[T])(using aggregating: Aggregating[Seq[T]]): Result = {
+  private def checkResult[T](
+      ds: Dataset[T]
+  )(compare: (Seq[T], Seq[T]) => Boolean, mismatchMsg: (Seq[T], Seq[T]) => String): Result = {
     val expected = reference.collect(ds)
     val actual =
       try implementation.collect(ds)
@@ -99,16 +101,32 @@ trait DatasetSuite extends AnyFunSuite {
             e
           )
       }
-    val containsSameElements = aggregating.containsTheSameElementsAs(actual, expected)
-    if containsSameElements then Result.Success
-    else Result.Failure(s"""Implementations did not produced the same results\n
-      |Reference results: ${expected.mkString(", ")}
-      |Implementation results: ${actual.mkString(", ")}
-      |
-      |Reference explain:\n${reference.explain(ds)}\n
-      |Implementation explain:\n${implementation.explain(ds)}
-      """.stripMargin)
+    if compare(actual, expected) then Result.Success else Result.Failure(mismatchMsg(expected, actual))
   }
+
+  private def checkSameResult[T](ds: Dataset[T])(using aggregating: Aggregating[Seq[T]]): Result =
+    checkResult(ds)(
+      aggregating.containsTheSameElementsAs(_, _),
+      (expected, actual) => s"""Implementations did not produced the same results\n
+        |Reference results: ${expected.mkString(", ")}
+        |Implementation results: ${actual.mkString(", ")}
+        |
+        |Reference explain:\n${reference.explain(ds)}\n
+        |Implementation explain:\n${implementation.explain(ds)}
+        """.stripMargin
+    )
+
+  private def checkOrderedResult[T](ds: Dataset[T])(using equality: Equality[T]): Result =
+    checkResult(ds)(
+      (actual, expected) =>
+        actual.size == expected.size && actual.zip(expected).forall(equality.areEqual(_, _)),
+      (expected, actual) => s"""Ordered results did not match.
+        |Expected: ${expected.mkString(", ")}
+        |Actual:   ${actual.mkString(", ")}
+        |
+        |Reference explain:\n${reference.explain(ds)}\n
+        |Implementation explain:\n${implementation.explain(ds)}""".stripMargin
+    )
 
   private def propTest[Input: Arbitrary](name: String, testInput: Input => Result) =
     test(name) {
@@ -182,4 +200,26 @@ trait DatasetSuite extends AnyFunSuite {
           }
       }
     }
+
+  def testOrdered[T: Arbitrary: Codec, R: Equality](
+      name: String,
+      computation: Dataset[T] => Dataset[R],
+      inputs: Seq[T]*
+  ): Unit = {
+    def testInput(values: Seq[T]): Result = checkOrderedResult(computation(Dataset.FromSeq(values)))
+    propTest(name, testInput)
+    inputs.foreach(inputSeq =>
+      test(s"$name with input ${inputSeq.mkString(", ")}")(testInput(inputSeq).check)
+    )
+  }
+
+  def testOrdered[T1: Arbitrary: Codec, T2: Arbitrary: Codec, R: Equality](
+      name: String,
+      computation: (Dataset[T1], Dataset[T2]) => Dataset[R]
+  ): Unit =
+    propTest(
+      name,
+      (input: (Seq[T1], Seq[T2])) =>
+        checkOrderedResult(computation(Dataset.FromSeq(input._1), Dataset.FromSeq(input._2)))
+    )
 }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/FloatingPointEquality.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/FloatingPointEquality.scala
@@ -23,6 +23,26 @@ object FloatingPointEquality {
         }
     }
 
+  given optionFloat: Equality[Option[Float]] =
+    new Equality[Option[Float]] {
+      override def areEqual(a: Option[Float], b: Any): Boolean =
+        b match {
+          case None => a.isEmpty
+          case Some(b: Float) => a.exists(float.areEqual(_, b))
+          case _ => false
+        }
+    }
+
+  given optionDouble: Equality[Option[Double]] =
+    new Equality[Option[Double]] {
+      override def areEqual(a: Option[Double], b: Any): Boolean =
+        b match {
+          case None => a.isEmpty
+          case Some(b: Double) => a.exists(double.areEqual(_, b))
+          case _ => false
+        }
+    }
+
   given seqFloat: Equality[Seq[Float]] =
     new Equality[Seq[Float]] {
       override def areEqual(a: Seq[Float], b: Any): Boolean =

--- a/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
@@ -376,6 +376,114 @@ sealed trait Dataset[T: Codec] {
     Dataset.Limit(this, n)
   }
 
+  /** Returns a new Dataset sorted by the given expression in ascending order.
+    *
+    * Only types for which [[Orderable]] evidence exists can be used as sort
+    * keys.
+    */
+  def orderBy[I: AsExpr.Of[K], K: Orderable](key: Expr[T] => I): Dataset[T] =
+    Dataset.OrderBy(this, CompiledExpr(key))
+
+  /** Returns a new Dataset sorted by two expressions in ascending order.
+    *
+    * For detailed usage see [[orderBy]].
+    */
+  def orderBy[I1: AsExpr.Of[K1], K1: Orderable, I2: AsExpr.Of[K2], K2: Orderable](
+      k1: Expr[T] => I1,
+      k2: Expr[T] => I2
+  ): Dataset[T] = orderBy(v => (k1(v), k2(v)))
+
+  /** Returns a new Dataset sorted by three expressions in ascending order.
+    *
+    * For detailed usage see [[orderBy]].
+    */
+  def orderBy[I1: AsExpr.Of[K1], K1: Orderable, I2: AsExpr.Of[K2], K2: Orderable, I3: AsExpr.Of[
+    K3
+  ], K3: Orderable](k1: Expr[T] => I1, k2: Expr[T] => I2, k3: Expr[T] => I3): Dataset[T] =
+    orderBy(v => (k1(v), k2(v), k3(v)))
+
+  /** Returns a new Dataset sorted by four expressions in ascending order.
+    *
+    * For detailed usage see [[orderBy]].
+    */
+  def orderBy[I1: AsExpr.Of[K1], K1: Orderable, I2: AsExpr.Of[K2], K2: Orderable, I3: AsExpr.Of[
+    K3
+  ], K3: Orderable, I4: AsExpr.Of[K4], K4: Orderable](
+      k1: Expr[T] => I1,
+      k2: Expr[T] => I2,
+      k3: Expr[T] => I3,
+      k4: Expr[T] => I4
+  ): Dataset[T] = orderBy(v => (k1(v), k2(v), k3(v), k4(v)))
+
+  /** Returns a new Dataset sorted by five expressions in ascending order.
+    *
+    * For detailed usage see [[orderBy]].
+    */
+  def orderBy[I1: AsExpr.Of[K1], K1: Orderable, I2: AsExpr.Of[K2], K2: Orderable, I3: AsExpr.Of[
+    K3
+  ], K3: Orderable, I4: AsExpr.Of[K4], K4: Orderable, I5: AsExpr.Of[K5], K5: Orderable](
+      k1: Expr[T] => I1,
+      k2: Expr[T] => I2,
+      k3: Expr[T] => I3,
+      k4: Expr[T] => I4,
+      k5: Expr[T] => I5
+  ): Dataset[T] = orderBy(v => (k1(v), k2(v), k3(v), k4(v), k5(v)))
+
+  /** Returns a new Dataset sorted by six expressions in ascending order.
+    *
+    * For detailed usage see [[orderBy]].
+    */
+  def orderBy[
+      I1: AsExpr.Of[K1],
+      K1: Orderable,
+      I2: AsExpr.Of[K2],
+      K2: Orderable,
+      I3: AsExpr.Of[K3],
+      K3: Orderable,
+      I4: AsExpr.Of[K4],
+      K4: Orderable,
+      I5: AsExpr.Of[K5],
+      K5: Orderable,
+      I6: AsExpr.Of[K6],
+      K6: Orderable
+  ](
+      k1: Expr[T] => I1,
+      k2: Expr[T] => I2,
+      k3: Expr[T] => I3,
+      k4: Expr[T] => I4,
+      k5: Expr[T] => I5,
+      k6: Expr[T] => I6
+  ): Dataset[T] = orderBy(v => (k1(v), k2(v), k3(v), k4(v), k5(v), k6(v)))
+
+  /** Returns a new Dataset sorted by seven expressions in ascending order.
+    *
+    * For detailed usage see [[orderBy]].
+    */
+  def orderBy[
+      I1: AsExpr.Of[K1],
+      K1: Orderable,
+      I2: AsExpr.Of[K2],
+      K2: Orderable,
+      I3: AsExpr.Of[K3],
+      K3: Orderable,
+      I4: AsExpr.Of[K4],
+      K4: Orderable,
+      I5: AsExpr.Of[K5],
+      K5: Orderable,
+      I6: AsExpr.Of[K6],
+      K6: Orderable,
+      I7: AsExpr.Of[K7],
+      K7: Orderable
+  ](
+      k1: Expr[T] => I1,
+      k2: Expr[T] => I2,
+      k3: Expr[T] => I3,
+      k4: Expr[T] => I4,
+      k5: Expr[T] => I5,
+      k6: Expr[T] => I6,
+      k7: Expr[T] => I7
+  ): Dataset[T] = orderBy(v => (k1(v), k2(v), k3(v), k4(v), k5(v), k6(v), k7(v)))
+
   /** Perform a inner join with another [[Dataset]] using the given join
     * condition.
     */
@@ -957,6 +1065,8 @@ object Dataset {
       extends Dataset[T](using left.codec)
   private[tyda] final case class Cache[T](input: Dataset[T]) extends Dataset[T](using input.codec)
   private[tyda] final case class Limit[T](input: Dataset[T], n: Int) extends Dataset[T](using input.codec)
+  private[tyda] final case class OrderBy[T, K](input: Dataset[T], key: CompiledExpr[T, K])
+      extends Dataset[T](using input.codec)
 
   private def tuple2Codec[A: Codec, B: Codec]: Codec[(A, B)] = summon
   private def leftOuterCodec[A: Codec, B: Codec]: Codec[(A, Option[B])] = summon

--- a/tyda/src/main/scala/com/choreograph/tyda/Date.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Date.scala
@@ -91,4 +91,5 @@ object Date {
   given Arbitrary[Date] = Arbitrary.between(MinValue, MaxValue + 1)
   given Ordering[Date] = Ordering[Int]
   given Groupable[Date] = Groupable[Int]
+  given Orderable[Date] = Orderable[Int]
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/Orderable.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Orderable.scala
@@ -1,0 +1,56 @@
+package com.choreograph.tyda
+
+import scala.annotation.implicitNotFound
+import scala.compiletime.erasedValue
+import scala.compiletime.summonFrom
+import scala.compiletime.summonInline
+import scala.deriving.Mirror
+
+/** Type class that serves as evidence that a type can be used in ordering
+  * operations.
+  *
+  * All primitive types are orderable. Option, products, and sum types are
+  * orderable if their element types are orderable. Seq and Map types are not
+  * orderable, reflecting the fact that SQL engines (e.g. BigQuery) do not
+  * support ORDER BY on array or map columns.
+  */
+@implicitNotFound(
+  "Type ${T} is not orderable.\n" + "If ${T} is a type parameter add a context bound: [${T}: Orderable]\n" +
+    "If ${T} is an opaque type add a given Orderable[${T}] = Orderable.derived to the companion object\n" +
+    "Note: Seq and Map types cannot be used in orderBy."
+)
+trait Orderable[T] extends Serializable
+
+object Orderable {
+  def apply[T: Orderable as o]: Orderable[T] = o
+
+  private case object Singleton extends Orderable[Any]
+
+  private def unchecked[T]: Orderable[T] =
+    // TYPE SAFETY: Orderable has no functionality and is just used as evidence
+    Singleton.asInstanceOf[Orderable[T]]
+
+  inline given derived[T]: Orderable[T] = {
+    check[T]
+    unchecked[T]
+  }
+
+  private inline def check[T]: Unit =
+    inline erasedValue[T] match {
+      case _: (EmptyTuple | Boolean | Byte | Short | Int | Long | Float | Double | String) => ()
+      case _: Option[t] => check[t]
+      case _: (h *: t) =>
+        check[h]
+        check[t]
+      case _ => summonFrom {
+          case m: Mirror.ProductOf[T] => check[m.MirroredElemTypes]
+          case m: Mirror.SumOf[T] => check[m.MirroredElemTypes]
+          case _ => summonInline[Orderable[T]]: Unit
+        }
+    }
+
+  // In not possible to match opaque types with type parameters in inline match.
+  // So we provide the given explicitly instead
+  // Is is reported here https://github.com/scala/scala3/issues/20280
+  given [P <: Int, S <: Int]: Orderable[Decimal[P, S]] = unchecked
+}

--- a/tyda/src/main/scala/com/choreograph/tyda/Timestamp.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Timestamp.scala
@@ -74,4 +74,5 @@ object Timestamp {
   given Arbitrary[Timestamp] = Arbitrary.between(MinValue, MaxValue + 1)
   given Ordering[Timestamp] = Ordering.Long
   given Groupable[Timestamp] = Groupable[Long]
+  given Orderable[Timestamp] = Orderable[Long]
 }


### PR DESCRIPTION
This is a first version of a orderBy that allows to create a ordered
dataset. It does not support any nulls first/last or ascening/descending
modifiers, but I think it will be possible to add in a follow up.
