### PR TITLE
Improve identifier quoting in sql backend

### DIFF
--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/DdlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/DdlWriter.scala
@@ -65,9 +65,16 @@ private[sql] final case class DdlWriter(writer: Writer, pretty: Boolean) {
 }
 
 private[sql] object DdlWriter {
+  extension (c: Char) {
+    def isAsciiLetterOrDigit: Boolean =
+      (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9')
+  }
   def shouldQuoteIdentifier(ident: Identifier): Boolean = {
     val name = ident.value
-    name.exists(c => !c.isLetterOrDigit && c != '_') || name.headOption.exists(_.isDigit) || isKeyword(name)
+    name.exists(c => !c.isAsciiLetterOrDigit && c != '_') || name.headOption.exists(_.isDigit) ||
+    isKeyword(name)
   }
 
   def writeIdentifier(writer: Writer, ident: Identifier): Unit =

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -1062,6 +1062,10 @@ SELECT CASE WHEN (t1.value IS NOT NULL) THEN (t1.value.value IS NULL) END AS val
 SELECT coalesce(CASE WHEN (t1.value IS NOT NULL) THEN [struct(t1.value AS value)] END, CAST([] AS ARRAY<STRUCT<value ARRAY<INT>>>)) AS value FROM t1
 ------ end
 
+------ Test: non ascii fields
+SELECT (CAST(t1.`瑞` AS INT) + CAST(t1.`典` AS INT)) AS value FROM t1
+------ end
+
 ------ Test: not equals on primitive
 SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -1062,6 +1062,10 @@ SELECT CASE WHEN (t1.value IS NOT NULL) THEN (t1.value.value IS NULL) END AS val
 SELECT coalesce(CASE WHEN (t1.value IS NOT NULL) THEN array(t1.value) END, CAST(array() AS ARRAY<ARRAY<INT>>)) AS value FROM t1
 ------ end
 
+------ Test: non ascii fields
+SELECT (CAST(t1.`瑞` AS INT) + CAST(t1.`典` AS INT)) AS value FROM t1
+------ end
+
 ------ Test: not equals on primitive
 SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
 ------ end

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -1218,6 +1218,12 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
     t => (t.map(_.a), t.map(_.b), t.map(_.c))
   )
 
+  testHasSameBehavior[(`瑞`: Short, `典`: Short), Int](
+    "non ascii fields",
+    r => r.`瑞`.cast[Int] + r.`典`.cast[Int],
+    (a, b) => a.toInt + b.toInt
+  )
+
   def testJsonRoundtrip[T: ClassTag: Codec: Arbitrary: TypeName: JsonArrayOrObject]: Unit =
     testHasSameBehavior[T, Option[T]](
       s"toJson/fromJson roundtrip for ${TypeName.name[T]}",


### PR DESCRIPTION
This improves the quoting logic to quote non ascii identifiers.

Fixes #81
