### PR TITLE
Remove the last <: Product bounds

### DIFF
--- a/tyda-table/src/main/scala/com/choreograph/tyda/table/Latest.scala
+++ b/tyda-table/src/main/scala/com/choreograph/tyda/table/Latest.scala
@@ -24,7 +24,7 @@ import com.choreograph.tyda.table.ArgsParser.Result
 final case class Latest[S <: Source[?, ?], Date](source: S, overrideDate: Option[Date] = None)
 
 object Latest {
-  extension [M, Date: Codec: Comparable, PartitionValue <: Product: Codec: Selector.To[Date]](
+  extension [M, Date: Codec: Comparable, PartitionValue: Codec: Selector.To[Date]](
       latest: Latest[Source[M, Partitioner.Hive[PartitionValue]], Date]
   )(using
       decoder: Partitioner.Determinator[PartitionValue, Partitioner.Hive[PartitionValue]],
@@ -44,7 +44,7 @@ object Latest {
             .aggregate(max)
       }
   }
-  extension [M: Codec, Date: Codec: Comparable, PartitionValue <: Product: Codec: Selector.To[Date]](
+  extension [M: Codec, Date: Codec: Comparable, PartitionValue: Codec: Selector.To[Date]](
       latest: Latest[Source[M, Partitioner.Hive[PartitionValue]], Date]
   )(using
       decoder: Partitioner.Determinator[PartitionValue, Partitioner.Hive[PartitionValue]],
@@ -68,9 +68,9 @@ object Latest {
     def readLatest(runDate: Date): Dataset[M] = readLatestWithPartitions(runDate).select(_._2)
   }
 
-  extension [M: Codec, Date: Codec: Comparable, PartitionValue <: Product: Codec: Remover.Of[
+  extension [M: Codec, Date: Codec: Comparable, PartitionValue: Codec: Remover.Of[Date] as r: Selector.To[
     Date
-  ] as r: Selector.To[Date]](latest: Latest[Source[M, Partitioner.Hive[PartitionValue]], Date])(using
+  ]](latest: Latest[Source[M, Partitioner.Hive[PartitionValue]], Date])(using
       decoder: Partitioner.Determinator[PartitionValue, Partitioner.Hive[PartitionValue]],
       creator: Partitioner.Creator[PartitionValue, Partitioner.Hive[PartitionValue]]
   )(using Groupable[r.Out], Codec[r.Out]) {

--- a/tyda-table/src/main/scala/com/choreograph/tyda/table/Source.scala
+++ b/tyda-table/src/main/scala/com/choreograph/tyda/table/Source.scala
@@ -92,7 +92,7 @@ object Source {
   /* Currently this is restricted to Hive partitioners since for tables that the only thing that will work.
    * But if we make readTablePartitions return the value instead of a then we should be able to relax this
    * constraint. */
-  extension [M, V <: Product: Codec](
+  extension [M, V: Codec](
       source: Source[M, Partitioner.Hive[V]]
   )(using decoder: Partitioner.Determinator[V, Partitioner.Hive[V]]) {
     def asPartitionDataset(p: Partitioner.Hive[V]): Dataset[V] =


### PR DESCRIPTION
In general we try to avoid `Product` bounds and insted use things like
`Mirror.ProductOf` for evidence that something is a product. The main
reason to not have `<: Product` is that NamedTuples do not not have that
upper bound. So having it makes the code less flexible.
