### PR TITLE
Add retry if BigQuery error message suggests a retry

### DIFF
--- a/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
+++ b/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
@@ -142,7 +142,10 @@ object BigQueryRunner {
   private val retryJobOption: BigQuery.JobOption =
     val retryConfig = BigQueryRetryConfig
       .newBuilder()
-      .retryOnMessage("Visibility check was unavailable")
+      .retryOnMessage(
+      "Visibility check was unavailable",
+      "Error encountered during execution. Retrying may solve the problem."
+    )
       .build()
     BigQuery.JobOption.bigQueryRetryConfig(retryConfig)
 

--- a/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
+++ b/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
@@ -143,9 +143,9 @@ object BigQueryRunner {
     val retryConfig = BigQueryRetryConfig
       .newBuilder()
       .retryOnMessage(
-      "Visibility check was unavailable",
-      "Error encountered during execution. Retrying may solve the problem."
-    )
+        "Visibility check was unavailable",
+        "Error encountered during execution. Retrying may solve the problem."
+      )
       .build()
     BigQuery.JobOption.bigQueryRetryConfig(retryConfig)
 


### PR DESCRIPTION
BigQuery semi often returns

503 Error encountered during execution. Retrying may solve the problem.

In those cases we will do as suggested, and simply retry.