### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "sbt"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  cooldown:
+    default-days: 7
+  ignore:
+  - dependency-name: "org.apache.spark:*"
+  - dependency-name: "org.scala-lang:*"


### PR DESCRIPTION
Alternative for https://github.com/unum-io/tyda/pull/56

Seems like dependabot recently added sbt support: https://github.blog/changelog/2026-05-26-dependabot-version-updates-now-support-the-sbt-ecosystem/
