### PR TITLE
Clean up casts in ExprUnparser

### DIFF
--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -235,7 +235,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
                   case SqlDialect.MapSupport.Array => sqlExpr
                 }
               )
-              .map(SqlExpr.Cast(_, ToDdl.toDdlType(expr.codec, dialect.ddl, false, true).tpe))
+              .map(cast(_, expr.codec, dialect))
           case ArrayCodec(_) => inner(operand)
           case codec => unreachable(s"UpcastToIterable only get codecs of Map and Iterable not $codec")
         }
@@ -447,10 +447,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
       case ExprNode.Quotient(CompatibleIntegral(), lhs, rhs) => for {
           lhs <- inner(lhs)
           rhs <- inner(rhs)
-        } yield SqlExpr.Cast(
-          SqlExpr.Function("div", Seq(lhs, rhs)),
-          ToDdl.toDdlType(expr.codec, dialect.ddl, true, true).tpe
-        )
+        } yield cast(SqlExpr.Function("div", Seq(lhs, rhs)), expr.codec, dialect)
       case ExprNode.Quotient(integral, _, _) =>
         Left(DatasetToSqlError.RequiresUdfCapability(s"Quotient uses custom integral instance $integral"))
       case ExprNode.Cast(value, _) => inner(value).map(cast(_, expr.codec, dialect))
@@ -466,19 +463,17 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
           case SqlDialect.MakeDuration.DiffBigInt => inner(value)
           case SqlDialect.MakeDuration.Cast => for {
               sqlExpr <- inner(value)
-              asDecimal =
-                SqlExpr.Cast(sqlExpr, ToDdl.toDdlType(Codec[Decimal[38, 6]], dialect.ddl, false, true).tpe)
+              asDecimal = cast(sqlExpr, Codec[Decimal[38, 6]], dialect)
               micros = SqlExpr.BinaryOp("*", asDecimal, literalToSqlExpr(1000000, Codec.Int, dialect))
-            } yield SqlExpr.Cast(micros, ToDdl.toDdlType(Codec.Long, dialect.ddl, false, true).tpe)
+            } yield cast(micros, Codec.Long, dialect)
         }
       case ExprNode.MicrosToDuration(value) => dialect.makeDuration match {
           case SqlDialect.MakeDuration.DiffBigInt => inner(value)
           case SqlDialect.MakeDuration.Cast => for {
               sqlExpr <- inner(value)
-              asDecimal =
-                SqlExpr.Cast(sqlExpr, ToDdl.toDdlType(Codec[Decimal[38, 6]], dialect.ddl, false, true).tpe)
+              asDecimal = cast(sqlExpr, Codec[Decimal[38, 6]], dialect)
               duration = SqlExpr.BinaryOp("/", asDecimal, literalToSqlExpr(1000000, Codec.Int, dialect))
-            } yield SqlExpr.Cast(duration, ToDdl.toDdlType(Codec[Duration], dialect.ddl, false, true).tpe)
+            } yield cast(duration, Codec[Duration], dialect)
         }
       case ExprNode.DateToDays(value) =>
         inner(value).map(v => SqlExpr.Function(dialect.extractDateDays, Seq(v)))
@@ -539,9 +534,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
                 )
             }
         }
-      case ExprNode.None(codec) =>
-        val ddlType = ToDdl.toDdlType(codec, dialect.ddl, notNull = false, supportsNotNull = true).tpe
-        Right(SqlExpr.Cast(SqlExpr.LiteralNull, ddlType))
+      case ExprNode.None(_) => Right(cast(SqlExpr.LiteralNull, expr.codec, dialect))
       case ExprNode.ToJson(value) =>
         val hasNestedArray = Codec
           .iterate(value.codec)
@@ -560,7 +553,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
       case ExprNode.FromJson(json, codec) => dialect.fromJson match {
           case SqlDialect.FromJsonSupport.Parser(fromJson, options) => for {
               jsonExpr <- inner(json)
-              ddlType = ToDdl.toDdlType(codec, dialect.ddl, notNull = false, supportsNotNull = true).tpe
+              ddlType = ToDdl.toDdlType(codec, dialect.ddl)
               optionsExpr = optionsToSqlExpr(options)
             } yield SqlExpr.Function(fromJson, Seq(jsonExpr, ddlAsSqlString(ddlType), optionsExpr))
           case extractors @ SqlDialect.FromJsonSupport.Extractors(_, _, _) =>
@@ -612,11 +605,11 @@ private def aggregateSeq[T, R](
   }
 
 private def cast(expr: SqlExpr, to: Codec[?], dialect: SqlDialect): SqlExpr =
-  SqlExpr.Cast(expr, ToDdl.toDdlType(to, dialect.ddl, false, true).tpe)
+  SqlExpr.Cast(expr, ToDdl.toDdlType(to, dialect.ddl))
 
 private def tryCast(expr: SqlExpr, from: Codec[?], to: Codec[?], dialect: SqlDialect): SqlExpr =
   SqlExpr
-    .Cast(dialect.tryCast, expr, ToDdl.toDdlType(to, dialect.ddl, false, true).tpe)
+    .Cast(dialect.tryCast, expr, ToDdl.toDdlType(to, dialect.ddl))
     .pipe(addControlCharCheckIfNeeded(expr, _, from, dialect))
     .pipe(addIntRangeCheckIfNeeded(_, to, dialect))
     .pipe(addDecimalRangeAndRoundingIfNeeded(_, to, dialect))
@@ -817,10 +810,7 @@ private def makeArray[T](values: Seq[SqlExpr], element: Codec[T], dialect: SqlDi
   }
   if values.isEmpty then
     given Codec[T] = element
-    SqlExpr.Cast(
-      array,
-      ToDdl.toDdlType(Codec[Seq[T]], dialect.ddl, notNull = true, supportsNotNull = false).tpe
-    )
+    cast(array, Codec[Seq[T]], dialect)
   else array
 }
 
@@ -830,8 +820,7 @@ private def makeMap[K, V](pairs: SqlExpr, key: Codec[K], value: Codec[V], dialec
     case SqlDialect.MapSupport.Array =>
       given Codec[K] = key
       given Codec[V] = value
-      val ddl = ToDdl.toDdlType(Codec[Map[K, V]], dialect.ddl, notNull = true, supportsNotNull = false).tpe
-      SqlExpr.Cast(pairs, ddl)
+      cast(pairs, Codec[Map[K, V]], dialect)
   }
 
 object CompatibleSum {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ToDdl.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ToDdl.scala
@@ -41,7 +41,7 @@ object ToDdl {
 
   private def toDdlSchema[T](codec: Codec[T], dialect: DdlDialect): Seq[DdlField] = {
     def fieldDdl(field: Field[?]): DdlField =
-      toDdlType(field.codec, dialect, notNull = true, supportsNotNull = dialect.supportsNotNullColumn).named(
+      toDdlField(field.codec, dialect, notNull = true, supportsNotNull = dialect.supportsNotNullColumn).named(
         field.name
       )
     codec match {
@@ -56,13 +56,16 @@ object ToDdl {
         val repr = sum.reprFields
         fieldDdl(repr.head).copy(comment = Some(docString)) +: repr.tail.map(fieldDdl)
       case _ =>
-        Seq(toDdlType(codec, dialect, notNull = true, supportsNotNull = dialect.supportsNotNullColumn).named(
+        Seq(toDdlField(codec, dialect, notNull = true, supportsNotNull = dialect.supportsNotNullColumn).named(
           "value"
         ))
     }
   }
 
-  private[tyda] def toDdlType[T](
+  def toDdlType[T](codec: Codec[T], dialect: DdlDialect): DdlType =
+    toDdlField(codec, dialect, notNull = true, supportsNotNull = true).tpe
+
+  private def toDdlField[T](
       codec: Codec[T],
       dialect: DdlDialect,
       notNull: Boolean,
@@ -70,7 +73,7 @@ object ToDdl {
   ): TypeAndNullabilityAndComment =
     codec match {
       case Codec.Option(element) =>
-        val innerDdlType = toDdlType(element, dialect, notNull = false, supportsNotNull)
+        val innerDdlType = toDdlField(element, dialect, notNull = false, supportsNotNull)
         if !notNull then
           TypeAndNullabilityAndComment(
             DdlType.Struct(Seq(
@@ -82,10 +85,10 @@ object ToDdl {
         else innerDdlType
       case sum: Codec.SumAsString[T] =>
         val docString = sum.encodedValues.mkString("one of: ", ", ", "")
-        toDdlType(Codec.String, dialect, notNull, supportsNotNull).copy(comment = Some(docString))
+        toDdlField(Codec.String, dialect, notNull, supportsNotNull).copy(comment = Some(docString))
       // We exclude Codec.Sum here so we can generate docs for the discriminant field
       case Codec.FromInjection(_, to) if !codec.isInstanceOf[Codec.Sum[?, ?]] =>
-        toDdlType(to, dialect, notNull, supportsNotNull)
+        toDdlField(to, dialect, notNull, supportsNotNull)
       case _ => TypeAndNullabilityAndComment(
           toNullableDdlType(codec, dialect),
           !(notNull && supportsNotNull),
@@ -120,13 +123,13 @@ object ToDdl {
       case Codec.Seq(given Codec[e]) =>
         val element = if shouldWrapArrayElement(Codec[e], dialect) then Codec[(value: e)] else Codec[e]
         DdlType.Array(
-          toDdlType(element, dialect, notNull = true, supportsNotNull = dialect.supportsNotNullArrayElement)
+          toDdlField(element, dialect, notNull = true, supportsNotNull = dialect.supportsNotNullArrayElement)
         )
       case Codec.Map(key, value) => dialect.map match {
           case DdlDialect.MapSupport.Array => mapAsArray(dialect)(using key, value)
           case DdlDialect.MapSupport.Native(supportsNotNullKey, supportsNotNullValue) => DdlType.Map(
-              toDdlType(key, dialect, notNull = true, supportsNotNull = supportsNotNullKey),
-              toDdlType(value, dialect, notNull = true, supportsNotNull = supportsNotNullValue)
+              toDdlField(key, dialect, notNull = true, supportsNotNull = supportsNotNullKey),
+              toDdlField(value, dialect, notNull = true, supportsNotNull = supportsNotNullValue)
             )
         }
 

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/ToDdlSpec.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/ToDdlSpec.scala
@@ -10,8 +10,10 @@ import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
 import com.choreograph.tyda.EnumStableHashCode
+import com.choreograph.tyda.SimpleTypeName
 import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.sql.DdlDialect.MapSupport
+import com.choreograph.tyda.sql.ast.DdlWriter
 
 object ToDdlSpec {
   final case class Person(name: String, age: Int) derives Codec
@@ -70,6 +72,13 @@ class ToDdlSpec extends AnyFunSuite {
 
   private def toSparkDdl(codec: Codec[?], pretty: Boolean = true): String =
     ToDdl.toDdl(codec, DdlDialect.Spark, pretty)
+
+  private def toSparkDdlType(codec: Codec[?], pretty: Boolean = false): String = {
+    val ddl = ToDdl.toDdlType(codec, DdlDialect.Spark)
+    val writer = new java.io.StringWriter()
+    DdlWriter(writer, pretty = pretty).write(ddl, 0)
+    writer.toString
+  }
 
   test("toDdl Person") {
     val ddl = toSparkDdl(Codec[Person])
@@ -371,4 +380,17 @@ class ToDdlSpec extends AnyFunSuite {
     )
     assert(toBigQueryDecimal(Codec[Decimal[38, 0]], parameterized = false) == "value BIGDECIMAL NOT NULL")
   }
+
+  def testSparkDdlType[T: Codec: SimpleTypeName](expected: String) =
+    test(s"toDdlType ${SimpleTypeName[T]}") {
+      val ddl = toSparkDdlType(Codec[T])
+      assert(ddl == expected)
+    }
+
+  testSparkDdlType[Int]("INT")
+  testSparkDdlType[Option[Int]]("INT")
+  testSparkDdlType[Option[Option[Int]]]("STRUCT<value INT>")
+  testSparkDdlType[Seq[Int]]("ARRAY<INT>")
+  testSparkDdlType[Seq[Option[Int]]]("ARRAY<INT>")
+  testSparkDdlType[(value: Int)]("STRUCT<value INT NOT NULL>")
 }


### PR DESCRIPTION
This reuses the cast builder helper inside ExprUnparser when we do casts. Also adds a new ToDdl.toDdlType method so that the ExprUnparser do not need to now about the fairly internal notNull and supportsNotNull.

This also includes a bugfix that corrects the value of `notNull` inside the `cast` helper. Currently it does not matter because we do not have any casts where the target type is actually `Option` there. (It only used with `CanCast`). So the `notNull` value only goes into determining the nullability of the field, but that  is immediately dropped when we call `.tpe`.  But without this fix cast to `Option[?]` will end up with the wrong type. This is needed for https://github.com/unum-io/tyda/pull/83
