### PR TITLE
Remove support for BigInt

### DIFF
--- a/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryDecoder.scala
+++ b/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryDecoder.scala
@@ -7,6 +7,7 @@ import com.google.cloud.bigquery.FieldList
 import com.google.cloud.bigquery.FieldValue
 import com.google.cloud.bigquery.FieldValueList
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
@@ -59,7 +60,7 @@ private def fieldDecoder[T](codec: Codec[T], field: Field): FieldValue => T = {
     case Codec.Float => _.getDoubleValue.toFloat
     case Codec.Double => _.getDoubleValue
     case Codec.String => _.getStringValue
-    case Codec.Bytes => _.getBytesValue
+    case Codec.Bytes => fv => Binary.fromArray(fv.getBytesValue)
     case decimal @ Codec.Decimal(precision, scale) => fv =>
         Decimal(using decimal.valid)(fv.getNumericValue).getOrElse(throw new RuntimeException(s"Value ${fv
             .getNumericValue} cannot be represented as Decimal($precision, $scale)"))

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/BigQuerySchemaValidatorSpec.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/BigQuerySchemaValidatorSpec.scala
@@ -6,6 +6,7 @@ import com.google.cloud.bigquery.StandardSQLTypeName
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.must.Matchers.*
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
@@ -42,7 +43,7 @@ class BigQuerySchemaValidatorSpec extends AnyFunSuite {
   checkNoErrors("required Float", Codec[Float], singleRequiredField(StandardSQLTypeName.FLOAT64))
   checkNoErrors("required Double", Codec[Double], singleRequiredField(StandardSQLTypeName.FLOAT64))
   checkNoErrors("required Date", Codec[Date], singleRequiredField(StandardSQLTypeName.DATE))
-  checkNoErrors("required BigInt", Codec[BigInt], singleRequiredField(StandardSQLTypeName.BYTES))
+  checkNoErrors("required Binary", Codec[Binary], singleRequiredField(StandardSQLTypeName.BYTES))
   checkNoErrors(
     "required Decimal[38, 9]",
     Codec[Decimal[38, 9]],

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteBigQuery.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteBigQuery.scala
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory
 
 import com.choreograph.tyda.Arbitrary
 import com.choreograph.tyda.Codec
-import com.choreograph.tyda.Codec.bigInt
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.Expr
 import com.choreograph.tyda.Format
@@ -91,9 +90,6 @@ abstract class DatasetReadWriteSuiteBigQuery extends DatasetReadWriteSuite, BigQ
         case ArrayCodec(Codec.Option(_)) => false
         // Nested arrays are not supported
         case ArrayCodec(ArrayCodec(_)) => false
-        // We should consider dropping this and just use Decimal(38, 0)
-        // But currently fails due to incorrect bytes handling in the bigquery dialect
-        case `bigInt` => false
         case _ => true
       }
   override def numericsReadModeForWriteTests: NumericsReadMode = NumericsReadMode.WidenBigQuery

--- a/tyda-json/src/main/scala/com/choreograph/tyda/json/CodecToJsoniter.scala
+++ b/tyda-json/src/main/scala/com/choreograph/tyda/json/CodecToJsoniter.scala
@@ -225,7 +225,7 @@ object CodecToJsoniter {
       case Codec.Double =>
         (out, value) => if value.isFinite then out.writeVal(value) else out.writeVal(value.toString)
       case Codec.String => (out, value) => out.writeVal(value)
-      case Codec.Bytes => (out, value) => out.writeBase64Val(value.toArray, doPadding = true)
+      case Codec.Bytes => (out, value) => out.writeBase64Val(value.to(Array), doPadding = true)
       case Codec.Decimal(_, _) => (out, value) => out.writeValAsString(value.toBigDecimal)
       case Codec.Date =>
         (out, value) => out.writeVal(java.time.LocalDate.ofEpochDay(value.daysSinceEpoch.toLong))

--- a/tyda-json/src/main/scala/com/choreograph/tyda/json/CodecToJsoniter.scala
+++ b/tyda-json/src/main/scala/com/choreograph/tyda/json/CodecToJsoniter.scala
@@ -9,6 +9,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
@@ -44,10 +45,7 @@ object CodecToJsoniter {
       case Codec.Float => 0.0f
       case Codec.Double => 0.0
       case Codec.String => ""
-      case Codec.Bytes =>
-        // This can not currently be empty because of it being used with BigInt
-        // TODO: Clean up after BigInt usage is replaced with Decimal(38, 0)
-        Array(0)
+      case Codec.Bytes => Binary.empty
       case codec @ Codec.Decimal(_, _) => Decimal.zero(using codec.valid)
       case Codec.Date => Date.fromDays(0)
       case Codec.TimestampMicros => Timestamp.fromMicros(0)
@@ -109,7 +107,7 @@ object CodecToJsoniter {
       case Codec.Double =>
         in => if in.nextValueIsString() then in.readString(null).toDouble else in.readDouble()
       case Codec.String => _.readString(null)
-      case Codec.Bytes => _.readBase64AsBytes(null)
+      case Codec.Bytes => in => Binary.fromArray(in.readBase64AsBytes(null))
       case codec @ Codec.Decimal(precision, scale) =>
         import codec.given
         in =>
@@ -227,7 +225,7 @@ object CodecToJsoniter {
       case Codec.Double =>
         (out, value) => if value.isFinite then out.writeVal(value) else out.writeVal(value.toString)
       case Codec.String => (out, value) => out.writeVal(value)
-      case Codec.Bytes => (out, value) => out.writeBase64Val(value, doPadding = true)
+      case Codec.Bytes => (out, value) => out.writeBase64Val(value.toArray, doPadding = true)
       case Codec.Decimal(_, _) => (out, value) => out.writeValAsString(value.toBigDecimal)
       case Codec.Date =>
         (out, value) => out.writeVal(java.time.LocalDate.ofEpochDay(value.daysSinceEpoch.toLong))

--- a/tyda-metadata/src/main/scala/com/choreograph/tyda/metadata/ExtractedMetadata.scala
+++ b/tyda-metadata/src/main/scala/com/choreograph/tyda/metadata/ExtractedMetadata.scala
@@ -36,7 +36,7 @@ object ExtractedMetadata:
   given ExtractedMetadata[String] = empty
   given [P <: Int, S <: Int]: ExtractedMetadata[TydaDecimal[P, S]] = empty
   given ExtractedMetadata[Array[Byte]] = empty
-  given ExtractedMetadata[BigInt] = empty
+
   given ExtractedMetadata[Date] = empty
   given ExtractedMetadata[Timestamp] = empty
   given ExtractedMetadata[Duration] = empty

--- a/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/GroupDecoder.scala
+++ b/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/GroupDecoder.scala
@@ -8,6 +8,7 @@ import org.apache.parquet.schema.PrimitiveType
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema.Type
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
@@ -80,7 +81,7 @@ private object GroupDecoder {
             .toMap
         }
       case prod: Codec.Product[T] => product(prod, parquetType).compose(_.getGroup(fieldName, 0))
-      case Codec.Bytes => group => group.getBinary(fieldName, 0).getBytes()
+      case Codec.Bytes => group => Binary.fromArray(group.getBinary(fieldName, 0).getBytes())
       case inj: Codec.FromInjection[T, ?] =>
         val inner = impl(fieldName, inj.to, parquetType)
         group => inj.inj.invert(inner(group))

--- a/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/Writer.scala
+++ b/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/Writer.scala
@@ -61,7 +61,8 @@ private object Writer {
       case Codec.Double => (consumer, value) => consumer.addDouble(value)
       case Codec.String => (consumer, value) =>
           consumer.addBinary(Binary.fromConstantByteArray(value.getBytes(StandardCharsets.UTF_8)))
-      case Codec.Bytes => (consumer, value) => consumer.addBinary(Binary.fromConstantByteArray(value.toArray))
+      case Codec.Bytes =>
+        (consumer, value) => consumer.addBinary(Binary.fromConstantByteArray(value.to(Array)))
       case Codec.DurationMicros => (consumer, value) => consumer.addLong(value.toMicros)
       case Codec.Date => (consumer, value) => consumer.addInteger(value.daysSinceEpoch)
       case decimal: Codec.Decimal[?, ?] =>

--- a/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/Writer.scala
+++ b/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/Writer.scala
@@ -61,7 +61,7 @@ private object Writer {
       case Codec.Double => (consumer, value) => consumer.addDouble(value)
       case Codec.String => (consumer, value) =>
           consumer.addBinary(Binary.fromConstantByteArray(value.getBytes(StandardCharsets.UTF_8)))
-      case Codec.Bytes => (consumer, value) => consumer.addBinary(Binary.fromConstantByteArray(value))
+      case Codec.Bytes => (consumer, value) => consumer.addBinary(Binary.fromConstantByteArray(value.toArray))
       case Codec.DurationMicros => (consumer, value) => consumer.addLong(value.toMicros)
       case Codec.Date => (consumer, value) => consumer.addInteger(value.daysSinceEpoch)
       case decimal: Codec.Decimal[?, ?] =>

--- a/tyda-parquet/src/test/scala/com/choreograph/tyda/parquet/ParquetRoundTripSuite.scala
+++ b/tyda-parquet/src/test/scala/com/choreograph/tyda/parquet/ParquetRoundTripSuite.scala
@@ -12,6 +12,7 @@ import org.scalactic.Equality
 import org.scalatest.funsuite.AnyFunSuite
 
 import com.choreograph.tyda.Arbitrary
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
@@ -92,7 +93,7 @@ class ParquetRoundTripSuite extends AnyFunSuite {
   testRoundTrip[Seq[Decimal[15, 5]]]
   testRoundTrip[Option[Decimal[38, 3]]]
   testRoundTrip[(Decimal[15, 5], Decimal[3, 0])]
-  testRoundTrip[BigInt]
+  testRoundTrip[Binary]
   testRoundTrip[Date]
   testRoundTrip[Timestamp]
   testRoundTrip[Duration]

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/NotNullNonEmptyDummyLiteral.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/NotNullNonEmptyDummyLiteral.scala
@@ -1,5 +1,6 @@
 package com.choreograph.tyda.rewrite
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
@@ -26,7 +27,7 @@ object NotNullNonEmptyDummyLiteral {
       case Codec.Double => ExprNode.Literal(0.0, Codec.Double)
       case Codec.String => ExprNode.Literal("", Codec.String)
       case Codec.Boolean => ExprNode.Literal(false, Codec.Boolean)
-      case Codec.Bytes => ExprNode.Literal(Array.emptyByteArray, Codec.Bytes)
+      case Codec.Bytes => ExprNode.Literal(Binary.empty, Codec.Bytes)
       case Codec.TimestampMicros => ExprNode.Literal(Timestamp.fromMicros(0), Codec.TimestampMicros)
       case Codec.DurationMicros => ExprNode.Literal(Duration.fromMicros(0), Codec.DurationMicros)
       case Codec.Date => ExprNode.Literal(Date.fromDays(0), Codec.Date)

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
@@ -1,8 +1,0 @@
-package com.choreograph.tyda.spark
-
-import com.choreograph.tyda.Binary
-
-private[spark] object BinaryHelper {
-  def fromArray(bytes: Array[Byte]): Binary = Binary.fromArray(bytes)
-  def toArray(b: Binary): Array[Byte] = b.to(Array)
-}

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
@@ -1,7 +1,7 @@
 package com.choreograph.tyda.spark
 
-import scala.collection.immutable.ArraySeq
+import com.choreograph.tyda.Binary
 
 private[spark] object BinaryHelper {
-  def fromArray(bytes: Array[Byte]): ArraySeq.ofByte = new ArraySeq.ofByte(bytes.clone())
+  def fromArray(bytes: Array[Byte]): Binary = Binary.fromArray(bytes)
 }

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
@@ -4,5 +4,5 @@ import com.choreograph.tyda.Binary
 
 private[spark] object BinaryHelper {
   def fromArray(bytes: Array[Byte]): Binary = Binary.fromArray(bytes)
-  def toArray(b: Binary): Array[Byte] = b.toArray
+  def toArray(b: Binary): Array[Byte] = b.to(Array)
 }

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
@@ -4,4 +4,5 @@ import com.choreograph.tyda.Binary
 
 private[spark] object BinaryHelper {
   def fromArray(bytes: Array[Byte]): Binary = Binary.fromArray(bytes)
+  def toArray(b: Binary): Array[Byte] = b.toArray
 }

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/BinaryHelper.scala
@@ -1,0 +1,7 @@
+package com.choreograph.tyda.spark
+
+import scala.collection.immutable.ArraySeq
+
+private[spark] object BinaryHelper {
+  def fromArray(bytes: Array[Byte]): ArraySeq.ofByte = new ArraySeq.ofByte(bytes.clone())
+}

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -78,8 +78,13 @@ private object CodecToExpressionEncoder {
       case Codec.Float => input
       case Codec.Double => input
       case Codec.Boolean => input
-      case Codec.Bytes =>
-        StaticInvoke(BinaryHelper.getClass, BinaryType, "toArray", input :: Nil, returnNullable = false)
+      case Codec.Bytes => StaticInvoke(
+          BinaryHelper.getClass,
+          catalystType(codec),
+          "toArray",
+          input :: Nil,
+          returnNullable = false
+        )
       case Codec.TimestampMicros => MicrosToTimestamp(input)
       case Codec.DurationMicros => input
       case Codec.Date => DateFromUnixDate(input)

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -39,9 +39,11 @@ import com.choreograph.tyda.spark.CodecToCatalystType.catalystStructType
 import com.choreograph.tyda.spark.CodecToCatalystType.catalystType
 import com.choreograph.tyda.spark.CodecToCatalystType.nullable
 
-// Since to is a generic extension method on Binary, it isn't directly
-// available to spark via java reflection.
+// Since Binary is an opaque type, we need to do something like
+// Literal.create + Invoke if we don't forward the method on an plain object.
+// This way we can use StaticInvoke as it "just works".
 private[spark] object BinaryHelper {
+  def fromArray(bytes: Array[Byte]): Binary = Binary.fromArray(bytes)
   def toArray(b: Binary): Array[Byte] = b.to(Array)
 }
 
@@ -243,7 +245,7 @@ private object CodecToExpressionEncoder {
       case Codec.Double => path
       case Codec.Boolean => path
       case Codec.Bytes =>
-        StaticInvoke(Binary.getClass, jvmType(codec), "fromArray", path :: Nil, returnNullable = false)
+        StaticInvoke(BinaryHelper.getClass, jvmType(codec), "fromArray", path :: Nil, returnNullable = false)
       case Codec.TimestampMicros => UnixMicros(path)
       case Codec.DurationMicros => path
       case Codec.Date => UnixDate(path)

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -39,6 +39,11 @@ import com.choreograph.tyda.spark.CodecToCatalystType.catalystStructType
 import com.choreograph.tyda.spark.CodecToCatalystType.catalystType
 import com.choreograph.tyda.spark.CodecToCatalystType.nullable
 
+private[spark] object BinaryHelper {
+  def fromArray(bytes: Array[Byte]): Binary = Binary.fromArray(bytes)
+  def toArray(b: Binary): Array[Byte] = b.to(Array)
+}
+
 /* This object currently contains code vendored from Spark 3.5.4 mainly from the files
  * https://github.com/apache/spark/blob/v3.5.4/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala
  * https://github.com/apache/spark/blob/v3.5.4/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SerializerBuildHelper.scala

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.objects.ValidateExternalType
 import org.apache.spark.sql.catalyst.expressions.objects.WrapOption
 import org.apache.spark.sql.types.*
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Field
 import com.choreograph.tyda.Forbidden
@@ -55,7 +56,7 @@ private object CodecToExpressionEncoder {
       case Codec.Float => FloatType
       case Codec.Double => DoubleType
       case Codec.Boolean => BooleanType
-      case Codec.Bytes => BinaryType
+      case Codec.Bytes => ObjectType(Binary.cls)
       case Codec.TimestampMicros => LongType
       case Codec.DurationMicros => LongType
       case Codec.Date => IntegerType
@@ -77,7 +78,7 @@ private object CodecToExpressionEncoder {
       case Codec.Float => input
       case Codec.Double => input
       case Codec.Boolean => input
-      case Codec.Bytes => input
+      case Codec.Bytes => Invoke(input, "unsafeArray", BinaryType)
       case Codec.TimestampMicros => MicrosToTimestamp(input)
       case Codec.DurationMicros => input
       case Codec.Date => DateFromUnixDate(input)
@@ -228,7 +229,13 @@ private object CodecToExpressionEncoder {
       case Codec.Float => path
       case Codec.Double => path
       case Codec.Boolean => path
-      case Codec.Bytes => path
+      case Codec.Bytes => StaticInvoke(
+          BinaryHelper.getClass,
+          ObjectType(Binary.cls),
+          "fromArray",
+          path :: Nil,
+          returnNullable = false
+        )
       case Codec.TimestampMicros => UnixMicros(path)
       case Codec.DurationMicros => path
       case Codec.Date => UnixDate(path)

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -229,13 +229,8 @@ private object CodecToExpressionEncoder {
       case Codec.Float => path
       case Codec.Double => path
       case Codec.Boolean => path
-      case Codec.Bytes => StaticInvoke(
-          BinaryHelper.getClass,
-          ObjectType(Binary.cls),
-          "fromArray",
-          path :: Nil,
-          returnNullable = false
-        )
+      case Codec.Bytes =>
+        StaticInvoke(BinaryHelper.getClass, jvmType(codec), "fromArray", path :: Nil, returnNullable = false)
       case Codec.TimestampMicros => UnixMicros(path)
       case Codec.DurationMicros => path
       case Codec.Date => UnixDate(path)

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -39,8 +39,9 @@ import com.choreograph.tyda.spark.CodecToCatalystType.catalystStructType
 import com.choreograph.tyda.spark.CodecToCatalystType.catalystType
 import com.choreograph.tyda.spark.CodecToCatalystType.nullable
 
+// Since to is a generic extension method on Binary, it isn't directly
+// available to spark via java reflection.
 private[spark] object BinaryHelper {
-  def fromArray(bytes: Array[Byte]): Binary = Binary.fromArray(bytes)
   def toArray(b: Binary): Array[Byte] = b.to(Array)
 }
 
@@ -242,7 +243,7 @@ private object CodecToExpressionEncoder {
       case Codec.Double => path
       case Codec.Boolean => path
       case Codec.Bytes =>
-        StaticInvoke(BinaryHelper.getClass, jvmType(codec), "fromArray", path :: Nil, returnNullable = false)
+        StaticInvoke(Binary.getClass, jvmType(codec), "fromArray", path :: Nil, returnNullable = false)
       case Codec.TimestampMicros => UnixMicros(path)
       case Codec.DurationMicros => path
       case Codec.Date => UnixDate(path)

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -78,7 +78,8 @@ private object CodecToExpressionEncoder {
       case Codec.Float => input
       case Codec.Double => input
       case Codec.Boolean => input
-      case Codec.Bytes => Invoke(input, "unsafeArray", BinaryType)
+      case Codec.Bytes =>
+        StaticInvoke(BinaryHelper.getClass, BinaryType, "toArray", input :: Nil, returnNullable = false)
       case Codec.TimestampMicros => MicrosToTimestamp(input)
       case Codec.DurationMicros => input
       case Codec.Date => DateFromUnixDate(input)

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -3,6 +3,7 @@ package com.choreograph.tyda.spark
 import scala.collection.Factory
 import scala.deriving.Mirror
 import scala.reflect.ClassTag
+import scala.reflect.classTag
 
 import org.apache.commons.lang3.reflect.ConstructorUtils
 import org.apache.spark.sql.Row
@@ -56,7 +57,7 @@ private object CodecToExpressionEncoder {
       case Codec.Float => FloatType
       case Codec.Double => DoubleType
       case Codec.Boolean => BooleanType
-      case Codec.Bytes => ObjectType(Binary.cls)
+      case Codec.Bytes => ObjectType(classTag[Binary].runtimeClass)
       case Codec.TimestampMicros => LongType
       case Codec.DurationMicros => LongType
       case Codec.Date => IntegerType

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
@@ -105,7 +105,7 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
     codec match {
       case Codec.Boolean | Codec.Byte | Codec.Short | Codec.Int | Codec.Long | Codec.Float | Codec.Double |
           Codec.String => lit(value)
-      case Codec.Bytes => lit(value.toArray)
+      case Codec.Bytes => lit(value.to(Array))
       case Codec.TimestampMicros =>
         convert(ExprNode.MicrosToTimestamp(ExprNode.Literal(value.toMicros, Codec.Long)))
       case Codec.Date => convert(ExprNode.DaysToDate(ExprNode.Literal(value.daysSinceEpoch, Codec.Int)))

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
@@ -104,7 +104,8 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
   private def literal[T](value: T, codec: Codec.Primitive[T])(using SparkSession): Column =
     codec match {
       case Codec.Boolean | Codec.Byte | Codec.Short | Codec.Int | Codec.Long | Codec.Float | Codec.Double |
-          Codec.String | Codec.Bytes => lit(value)
+          Codec.String => lit(value)
+      case Codec.Bytes => lit(value.toArray)
       case Codec.TimestampMicros =>
         convert(ExprNode.MicrosToTimestamp(ExprNode.Literal(value.toMicros, Codec.Long)))
       case Codec.Date => convert(ExprNode.DaysToDate(ExprNode.Literal(value.daysSinceEpoch, Codec.Int)))

--- a/tyda-spark/src/main/spark-4/com/choreograph/tyda/spark/CodecToEncoder.scala
+++ b/tyda-spark/src/main/spark-4/com/choreograph/tyda/spark/CodecToEncoder.scala
@@ -36,7 +36,7 @@ object CodecToEncoder {
   private[spark] def convertInternal[T: Codec]: ExpressionEncoder[T] = ExpressionEncoder(toAgnostic(Codec[T]))
 
   private object BinarySparkCodec extends SparkCodec[Binary, Array[Byte]] {
-    def encode(value: Binary): Array[Byte] = value.toArray
+    def encode(value: Binary): Array[Byte] = value.to(Array)
     def decode(value: Array[Byte]): Binary = Binary.fromArray(value)
   }
 

--- a/tyda-spark/src/main/spark-4/com/choreograph/tyda/spark/CodecToEncoder.scala
+++ b/tyda-spark/src/main/spark-4/com/choreograph/tyda/spark/CodecToEncoder.scala
@@ -19,6 +19,7 @@ import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils
 import org.apache.spark.sql.types.DecimalType
 import org.apache.spark.sql.types.Metadata
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Duration
@@ -33,6 +34,11 @@ object CodecToEncoder {
   given convert[T: Codec]: Encoder[T] = convertInternal[T]
 
   private[spark] def convertInternal[T: Codec]: ExpressionEncoder[T] = ExpressionEncoder(toAgnostic(Codec[T]))
+
+  private object BinarySparkCodec extends SparkCodec[Binary, Array[Byte]] {
+    def encode(value: Binary): Array[Byte] = value.toArray
+    def decode(value: Array[Byte]): Binary = Binary.fromArray(value)
+  }
 
   private object TimestampSparkCodec extends SparkCodec[Timestamp, Instant] {
     def encode(value: Timestamp): Instant = SparkDateTimeUtils.microsToInstant(value.toMicros)
@@ -76,7 +82,12 @@ object CodecToEncoder {
       case Codec.Double => AgnosticEncoders.PrimitiveDoubleEncoder
       case Codec.Boolean => AgnosticEncoders.PrimitiveBooleanEncoder
       case Codec.String => AgnosticEncoders.StringEncoder
-      case Codec.Bytes => AgnosticEncoders.BinaryEncoder
+      case Codec.Bytes => TransformingEncoder(
+          clsTag = codec.classTag,
+          transformed = AgnosticEncoders.BinaryEncoder,
+          codecProvider = () => BinarySparkCodec,
+          nullable = true
+        )
       case Codec.Decimal(precision, scale) =>
         // TYPE SAFETY: Cast is safe since tyda Decimal type is an opaque type for BigDecimal
         AgnosticEncoders.ScalaDecimalEncoder(DecimalType(precision, scale)).asInstanceOf[AgnosticEncoder[T]]

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
@@ -200,22 +200,10 @@ trait CodecToEncoderSpecBase extends AnyFunSuite with SharedSparkSession {
   test[NestedEnum](supportsNull = false)
   test[GenericEmptyVariants[Generic.A.type]](supportsNull = false)
   test[Binary](supportsNull = false)
-  {
-    given Equiv[Option[Binary]] = Equiv.universal
-    test[Option[Binary]](supportsNull = false)
-  }
-  {
-    given Equiv[Tuple1[Binary]] = Equiv.universal
-    test[Tuple1[Binary]](supportsNull = false)
-  }
-  {
-    given Equiv[Seq[Binary]] = Equiv.universal
-    test[Seq[Binary]]()
-  }
-  {
-    given Equiv[Map[Int, Binary]] = Equiv.universal
-    test[Map[Int, Binary]]()
-  }
+  test[Option[Binary]](supportsNull = false)
+  test[Tuple1[Binary]](supportsNull = false)
+  test[Seq[Binary]]()
+  test[Map[Int, Binary]]()
   test[EnumString](supportsNull = false)
   test[(name: String, age: Int)](supportsNull = false)
   test[BigNamedTuple](supportsNull = false)

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.types.TimestampType
 import org.scalatest.funsuite.AnyFunSuite
 
 import com.choreograph.tyda.Arbitrary
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
@@ -198,7 +199,23 @@ trait CodecToEncoderSpecBase extends AnyFunSuite with SharedSparkSession {
   test[MyString]()
   test[NestedEnum](supportsNull = false)
   test[GenericEmptyVariants[Generic.A.type]](supportsNull = false)
-  test[BigInt](supportsNull = false)
+  test[Binary](supportsNull = false)
+  {
+    given Equiv[Option[Binary]] = Equiv.universal
+    test[Option[Binary]](supportsNull = false)
+  }
+  {
+    given Equiv[Tuple1[Binary]] = Equiv.universal
+    test[Tuple1[Binary]](supportsNull = false)
+  }
+  {
+    given Equiv[Seq[Binary]] = Equiv.universal
+    test[Seq[Binary]]()
+  }
+  {
+    given Equiv[Map[Int, Binary]] = Equiv.universal
+    test[Map[Int, Binary]]()
+  }
   test[EnumString](supportsNull = false)
   test[(name: String, age: Int)](supportsNull = false)
   test[BigNamedTuple](supportsNull = false)
@@ -237,7 +254,7 @@ trait CodecToEncoderSpecBase extends AnyFunSuite with SharedSparkSession {
   schemaTest[Float](FloatType)
   schemaTest[Double](DoubleType)
   schemaTest[Boolean](BooleanType)
-  schemaTest[BigInt](BinaryType)
+  schemaTest[Binary](BinaryType)
   schemaTest[Timestamp](TimestampType)
   schemaTest[Duration](LongType)
   schemaTest[Date](DateType)

--- a/tyda-sparksql/src/test/scala/com/choreograph/tyda/sparksql/ToDdlSparkSpec.scala
+++ b/tyda-sparksql/src/test/scala/com/choreograph/tyda/sparksql/ToDdlSparkSpec.scala
@@ -6,6 +6,7 @@ import org.apache.spark.sql.types.MapType
 import org.apache.spark.sql.types.StructType
 import org.scalatest.funsuite.AnyFunSuite
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
@@ -124,7 +125,7 @@ class ToDdlSparkSpec extends AnyFunSuite {
 
   sameAsCodecToEncoderButMoreStrict[String]
   sameAsCodecToEncoderButMoreStrict[Decimal[10, 2]]
-  sameAsCodecToEncoderButMoreStrict[BigInt]
+  sameAsCodecToEncoderButMoreStrict[Binary]
   sameAsCodecToEncoderButMoreStrict[Enum]
   sameAsCodecToEncoderButMoreStrict[List[Option[Int]]]
   sameAsCodecToEncoderButMoreStrict[List[Option[List[Option[Int]]]]]

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -949,8 +949,8 @@ private def literalToSqlExpr[T](value: T, codec: Codec.Primitive[T], dialect: Sq
       SqlExpr.Cast(sqlValue, ToDdl.toNullableDdlType(codec, dialect.ddl))
     case Codec.String => SqlExpr.LiteralString(value.toString)
     case Codec.Bytes => dialect.binaryLiteral match {
-        case SqlDialect.BinaryLiteral.HexString => SqlExpr.LiteralHexString(value)
-        case SqlDialect.BinaryLiteral.ByteEscapeString => SqlExpr.LiteralByteEscapeString(value)
+        case SqlDialect.BinaryLiteral.HexString => SqlExpr.LiteralHexString(value.toArray)
+        case SqlDialect.BinaryLiteral.ByteEscapeString => SqlExpr.LiteralByteEscapeString(value.toArray)
       }
     case Codec.Boolean => SqlExpr.LiteralBool(value)
     case Codec.TimestampMicros => dialect.makeTimestamp match {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -949,8 +949,8 @@ private def literalToSqlExpr[T](value: T, codec: Codec.Primitive[T], dialect: Sq
       SqlExpr.Cast(sqlValue, ToDdl.toNullableDdlType(codec, dialect.ddl))
     case Codec.String => SqlExpr.LiteralString(value.toString)
     case Codec.Bytes => dialect.binaryLiteral match {
-        case SqlDialect.BinaryLiteral.HexString => SqlExpr.LiteralHexString(value.toArray)
-        case SqlDialect.BinaryLiteral.ByteEscapeString => SqlExpr.LiteralByteEscapeString(value.toArray)
+        case SqlDialect.BinaryLiteral.HexString => SqlExpr.LiteralHexString(value.to(Array))
+        case SqlDialect.BinaryLiteral.ByteEscapeString => SqlExpr.LiteralByteEscapeString(value.to(Array))
       }
     case Codec.Boolean => SqlExpr.LiteralBool(value)
     case Codec.TimestampMicros => dialect.makeTimestamp match {

--- a/tyda-sql/src/test/resources/golden/DatasetReadWriteJsonBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetReadWriteJsonBigQueryGoldenSuite.golden
@@ -1,3 +1,7 @@
+------ Test: write com.choreograph.tyda.Binary$package.Binary
+EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.json', format='JSON') AS SELECT t1.value AS value FROM t1
+------ end
+
 ------ Test: write com.choreograph.tyda.Date$package.Date
 EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.json', format='JSON') AS SELECT t1.value AS value FROM t1
 ------ end
@@ -123,9 +127,5 @@ EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.json', format='JSON') AS
 ------ end
 
 ------ Test: write scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Long]]
-EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.json', format='JSON') AS SELECT t1.value AS value FROM t1
------- end
-
------- Test: write scala.math.BigInt
 EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.json', format='JSON') AS SELECT t1.value AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetReadWriteJsonSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetReadWriteJsonSparkSqlGoldenSuite.golden
@@ -1,3 +1,7 @@
+------ Test: write com.choreograph.tyda.Binary$package.Binary
+CREATE TABLE temp_write_2134402965 USING JSON OPTIONS(mode='FAILFAST', timeZone='UTC', timestampFormat='yyyy-MM-dd\'T\'HH:mm[:ss][.SSSSSS][XXX]') LOCATION '/tmp/dataset-read-write/' AS SELECT t1.value AS value FROM t1
+------ end
+
 ------ Test: write com.choreograph.tyda.Date$package.Date
 CREATE TABLE temp_write_2134402965 USING JSON OPTIONS(mode='FAILFAST', timeZone='UTC', timestampFormat='yyyy-MM-dd\'T\'HH:mm[:ss][.SSSSSS][XXX]') LOCATION '/tmp/dataset-read-write/' AS SELECT t1.value AS value FROM t1
 ------ end
@@ -123,9 +127,5 @@ CREATE TABLE temp_write_2134402965 USING JSON OPTIONS(mode='FAILFAST', timeZone=
 ------ end
 
 ------ Test: write scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Long]]
-CREATE TABLE temp_write_2134402965 USING JSON OPTIONS(mode='FAILFAST', timeZone='UTC', timestampFormat='yyyy-MM-dd\'T\'HH:mm[:ss][.SSSSSS][XXX]') LOCATION '/tmp/dataset-read-write/' AS SELECT t1.value AS value FROM t1
------- end
-
------- Test: write scala.math.BigInt
 CREATE TABLE temp_write_2134402965 USING JSON OPTIONS(mode='FAILFAST', timeZone='UTC', timestampFormat='yyyy-MM-dd\'T\'HH:mm[:ss][.SSSSSS][XXX]') LOCATION '/tmp/dataset-read-write/' AS SELECT t1.value AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetReadWriteParquetBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetReadWriteParquetBigQueryGoldenSuite.golden
@@ -1,3 +1,7 @@
+------ Test: write com.choreograph.tyda.Binary$package.Binary
+EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.parquet', format='PARQUET') AS SELECT t1.value AS value FROM t1
+------ end
+
 ------ Test: write com.choreograph.tyda.Date$package.Date
 EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.parquet', format='PARQUET') AS SELECT t1.value AS value FROM t1
 ------ end
@@ -123,9 +127,5 @@ EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.parquet', format='PARQUE
 ------ end
 
 ------ Test: write scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Long]]
-EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.parquet', format='PARQUET') AS SELECT t1.value AS value FROM t1
------- end
-
------- Test: write scala.math.BigInt
 EXPORT DATA OPTIONS(uri='/tmp/dataset-read-write/part-*.parquet', format='PARQUET') AS SELECT t1.value AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetReadWriteParquetSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetReadWriteParquetSparkSqlGoldenSuite.golden
@@ -1,3 +1,7 @@
+------ Test: write com.choreograph.tyda.Binary$package.Binary
+CREATE TABLE temp_write_2134402965 USING PARQUET LOCATION '/tmp/dataset-read-write/' AS SELECT t1.value AS value FROM t1
+------ end
+
 ------ Test: write com.choreograph.tyda.Date$package.Date
 CREATE TABLE temp_write_2134402965 USING PARQUET LOCATION '/tmp/dataset-read-write/' AS SELECT t1.value AS value FROM t1
 ------ end
@@ -123,9 +127,5 @@ CREATE TABLE temp_write_2134402965 USING PARQUET LOCATION '/tmp/dataset-read-wri
 ------ end
 
 ------ Test: write scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Long]]
-CREATE TABLE temp_write_2134402965 USING PARQUET LOCATION '/tmp/dataset-read-write/' AS SELECT t1.value AS value FROM t1
------- end
-
------- Test: write scala.math.BigInt
 CREATE TABLE temp_write_2134402965 USING PARQUET LOCATION '/tmp/dataset-read-write/' AS SELECT t1.value AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/ToDdlSpec.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/ToDdlSpec.scala
@@ -5,6 +5,7 @@ import scala.reflect.ClassTag
 import org.scalatest.compatible.Assertion
 import org.scalatest.funsuite.AnyFunSuite
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
@@ -164,8 +165,8 @@ class ToDdlSpec extends AnyFunSuite {
                     |""".stripMargin)
   }
 
-  test("toDdl BigInt") {
-    val ddl = toSparkDdl(Codec[BigInt])
+  test("toDdl Binary") {
+    val ddl = toSparkDdl(Codec[Binary])
     assert(ddl == """
                     |value BINARY NOT NULL
                     |""".stripMargin)

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/UnparserSuite.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/UnparserSuite.scala
@@ -2,6 +2,7 @@ package com.choreograph.tyda.sql
 
 import scala.reflect.ClassTag
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.EnumStableHashCode
@@ -110,7 +111,9 @@ abstract class UnparserSuite extends SqlGoldenTestSuite {
 
   testSql("literal enum as string") { Dataset.FromSeq(Seq(E2.First)).select(_ == E2.Second) }
 
-  testSql("bytes literal") { Dataset.FromSeq(Seq(BigInt(3405691582L))) }
+  testSql("bytes literal") {
+    Dataset.FromSeq(Seq(Binary.fromArray(Array(0x00, 0xca, 0xfe, 0xba, 0xbe).map(_.toByte))))
+  }
 
   testSql("empty collection") { Dataset.FromSeq[M1](Seq()) }
 

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetReadWriteSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetReadWriteSuite.scala
@@ -12,6 +12,7 @@ import org.scalatest.enablers.Aggregating
 import shapeless3.deriving.Labelling
 
 import com.choreograph.tyda.Arbitrary
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.Date
@@ -265,7 +266,7 @@ trait DatasetReadWriteSuite extends DatasetSuite {
   testReadWrite[Decimal[3, 0]]
   testReadWrite[Decimal[15, 5]]
   testReadWrite[Decimal[38, 9]]
-  testReadWrite[BigInt]
+  testReadWrite[Binary]
   testReadWrite[Date]
   testReadWrite[Timestamp]
   testReadWrite[Duration]

--- a/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
@@ -1,10 +1,10 @@
 package com.choreograph.tyda
 
 import java.nio.charset.StandardCharsets
+import java.util.Arrays
 
 import scala.collection.immutable.ArraySeq
 import scala.reflect.ClassTag
-import java.util.Arrays
 
 /** An immutable sequence of bytes with value semantics.
   *

--- a/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
@@ -13,8 +13,6 @@ opaque type Binary = ArraySeq.ofByte
 
 object Binary {
 
-  def cls: Class[Binary] = classOf[ArraySeq.ofByte]
-
   /** An empty `Binary` value. */
   val empty: Binary = new ArraySeq.ofByte(Array.emptyByteArray)
 

--- a/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
@@ -3,6 +3,7 @@ package com.choreograph.tyda
 import java.nio.charset.StandardCharsets
 
 import scala.collection.immutable.ArraySeq
+import scala.reflect.ClassTag
 
 /** An immutable sequence of bytes with value semantics.
   *
@@ -11,6 +12,8 @@ import scala.collection.immutable.ArraySeq
 opaque type Binary = ArraySeq.ofByte
 
 object Binary {
+
+  def cls: Class[Binary] = classOf[ArraySeq.ofByte]
 
   /** An empty `Binary` value. */
   val empty: Binary = new ArraySeq.ofByte(Array.emptyByteArray)
@@ -28,14 +31,10 @@ object Binary {
 
     /** Returns the number of bytes. */
     def length: Int = b.length
-  }
 
-  private object BinaryToArray extends Injection[Binary, Array[Byte]] {
-    def apply(b: Binary): Array[Byte] = b.toArray
-    def invert(arr: Array[Byte]): Binary = new ArraySeq.ofByte(arr)
+    /** Returns a copy of the bytes. */
+    def toArray: Array[Byte] = b.toArray
   }
-
-  given codec: Codec[Binary] = Codec.fromInjection(BinaryToArray, Codec.Bytes)
 
   given arbitrary: Arbitrary[Binary] =
     for {
@@ -44,4 +43,5 @@ object Binary {
     } yield ArraySeq.ofByte(arr)
 
   given Groupable[Binary] = Groupable.derived
+  given Equiv[Binary] = Equiv.universal
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 
 import scala.collection.immutable.ArraySeq
 import scala.reflect.ClassTag
+import java.util.Arrays
 
 /** An immutable sequence of bytes with value semantics.
   *
@@ -42,6 +43,5 @@ object Binary {
 
   given Groupable[Binary] = Groupable.derived
 
-  import scala.math.Ordering.Implicits.seqOrdering
-  given Ordering[Binary] = Ordering.by(b => b.toArray.toSeq)
+  given Ordering[Binary] = (x, y) => Arrays.compareUnsigned(x.unsafeArray, y.unsafeArray)
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
@@ -43,5 +43,7 @@ object Binary {
     } yield ArraySeq.ofByte(arr)
 
   given Groupable[Binary] = Groupable.derived
-  given Equiv[Binary] = Equiv.universal
+
+  import scala.math.Ordering.Implicits.seqOrdering
+  given Ordering[Binary] = Ordering.by(b => b.toArray.toSeq)
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Binary.scala
@@ -3,8 +3,8 @@ package com.choreograph.tyda
 import java.nio.charset.StandardCharsets
 import java.util.Arrays
 
+import scala.collection.Factory
 import scala.collection.immutable.ArraySeq
-import scala.reflect.ClassTag
 
 /** An immutable sequence of bytes with value semantics.
   *
@@ -31,8 +31,8 @@ object Binary {
     /** Returns the number of bytes. */
     def length: Int = b.length
 
-    /** Returns a copy of the bytes. */
-    def toArray: Array[Byte] = b.toArray
+    /** Returns a copy of the bytes as C. */
+    def to[C](factory: Factory[Byte, C]): C = factory.fromSpecific(b)
   }
 
   given arbitrary: Arbitrary[Binary] =

--- a/tyda/src/main/scala/com/choreograph/tyda/Codec.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Codec.scala
@@ -259,7 +259,7 @@ object Codec {
     def inj: Injection[T, String] = SumAsStringInjection(values, encodedValues)
   }
 
-  /** A codec that encodes an [[Array[Byte]]] as a binary type.
+  /** A codec that encodes an [[Binary]] as a binary type.
     *
     * Note: This is distinct from encoding a [[scala.Seq[Byte]]], which is
     * represented as an array where each element is a byte.
@@ -294,7 +294,7 @@ object Codec {
     * The deserializer is not supported: need a(n) "ARRAY" field but got "BINARY".
     * ```
     */
-  private[tyda] case object Bytes extends Primitive[Array[Byte]]
+  private[tyda] case object Bytes extends Primitive[Binary]
 
   private[tyda] sealed trait FromInjection[From, To] extends Codec[From] {
     def inj: Injection[From, To]
@@ -315,11 +315,6 @@ object Codec {
       def to: Codec[To] = withTo
       def classTag: ClassTag[From] = summon
     }
-
-  private object BigIntAsBytes extends Injection[scala.BigInt, Array[Byte]] {
-    def apply(from: scala.BigInt): Array[Byte] = from.toByteArray
-    def invert(to: Array[Byte]): scala.BigInt = scala.BigInt(to)
-  }
 
   private def checkStableHashCode[S](tag: ClassTag[S]): Unit = {
     val isEnum = classOf[scala.reflect.Enum].isAssignableFrom(tag.runtimeClass)
@@ -349,13 +344,7 @@ object Codec {
   given decimal[P <: Int, S <: Int](using valid: TydaDecimal.Valid[P, S]): Codec[TydaDecimal[P, S]] =
     Decimal[P, S](valid.precision, valid.scale)
 
-  /** Encodes a [[BigInt]] as an array of bytes.
-    *
-    * Note: This is different from Spark that will store BigInt as a fixed size
-    * array of 16 bytes. This instead uses a variable length array and can
-    * therefore support all values of [[BigInt]].
-    */
-  given bigInt: Codec[BigInt] = fromInjection(BigIntAsBytes, Codec.Bytes)
+  given binary: Codec[Binary] = Codec.Bytes
 
   given seq[T: Codec, C <: scala.Seq[T]: ClassTag as tag](using Factory[T, C]): Codec[C] = {
     val seqTag = classTag[scala.Seq[T]]

--- a/tyda/src/test/scala/com/choreograph/tyda/BinarySpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/BinarySpec.scala
@@ -6,36 +6,36 @@ class BinarySpec extends AnyFunSuite {
   test("equal binaries compare as 0") {
     val binary1 = Binary.fromArray(Array[Byte](1, 2, 3))
     val binary2 = Binary.fromArray(Array[Byte](1, 2, 3))
-    assert(summon[Ordering[Binary]].compare(binary1, binary2) == 0)
+    assert(Ordering[Binary].compare(binary1, binary2) == 0)
   }
 
   test("shorter prefix is less than longer") {
     val shorter = Binary.fromArray(Array[Byte](1))
     val longer = Binary.fromArray(Array[Byte](1, 2))
-    assert(summon[Ordering[Binary]].compare(shorter, longer) < 0)
+    assert(Ordering[Binary].compare(shorter, longer) < 0)
   }
 
   test("unsigned byte ordering: 0xff > 0x01") {
     val binary1 = Binary.fromArray(Array[Byte](0xff.toByte))
     val binary2 = Binary.fromArray(Array[Byte](1))
-    assert(summon[Ordering[Binary]].compare(binary1, binary2) > 0)
+    assert(Ordering[Binary].compare(binary1, binary2) > 0)
   }
 
   test("unsigned byte ordering: 0x80 > 0x7f") {
     val binary1 = Binary.fromArray(Array[Byte](0x80.toByte))
     val binary2 = Binary.fromArray(Array[Byte](0x7f.toByte))
-    assert(summon[Ordering[Binary]].compare(binary1, binary2) > 0)
+    assert(Ordering[Binary].compare(binary1, binary2) > 0)
   }
 
   test("empty binary is least") {
     val empty = Binary.empty
     val nonEmpty = Binary.fromArray(Array[Byte](0))
-    assert(summon[Ordering[Binary]].compare(empty, nonEmpty) < 0)
+    assert(Ordering[Binary].compare(empty, nonEmpty) < 0)
   }
 
   test("lexicographic: first differing byte determines order") {
     val binary1 = Binary.fromArray(Array[Byte](1, 3))
     val binary2 = Binary.fromArray(Array[Byte](1, 2))
-    assert(summon[Ordering[Binary]].compare(binary1, binary2) > 0)
+    assert(Ordering[Binary].compare(binary1, binary2) > 0)
   }
 }

--- a/tyda/src/test/scala/com/choreograph/tyda/BinarySpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/BinarySpec.scala
@@ -1,0 +1,41 @@
+package com.choreograph.tyda
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class BinarySpec extends AnyFunSuite {
+  test("equal binaries compare as 0") {
+    val binary1 = Binary.fromArray(Array[Byte](1, 2, 3))
+    val binary2 = Binary.fromArray(Array[Byte](1, 2, 3))
+    assert(summon[Ordering[Binary]].compare(binary1, binary2) == 0)
+  }
+
+  test("shorter prefix is less than longer") {
+    val shorter = Binary.fromArray(Array[Byte](1))
+    val longer = Binary.fromArray(Array[Byte](1, 2))
+    assert(summon[Ordering[Binary]].compare(shorter, longer) < 0)
+  }
+
+  test("unsigned byte ordering: 0xff > 0x01") {
+    val binary1 = Binary.fromArray(Array[Byte](0xff.toByte))
+    val binary2 = Binary.fromArray(Array[Byte](1))
+    assert(summon[Ordering[Binary]].compare(binary1, binary2) > 0)
+  }
+
+  test("unsigned byte ordering: 0x80 > 0x7f") {
+    val binary1 = Binary.fromArray(Array[Byte](0x80.toByte))
+    val binary2 = Binary.fromArray(Array[Byte](0x7f.toByte))
+    assert(summon[Ordering[Binary]].compare(binary1, binary2) > 0)
+  }
+
+  test("empty binary is least") {
+    val empty = Binary.empty
+    val nonEmpty = Binary.fromArray(Array[Byte](0))
+    assert(summon[Ordering[Binary]].compare(empty, nonEmpty) < 0)
+  }
+
+  test("lexicographic: first differing byte determines order") {
+    val binary1 = Binary.fromArray(Array[Byte](1, 3))
+    val binary2 = Binary.fromArray(Array[Byte](1, 2))
+    assert(summon[Ordering[Binary]].compare(binary1, binary2) > 0)
+  }
+}


### PR DESCRIPTION
BigInt was added before decimal. Current usage can and should be replaced by Decimal instead.