### PR TITLE
Validate output schema in BigQueryRunner

### DIFF
--- a/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
+++ b/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
@@ -177,7 +177,7 @@ object BigQueryRunner {
       (this, other) match {
         case (Compatible, Compatible) => Compatible
         case (Incompatible, _) | (_, Incompatible) => Incompatible
-        case _ => Lossy
+        case (Lossy, _) | (_, Lossy) => Lossy
       }
   }
 
@@ -214,7 +214,7 @@ object BigQueryRunner {
                 Compatibility.Incompatible
               case Codec.Option(ArrayCodec(_)) =>
                 logLossy(
-                  s"Dataset writes to '$path' have optional nested arrays, nulls will be written as empty arrays."
+                  s"Dataset writes to '$path' have optional arrays, Nones will be written as empty arrays."
                 )
                 compat.merge(Compatibility.Lossy)
               case _ => compat

--- a/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
+++ b/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
@@ -20,13 +20,15 @@ import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.Runner
 import com.choreograph.tyda.RunnerArgs
-import com.choreograph.tyda.RunnerArgs.ValidateSchema
+import com.choreograph.tyda.RunnerArgs.ValidateReadSchema
+import com.choreograph.tyda.RunnerArgs.ValidateWriteCompatibility
 import com.choreograph.tyda.bigquery.BigQueryRunner.buildClient
+import com.choreograph.tyda.rewrite.ArrayCodec
 import com.choreograph.tyda.sql.SqlDialect
 import com.choreograph.tyda.sql.toSql
 
 class BigQueryRunner(args: RunnerArgs.BigQuery) extends Runner {
-  import BigQueryRunner.{logger, formatPlan}
+  import BigQueryRunner.{logger, formatPlan, checkWriteCompatibility}
   val bigQuery = buildClient(args.projectId)
 
   def sql(ds: Dataset[?] | Dataset.Action): String =
@@ -36,7 +38,8 @@ class BigQueryRunner(args: RunnerArgs.BigQuery) extends Runner {
     }
 
   def execute(ds: Dataset.Action): Unit = {
-    validateReadTableSchemas(ds, args.validateSchemas)
+    validateReadTableSchemas(ds, args.validateReadSchemas)
+    checkWriteCompatibility(ds, args.validateWriteCompatibility)
     val query = sql(ds)
     logger.info(s"Executing query:\n$query")
     val queryConfig = QueryJobConfiguration.newBuilder(query).build()
@@ -48,7 +51,7 @@ class BigQueryRunner(args: RunnerArgs.BigQuery) extends Runner {
   }
 
   def collect[T](ds: Dataset[T]): Seq[T] = {
-    validateReadTableSchemas(ds, args.validateSchemas)
+    validateReadTableSchemas(ds, args.validateReadSchemas)
     val queryConfig = QueryJobConfiguration.newBuilder(sql(BigQueryCollectionRewrites.rewrite(ds))).build()
     val result = bigQuery.query(queryConfig, BigQueryRunner.retryJobOption)
     assert(!(result.getSchema == null), "Query did not return a schema unable to decode results.")
@@ -113,12 +116,12 @@ class BigQueryRunner(args: RunnerArgs.BigQuery) extends Runner {
 
   private def validateReadTableSchemas[T](
       ds: Dataset[T] | Dataset.Action,
-      validateSchemas: ValidateSchema
+      validateSchemas: ValidateReadSchema
   ): Unit = {
     val failOnSchemaIssue = validateSchemas match {
-      case ValidateSchema.Off => return
-      case ValidateSchema.Warn => false
-      case ValidateSchema.Strict => true
+      case ValidateReadSchema.Off => return
+      case ValidateReadSchema.Warn => false
+      case ValidateReadSchema.Strict => true
     }
     def log(message: String): Unit = if (failOnSchemaIssue) logger.error(message) else logger.warn(message)
     val check: Dataset[?] => Boolean = _ match {
@@ -165,6 +168,72 @@ object BigQueryRunner {
           .mkString("\n")
       )
       .getOrElse("No query plan available")
+  }
+
+  private enum Compatibility {
+    case Lossy, Incompatible, Compatible
+
+    def merge(other: Compatibility): Compatibility =
+      (this, other) match {
+        case (Compatible, Compatible) => Compatible
+        case (Incompatible, _) | (_, Incompatible) => Incompatible
+        case _ => Lossy
+      }
+  }
+
+  private[bigquery] def checkWriteCompatibility[T](
+      ds: Dataset.Action,
+      validateSchemas: ValidateWriteCompatibility
+  ): Unit = {
+    val (failOnLossy, failOnIncompatible) = validateSchemas match {
+      case ValidateWriteCompatibility.Off => return
+      case ValidateWriteCompatibility.Warn => (false, false)
+      case ValidateWriteCompatibility.Lossy => (false, true)
+      case ValidateWriteCompatibility.Strict => (true, true)
+    }
+    def logIncompatible(message: String): Unit =
+      if (failOnIncompatible) logger.error(message) else logger.warn(message)
+    def logLossy(message: String): Unit = if (failOnLossy) logger.error(message) else logger.warn(message)
+    val compatibility = ds match {
+      case Dataset.Action.Write(input = ds, path = path) => Codec
+          .iterate(ds.codec)
+          .foldLeft(Compatibility.Compatible) { (compat, codec) =>
+            codec match {
+              case ArrayCodec(ArrayCodec(_)) =>
+                logIncompatible(
+                  s"Dataset writes to '$path' have nested arrays which is not supported in BigQuery."
+                )
+                Compatibility.Incompatible
+              case ArrayCodec(Codec.Option(_)) =>
+                logIncompatible(
+                  s"Dataset writes to '$path' have arrays of optional values which is not supported in BigQuery."
+                )
+                Compatibility.Incompatible
+              case Codec.Map(_, _) =>
+                logIncompatible(s"Dataset writes to '$path' have maps which are not supported in BigQuery.")
+                Compatibility.Incompatible
+              case Codec.Option(ArrayCodec(_)) =>
+                logLossy(
+                  s"Dataset writes to '$path' have optional nested arrays, nulls will be written as empty arrays."
+                )
+                compat.merge(Compatibility.Lossy)
+              case _ => compat
+            }
+          }
+    }
+    compatibility match {
+      case Compatibility.Compatible => ()
+      case Compatibility.Lossy if failOnLossy =>
+        throw new RuntimeException(
+          "Dataset has lossy write compatibility issues: see logs for details. " +
+            "If the lossy behavior is acceptable you can set the validate-write-compatibility runner flag to 'lossy'."
+        )
+      case Compatibility.Incompatible if failOnIncompatible =>
+        throw new RuntimeException(
+          "Dataset has incompatible write compatibility issues: see logs for details."
+        )
+      case _ => ()
+    }
   }
 
   /** Factory method for reflection-based runner creation. */

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/BigQueryRunnerSpec.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/BigQueryRunnerSpec.scala
@@ -2,12 +2,71 @@ package com.choreograph.tyda.bigquery
 
 import org.scalatest.funsuite.AnyFunSuite
 
-import com.choreograph.tyda.Runner
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Dataset
+import com.choreograph.tyda.Format
 import com.choreograph.tyda.RunnerArgs
+import com.choreograph.tyda.RunnerArgs.ValidateWriteCompatibility
 
 class BigQueryRunnerSpec extends AnyFunSuite {
   test("createRunner returns BigQueryRunner") {
     val runner = RunnerArgs.createRunner(RunnerArgs.BigQuery("test-project-id"), "test-app")
     assert(runner.isInstanceOf[BigQueryRunner])
   }
+
+  private def check[T: Codec](mode: ValidateWriteCompatibility) =
+    BigQueryRunner.checkWriteCompatibility(Dataset.from[T](Seq.empty).writeToPath("p", Format.Parquet), mode)
+
+  private def expectIncompatible[T: Codec](
+      name: String,
+      mode: ValidateWriteCompatibility = ValidateWriteCompatibility.Strict
+  ) =
+    test(name) {
+      val ex = intercept[RuntimeException](check[T](mode))
+      assert(ex.getMessage.contains("incompatible"))
+    }
+
+  private def expectLossy[T: Codec](name: String) =
+    test(name) {
+      val ex = intercept[RuntimeException](check[T](ValidateWriteCompatibility.Strict))
+      assert(ex.getMessage.contains("lossy"))
+    }
+
+  private def expectCompatible[T: Codec](
+      name: String,
+      mode: ValidateWriteCompatibility = ValidateWriteCompatibility.Strict
+  ) = test(name) { check[T](mode) }
+
+  expectCompatible[Seq[Int]]("compatible: simple array")
+  expectCompatible[Option[Int]]("compatible: optional scalar")
+  expectCompatible[(a: Int, b: Seq[String])]("compatible: struct with array field")
+  expectCompatible[Option[Seq[Int]]](
+    "compatible: optional array in Lossy mode",
+    ValidateWriteCompatibility.Lossy
+  )
+  expectCompatible[Seq[Seq[Int]]]("compatible: nested arrays in Warn mode", ValidateWriteCompatibility.Warn)
+  expectCompatible[Seq[Seq[Int]]]("compatible: nested arrays in Off mode", ValidateWriteCompatibility.Off)
+
+  expectIncompatible[Seq[Seq[Int]]]("Strict: nested arrays are incompatible")
+  expectIncompatible[Seq[Option[Int]]]("Strict: array of optionals is incompatible")
+  expectIncompatible[Map[String, Int]]("Strict: map is incompatible")
+  expectIncompatible[(a: Int, b: Seq[Seq[Int]])]("Strict: nested arrays inside struct are incompatible")
+  expectIncompatible[(a: Int, b: Seq[Option[Int]])](
+    "Strict: array of optionals inside struct is incompatible"
+  )
+  expectIncompatible[Seq[(a: Int, b: Seq[Seq[Int]])]](
+    "Strict: nested arrays inside array of structs is incompatible"
+  )
+  expectIncompatible[Seq[(a: Int, b: Seq[Option[Int]])]](
+    "Strict: array of optionals inside array of structs is incompatible"
+  )
+  expectLossy[Option[Seq[Int]]]("Strict: optional array is lossy")
+  expectLossy[(a: Int, b: Option[Seq[Int]])]("Strict: optional array inside struct is lossy")
+  expectLossy[Seq[(a: Int, b: Option[Seq[Int]])]]("Strict: optional array inside array of structs is lossy")
+
+  expectIncompatible[Seq[Seq[Int]]]("Lossy: nested arrays are incompatible", ValidateWriteCompatibility.Lossy)
+  expectIncompatible[Seq[Option[Int]]](
+    "Lossy: array of optionals is incompatible",
+    ValidateWriteCompatibility.Lossy
+  )
 }

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteBigQuery.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteBigQuery.scala
@@ -51,7 +51,7 @@ class BigQueryTestRunner(args: RunnerArgs.BigQuery) extends BigQueryRunner(args)
 trait WithConfiguredBigQueryTestRunner {
   def runner: BigQueryTestRunner = {
     val projectId = BigQueryIntegrationTestEnvVariables.getProjectIdOrSkip
-    new BigQueryTestRunner(RunnerArgs.BigQuery(projectId, RunnerArgs.ValidateSchema.Off))
+    new BigQueryTestRunner(RunnerArgs.BigQuery(projectId, RunnerArgs.ValidateReadSchema.Off))
   }
 }
 

--- a/tyda/src/main/scala/com/choreograph/tyda/RunnerArgs.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/RunnerArgs.scala
@@ -3,7 +3,9 @@ package com.choreograph.tyda
 enum RunnerArgs {
   case BigQuery(
       projectId: String,
-      validateSchemas: RunnerArgs.ValidateSchema = RunnerArgs.ValidateSchema.Strict
+      validateReadSchemas: RunnerArgs.ValidateReadSchema = RunnerArgs.ValidateReadSchema.Strict,
+      validateWriteCompatibility: RunnerArgs.ValidateWriteCompatibility =
+        RunnerArgs.ValidateWriteCompatibility.Strict
   )
   case Iterator
   case Spark(master: Option[String] = None, logLevel: Option[RunnerArgs.SparkLogLevels] = None)
@@ -16,9 +18,42 @@ object RunnerArgs {
     def toSparkConf: String = toString.toUpperCase
   }
 
-  enum ValidateSchema {
+  /** Control how schemas are validated when reading a BigQuery table.
+    *
+    *   - `Strict`: The schema must match exactly. Any differences will result
+    *     in an error.
+    *   - `Warn`: Log a warning for any differences, but allow the read to
+    *     proceed.
+    *   - `Off`: No validation is performed. Any differences will be ignored.
+    */
+  enum ValidateReadSchema {
     case Strict, Warn, Off
   }
+
+  /** Control how schemas are validated with BigQuery compatibility.
+    *
+    * BigQuery has some limitations on the types of schemas it can support. The
+    * unsupported cases are
+    *
+    *   - Directly nested arrays e.g `Seq[Seq[Int]]` are not supported
+    *   - Array elements can not be null e.g `Seq[Option[Int]]` are not
+    *     supported
+    *   - Nullable arrays e.g `Option[Seq[Int]]` are lossily supported and on
+    *     writes nulls are changed into empty values.
+    *
+    * The supported values here are:
+    *
+    *   - `Strict`: The schema must be fully supported by BigQuery. Any
+    *     unsupported features will result in an error.
+    *   - `Lossy`: The lossy supported features are allowed but other
+    *     incompatibilities will result in an error.
+    *   - `Warn`: Log a warning for incompatibilities but allow execution.
+    *   - `Off`: No validation is performed.
+    */
+  enum ValidateWriteCompatibility {
+    case Strict, Lossy, Warn, Off
+  }
+
   private def runnerClassName(arg: RunnerArgs): String =
     arg match {
       case BigQuery(projectId = _) => "com.choreograph.tyda.bigquery.BigQueryRunner$"


### PR DESCRIPTION
Currently we will either write the wrong schema or produce a non
descriptive error.

I think producing the wrong schema without warning is
bad behavior. But since we currently do not know how to over come the
bigquery limitations, we just log some errors/warnings and fail
depending on what the flag is set to.
