### PR TITLE
Improve scalafmt settings for comments

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,6 +2,8 @@ version = 3.10.7
 runner.dialect = scala3
 
 comments.wrap = standalone
+comments.wrapStandaloneSlcAsSlc = true
+comments.wrapSingleLineMlcAsSlc = true
 docstrings.wrapMaxColumn = 80
 maxColumn = 110
 

--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,7 @@ lazy val sparkRunSettings = Seq(
     "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
   ),
   // Add provided dependencies to run to classpath based on
-  /* https://stackoverflow.com/questions/18838944/how-to-add-provided-dependencies-back-to-run-test-tasks-classpath/21803413#21803413 */
+  // https://stackoverflow.com/questions/18838944/how-to-add-provided-dependencies-back-to-run-test-tasks-classpath/21803413#21803413
   // https://github.com/sbt/sbt/issues/3733
   // Adding it to the Runtime configuration will not work as that will also include it in the assembly
   Compile / run :=

--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/NestedLoopJoin.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/NestedLoopJoin.scala
@@ -1,6 +1,6 @@
 package com.choreograph.tyda.iterator
 
-/* Implements a nested loop join with SQL join semantics */
+// Implements a nested loop join with SQL join semantics
 private object NestedLoopJoin {
 
   def join[T, U](left: Iterator[T], right: Iterator[U], p: (T, U) => Boolean): Iterator[(T, U)] = {

--- a/tyda-metadata/src/main/scala/com/choreograph/tyda/metadata/TypeDocs.scala
+++ b/tyda-metadata/src/main/scala/com/choreograph/tyda/metadata/TypeDocs.scala
@@ -16,7 +16,7 @@ object TypeDocs:
     import quotes.reflect.*
 
     val repr = TypeRepr.of[T]
-    /* For singleton enum cases (e.g. `case Foo`), typeSymbol points to the parent enum. */
+    // For singleton enum cases (e.g. `case Foo`), typeSymbol points to the parent enum.
     val sym = if repr.isSingleton then repr.termSymbol else repr.typeSymbol
 
     val docstring = sym.docstring

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/CodecToExpressionEncoder.scala
@@ -341,9 +341,9 @@ private object CodecToExpressionEncoder {
     Invoke(rowEncoder, "decode", jvmType(sum), Seq(row))
   }
 
-  /* Because we use the row encoder for sum type we need some special handling when it the top level object.
-   * Spark also has this for the RowEncoder: */
-  /* https://github.com/apache/spark/blob/7c29c664cdc9321205a98a14858aaf8daaa19db2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala#L218-L223 */
+  // Because we use the row encoder for sum type we need some special handling when it the top level object.
+  // Spark also has this for the RowEncoder:
+  // https://github.com/apache/spark/blob/7c29c664cdc9321205a98a14858aaf8daaa19db2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala#L218-L223
   private def createRowDeserializer(
       path: Expression,
       fields: Seq[Field[?]],
@@ -392,8 +392,8 @@ private object CodecToExpressionEncoder {
     )
   }
 
-  /* Conservative List of collections directly supported by Spark. This is needed because Spark does not
-   * correctly handle collections that takes an implicit parameter to their newBuilder method. */
+  // Conservative List of collections directly supported by Spark. This is needed because Spark does not
+  // correctly handle collections that takes an implicit parameter to their newBuilder method.
   private val sparkSupportedCollections = Seq(classOf[List[?]], classOf[Set[?]], classOf[Seq[?]])
 
   private def createDeserializerForIterable[T, C <: Iterable[T]](

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
@@ -123,7 +123,7 @@ object DatasetOnSpark {
    * collected. */
   //
   // This is the same approach as is used in Spark for cleaning up persisted RDDs
-  /* https://github.com/apache/spark/blob/4e5ed454fb292bc22cbdb6fc69b7de322e0afeff/core/src/main/scala/org/apache/spark/ContextCleaner.scala#L76 */
+  // https://github.com/apache/spark/blob/4e5ed454fb292bc22cbdb6fc69b7de322e0afeff/core/src/main/scala/org/apache/spark/ContextCleaner.scala#L76
   private val referenceQueue = new ReferenceQueue[Dataset[?]]()
   private val unpersistTasks = Collections.newSetFromMap[UnpersistTask](ConcurrentHashMap())
 

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/SumToRowEncoder.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/SumToRowEncoder.scala
@@ -43,7 +43,7 @@ private object SumToRowEncoder {
         val discriminant = out.getString(0)
         val ordinal = discriminantToOrdinal(discriminant)
         ordinalToSingleton(ordinal)
-          /* When reading old data where a singleton has been changed to a product spark can return null here. */
+          // When reading old data where a singleton has been changed to a product spark can return null here.
           .orElse(Option(out.getAs[Option[T]](ordinalToIndex(ordinal))).flatten)
           .orElse(ordinalToProductOfAllNone(ordinal))
           .getOrElse {

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/SharedSparkSession.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/SharedSparkSession.scala
@@ -26,10 +26,9 @@ private[spark] trait SharedSparkSession {
     .foreach { projectId => spark.conf.set("spark.datasource.bigquery.parentProject", projectId) }
 
   // Based on what is done in the spark codebase
-  /* https://github.com/apache/spark/blob/4e5ed454fb292bc22cbdb6fc69b7de322e0afeff/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SQLConfHelper.scala#L34-L37 */
-  //
-  /* It quite ugly as it modifies the global state of the shared SparkSession, so depends no the test runner
-   * not running individual test in a suite in parallel. */
+  // https://github.com/apache/spark/blob/4e5ed454fb292bc22cbdb6fc69b7de322e0afeff/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SQLConfHelper.scala#L34-L37
+  // It quite ugly as it modifies the global state of the shared SparkSession, so depends no the test runner
+  // not running individual test in a suite in parallel.
   def withConf[T](pairs: (String, String)*)(f: => T): T = {
     val oldConf = pairs.map { case (k, _) => k -> spark.conf.get(k) }.toMap
     pairs.foreach { case (k, v) => spark.conf.set(k, v) }

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -304,7 +304,7 @@ private final case class SelectBuilder[T, R](
     val newSelect = andThenRelaxed(select, explode)
     explode.codec match {
       case Codec.Product(_, _, _) | Codec.Sum(_, _) =>
-        /* When exploding to a structured type we end up with a single column and need to flatten it manually */
+        // When exploding to a structured type we end up with a single column and need to flatten it manually
         buildWithSelect(
           NonEmpty[Seq]((newSelect, "_1"))
         ).flatMap(makeSubquery[Tuple1[R2]](_, summon).select(CompiledExpr(_._1)))
@@ -412,7 +412,7 @@ private final case class SelectBuilder[T, R](
       )
     select match {
       case compiled: CompiledExpr[T, R] if !distinct && allOnlySelects(compiled) =>
-        /* The explodes can be added as joins in the existing from without a subquery. */
+        // The explodes can be added as joins in the existing from without a subquery.
         val explodeCodecs = instances.foldLeft0(Vector.empty[Codec[?]])([t] =>
           (acc, select) =>
             select match {

--- a/tyda-table/src/main/scala/com/choreograph/tyda/table/ArgsParser.scala
+++ b/tyda-table/src/main/scala/com/choreograph/tyda/table/ArgsParser.scala
@@ -245,7 +245,7 @@ object ArgsParser {
     def parse(t: String): Option[T]
     final def parseResult(t: String): Result[T] = parse(t).toRight(Error.UnparsableValue(t, hint))
     def serialize(t: T, templateTag: Option[String]): String
-    /* Return information about what as valid value */
+    // Return information about what as valid value
     def hint: String
 
     def withHint(newHint: String): Arg[T] =

--- a/tyda-table/src/test/scala/com/choreograph/tyda/table/WideBigQuerySpec.scala
+++ b/tyda-table/src/test/scala/com/choreograph/tyda/table/WideBigQuerySpec.scala
@@ -21,7 +21,7 @@ object WideBigQuerySpec {
   private given Arbitrary[Double] = Arbitrary[Double].filter(!_.isNaN)
 }
 
-/* This test suite is defined in tyda-iterator to leverage the iterator implmementation as part of testing */
+// This test suite is defined in tyda-iterator to leverage the iterator implmementation as part of testing
 class WideBigQuerySpec extends AnyFunSuite {
   import WideBigQuerySpec.given
   private def repr[T](codec: Codec[T]): Codec[?] =

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
@@ -53,7 +53,7 @@ object DatasetAggregatesSuite {
   given smallDouble: Arbitrary[Double] = Arbitrary.between(0, 1)
 }
 
-/* Testsuite focusing on aggregates that will compare a Dataset backend to a reference implementation. */
+// Testsuite focusing on aggregates that will compare a Dataset backend to a reference implementation.
 trait DatasetAggregatesSuite extends DatasetSuite {
   import DatasetAggregatesSuite.{EnumWithOrdering, Inner, Outer}
   import DatasetSuite.{Pair, TinyByte}

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
@@ -11,7 +11,7 @@ object DatasetBasicSuite {
   final case class SimpleProduct(a: Int, b: String)
 }
 
-/* Testsuite focusing on select and filter that will compare a Dataset backend to a reference implementation. */
+// Testsuite focusing on select and filter that will compare a Dataset backend to a reference implementation.
 trait DatasetBasicSuite extends DatasetSuite {
   import DatasetBasicSuite.{WideTuple, SimpleProduct}
   import DatasetSuite.{MyEnum, TinyByte}

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetJoinSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetJoinSuite.scala
@@ -14,7 +14,7 @@ object DatasetJoinSuite {
   type NullableM2 = NamedTuple.Map[NamedTuple.From[M2], Option]
 }
 
-/* Testsuite focusing on joins that will compare a Dataset backend to a reference implementation. */
+// Testsuite focusing on joins that will compare a Dataset backend to a reference implementation.
 trait DatasetJoinSuite extends DatasetSuite {
   import DatasetJoinSuite.*
   import DatasetSuite.Pair

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSuite.scala
@@ -73,7 +73,7 @@ object DatasetSuite {
   }
 }
 
-/* Testsuite that will compare a Dataset backend to a reference implementation. */
+// Testsuite that will compare a Dataset backend to a reference implementation.
 trait DatasetSuite extends AnyFunSuite {
   import DatasetSuite.Result
 

--- a/tyda/src/main/scala/com/choreograph/tyda/Arbitrary.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Arbitrary.scala
@@ -53,10 +53,10 @@ object Arbitrary {
   def hackDouble: Arbitrary[Double] =
     double.filter(f => java.lang.Double.doubleToRawLongBits(f) != negativeZeroDoubleBits)
 
-  /* Create an new `Arbitrary[T]` that will generate values between `min` (inclusive) and `max` (exclusive). */
+  // Create an new `Arbitrary[T]` that will generate values between `min` (inclusive) and `max` (exclusive).
   def between[T: Between](min: T, max: T): Arbitrary[T] = Between[T](min, max)
 
-  /* Create an Arbitrary instance for `T` that will generate one of the provided values. */
+  // Create an Arbitrary instance for `T` that will generate one of the provided values.
   def oneOf[T](v0: T, vn: T*): Arbitrary[T] = {
     val values = (v0 +: vn).toIndexedSeq
     between(0, values.size).map(i => values(i))
@@ -66,11 +66,11 @@ object Arbitrary {
   def bytes(n: Int): Arbitrary[Array[Byte]] =
     FixedSizeIterableArbitrary[Byte, Array[Byte]](Arbitrary[Byte], n, summon)
 
-  /* Create an `Arbitrary[Seq[T]]` that generates sequences of length `n`. */
+  // Create an `Arbitrary[Seq[T]]` that generates sequences of length `n`.
   def seqN[T: Arbitrary](n: Int): Arbitrary[Seq[T]] =
     FixedSizeIterableArbitrary[T, Seq[T]](Arbitrary[T], n, summon)
 
-  /* Create an arbitrary instance that generates tuples of length `N` with elements of type `T`. */
+  // Create an arbitrary instance that generates tuples of length `N` with elements of type `T`.
   def tupleN[T: ClassTag: Arbitrary as arb, N <: Int: ValueOf](using
       N >= 0 =:= true
   ): Arbitrary[TupleOperations.TupleN[T, N]] =
@@ -94,7 +94,7 @@ object Arbitrary {
       Tuple.fromArray(set.toArray).asInstanceOf[TupleOperations.TupleN[T, N]]
     }
 
-  /* Create an new `Arbitrary[T]` that will use given the `Arbitrary[T]` with equal probability. */
+  // Create an new `Arbitrary[T]` that will use given the `Arbitrary[T]` with equal probability.
   def combine[T](arb0: Arbitrary[T], arb1: Arbitrary[T], arbs: Arbitrary[T]*): Arbitrary[T] = {
     val arbitraries = (arb0 +: arb1 +: arbs).toIndexedSeq
     between(0, arbitraries.size).flatMap(i => arbitraries(i))
@@ -150,7 +150,7 @@ object Arbitrary {
         FloatingArbitrary(_.between(min, max), origin)
   }
 
-  /* Arbitrary instances for primitive types that is biased towards edge cases. */
+  // Arbitrary instances for primitive types that is biased towards edge cases.
   private def integral[T: NumericLimits: Integral](genUniform: Random => T): Arbitrary[T] = {
     val edgeCases = Vector(Numeric[T].zero, NumericLimits[T].min, NumericLimits[T].max)
     val gen =
@@ -158,7 +158,7 @@ object Arbitrary {
     IntegralArbitrary(gen, negateInShrink = true)
   }
 
-  /* Arbitrary instances for floating point types that is biased towards edge cases. */
+  // Arbitrary instances for floating point types that is biased towards edge cases.
   private def floating[T: FloatingLimits: Fractional](genUniform: Random => T): Arbitrary[T] = {
     val numeric = Numeric[T]
     import numeric.mkNumericOps

--- a/tyda/src/main/scala/com/choreograph/tyda/NumericLimits.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/NumericLimits.scala
@@ -1,12 +1,12 @@
 package com.choreograph.tyda
 
-/* NumericLimits is a type class that provides the minimum and maximum values of a numeric type. */
+// NumericLimits is a type class that provides the minimum and maximum values of a numeric type.
 private[tyda] trait NumericLimits[T] {
   def min: T
   def max: T
 }
 
-/* Specialized type class with values that only exists for floating point types. */
+// Specialized type class with values that only exists for floating point types.
 private[tyda] trait FloatingLimits[T] extends NumericLimits[T] {
   def nan: T
   def infinity: T

--- a/tyda/src/main/scala/com/choreograph/tyda/shapeless3extras/package.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/shapeless3extras/package.scala
@@ -30,7 +30,7 @@ extension [T, F[_]](inst: K0.ProductInstances[F, T]) {
 
 extension [T <: Tuple, F[_]](inst: K0.ProductInstances[F, T]) {
   def toTuple: Tuple.Map[T, F] =
-    /* TYPE SAFETY: For tuples the type classes in K0.ProductInstances[F, T] is exactly Tuple.Map[T, F] */
+    // TYPE SAFETY: For tuples the type classes in K0.ProductInstances[F, T] is exactly Tuple.Map[T, F]
     Tuple.fromIArray(IArray.from(inst.mapConst[Any]([t] => v => v: Any))).asInstanceOf[Tuple.Map[T, F]]
 }
 


### PR DESCRIPTION
The settings would rewrite long `//` comments into /* */ even if it was
part of a large block of `//` comments. This changes the settings so
that `//` is maintained when rewriting comments and `/* */` comments on
single lines are changed into `//`.

I hope this will make the current scalafmt annoyances related to
comments will go away.
