### PR TITLE
Also coerce table schemas on read

### DIFF
--- a/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
+++ b/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/BigQueryRunner.scala
@@ -12,6 +12,7 @@ import com.google.cloud.bigquery.Job
 import com.google.cloud.bigquery.JobInfo
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics
 import com.google.cloud.bigquery.QueryJobConfiguration
+import com.google.cloud.bigquery.Schema
 import com.google.cloud.bigquery.TableDefinition
 import com.google.cloud.bigquery.TableId
 import org.slf4j.LoggerFactory
@@ -21,7 +22,11 @@ import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.Runner
 import com.choreograph.tyda.RunnerArgs
 import com.choreograph.tyda.RunnerArgs.ValidateSchema
+import com.choreograph.tyda.TreeApi.Continue
+import com.choreograph.tyda.TreeApi.Control
+import com.choreograph.tyda.TreeApi.Skip
 import com.choreograph.tyda.bigquery.BigQueryRunner.buildClient
+import com.choreograph.tyda.rewrite.Coercion
 import com.choreograph.tyda.sql.SqlDialect
 import com.choreograph.tyda.sql.toSql
 
@@ -35,28 +40,36 @@ class BigQueryRunner(args: RunnerArgs.BigQuery) extends Runner {
       case Left(err) => throw new RuntimeException(s"Failed to unparse dataset to SQL: $err")
     }
 
-  def execute(ds: Dataset.Action): Unit = {
-    validateReadTableSchemas(ds, args.validateSchemas)
-    val query = sql(ds)
+  def execute(action: Dataset.Action): Unit = {
+    val coerced = validateAndCoerceReadTableSchemas(action, args.validateSchemas)
+    val query = sql(coerced)
     logger.info(s"Executing query:\n$query")
     val queryConfig = QueryJobConfiguration.newBuilder(query).build()
     // Do we need error handling here, or will those always result in exceptions?
     try bigQuery.query(queryConfig, BigQueryRunner.retryJobOption): Unit
     catch
-      case e: BigQueryException =>
-        throw new RuntimeException(s"Failed to execute query:\n${explain(ds)}\nError: ${e.getMessage}", e)
+      case e: BigQueryException => throw new RuntimeException(
+          s"Failed to execute query:\n${explain(coerced)}\nError: ${e.getMessage}",
+          e
+        )
   }
 
   def collect[T](ds: Dataset[T]): Seq[T] = {
-    validateReadTableSchemas(ds, args.validateSchemas)
-    val queryConfig = QueryJobConfiguration.newBuilder(sql(BigQueryCollectionRewrites.rewrite(ds))).build()
+    val coerced = validateAndCoerceReadTableSchemas(ds, args.validateSchemas)
+    val queryConfig = QueryJobConfiguration
+      .newBuilder(sql(BigQueryCollectionRewrites.rewrite(coerced)))
+      .build()
     val result = bigQuery.query(queryConfig, BigQueryRunner.retryJobOption)
     assert(!(result.getSchema == null), "Query did not return a schema unable to decode results.")
-    result.iterateAll().asScala.map(createDecoder(ds.codec, result.getSchema().getFields())).toSeq
+    result.iterateAll().asScala.map(createDecoder(coerced.codec, result.getSchema().getFields())).toSeq
   }
 
-  def explain[T](ds: Dataset[T]): String = explainImpl(BigQueryCollectionRewrites.rewrite(ds))
-  def explain(action: Dataset.Action): String = explainImpl(action)
+  def explain[T](ds: Dataset[T]): String =
+    explainImpl(
+      validateAndCoerceReadTableSchemas(BigQueryCollectionRewrites.rewrite(ds), args.validateSchemas)
+    )
+  def explain(action: Dataset.Action): String =
+    explainImpl(validateAndCoerceReadTableSchemas(action, args.validateSchemas))
 
   /** Provides a human-readable explanation of the execution plan for the given
     * dataset.
@@ -82,57 +95,87 @@ class BigQueryRunner(args: RunnerArgs.BigQuery) extends Runner {
       case _ => None
     }
 
-  private def isInvalidOrUncheckable(
-      identifier: String,
-      partitionCodec: Codec[?],
-      modelCodec: Codec[?],
-      log: String => Unit
-  ): Boolean = {
+  private def getSchema(identifier: String, log: String => Unit): Option[Schema] = {
     val id = extractTableId(identifier) match {
       case Some(tableId) => tableId
       case None =>
         log(s"Unable to extract dataset and table from identifier '$identifier', unable to validate schemas")
-        return true
+        return None
     }
     val table = bigQuery.getTable(id)
     if (table == null) {
       log(s"Table '$id' does not exist, unable to validate schemas")
-      return true
+      return None
     }
     val definition: TableDefinition = table.getDefinition()
     val schema = definition.getSchema()
     if (schema == null) {
       log(s"Table '$identifier' does not have a schema, unable to validate schemas")
-      return true
+      return None
     }
-    val fields = schema.getFields()
-    val errors = validateSchema(partitionCodec, fields) ++ validateSchema(modelCodec, fields)
-    errors.foreach(e => log(e.formatted(identifier)))
-    errors.nonEmpty
+    Option(schema)
   }
 
-  private def validateReadTableSchemas[T](
-      ds: Dataset[T] | Dataset.Action,
+  private def checkAndCoerce(
       validateSchemas: ValidateSchema
-  ): Unit = {
+  ): [t] => (Boolean, Dataset[t]) => Control[(Boolean, Dataset[t])] = {
     val failOnSchemaIssue = validateSchemas match {
-      case ValidateSchema.Off => return
+      case ValidateSchema.Off => return [t] => (acc, ds) => Continue(acc, ds)
       case ValidateSchema.Warn => false
       case ValidateSchema.Strict => true
     }
+
     def log(message: String): Unit = if (failOnSchemaIssue) logger.error(message) else logger.warn(message)
-    val check: Dataset[?] => Boolean = _ match {
-      case Dataset.ReadTable(identifier, _, partitionSchema, modelSchema) =>
-        isInvalidOrUncheckable(identifier, partitionSchema, modelSchema, log)
-      case _ => false
+    def coerce[P, M](
+        schema: Schema,
+        foundError: Boolean,
+        read: Dataset.ReadTable[P, M]
+    ): Control[(Boolean, Dataset[(P, M)])] = {
+      val physicalCodec = SchemaToCodec(schema)
+      Coercion(physicalCodec, read.partitionCodec, read.modelCodec) match {
+        case Coercion.Exact => Continue(foundError, read)
+        case Coercion.Widen(cast) => Skip(
+            foundError,
+            read
+              .copy(partitionCodec = Codec[EmptyTuple], modelCodec = physicalCodec.codec)
+              .select(_._2)
+              .select(cast)
+          )
+        case Coercion.Incompatible(errors) =>
+          log(errors.fmt)
+          Continue(true, read)
+      }
     }
-    val foundError = ds match {
-      case action: Dataset.Action => action.exists(check)
-      case dataset: Dataset[T] => dataset.exists(check)
-    }
-    if (foundError && failOnSchemaIssue) {
+
+    [t] =>
+      (foundError, ds) =>
+        ds match {
+          case read @ Dataset.ReadTable(identifier = identifier) =>
+            getSchema(identifier, log).fold(Continue(true, ds))(coerce(_, foundError, read))
+          case _ => Continue(foundError, ds)
+        }
+  }
+
+  private def checkValidation(foundError: Boolean, validateSchemas: ValidateSchema): Unit =
+    if (foundError && validateSchemas == ValidateSchema.Strict) {
       throw new RuntimeException("Schema validation errors found, see logs for details.")
     }
+
+  private def validateAndCoerceReadTableSchemas[T](
+      ds: Dataset[T],
+      validateSchemas: ValidateSchema
+  ): Dataset[T] = {
+    val (foundError, coerced) = ds.transformAccumulateDown(false)(checkAndCoerce(validateSchemas))
+    checkValidation(foundError, validateSchemas)
+    coerced
+  }
+  private def validateAndCoerceReadTableSchemas(
+      action: Dataset.Action,
+      validateSchemas: ValidateSchema
+  ): Dataset.Action = {
+    val (foundError, coerced) = action.transformAccumulateDown(false)(checkAndCoerce(validateSchemas))
+    checkValidation(foundError, validateSchemas)
+    coerced
   }
 }
 

--- a/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/SchemaToCodec.scala
+++ b/tyda-big-query/src/main/scala/com/choreograph/tyda/bigquery/SchemaToCodec.scala
@@ -1,0 +1,77 @@
+package com.choreograph.tyda.bigquery
+
+import scala.compiletime.ops.boolean.&&
+import scala.compiletime.ops.int.<=
+import scala.compiletime.ops.int.>=
+import scala.jdk.CollectionConverters.*
+
+import com.google.cloud.bigquery.Field as BqField
+import com.google.cloud.bigquery.Field.Mode
+import com.google.cloud.bigquery.FieldList
+import com.google.cloud.bigquery.Schema
+import com.google.cloud.bigquery.StandardSQLTypeName
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Field
+import com.choreograph.tyda.rewrite.ApproximatedCodec
+
+/** Builds a `Codec` from a runtime BigQuery schema.
+  */
+object SchemaToCodec {
+
+  def apply(schema: Schema): ApproximatedCodec[?] = recordCodec(schema.getFields)
+
+  private def recordCodec(fields: FieldList): ApproximatedCodec[?] = {
+    val nameAndApproximatedCodec = fields
+      .asScala
+      .iterator
+      .flatMap(f => fieldCodec(f).map(c => f.getName -> c))
+      .toSeq
+    val tydaFields = nameAndApproximatedCodec.map((name, approx) => Field(name, approx.codec))
+    val isExact = fields.size == tydaFields.size && nameAndApproximatedCodec.forall(_._2.isExact)
+    ApproximatedCodec(Codec.unsafeNamedTuple(tydaFields), isExact)
+  }
+
+  private def fieldCodec(field: BqField): Option[ApproximatedCodec[?]] =
+    Option(field.getMode).getOrElse(Mode.NULLABLE) match {
+      case Mode.REQUIRED => baseCodec(field)
+      case Mode.NULLABLE => baseCodec(field).map(c => c.copy(codec = Codec.Option(c.codec)))
+      case Mode.REPEATED => baseCodec(field).map(c => c.copy(codec = Codec.Seq(c.codec)))
+    }
+
+  private def baseCodec(field: BqField): Option[ApproximatedCodec[?]] = {
+    def exact[T](codec: Codec[T]) = Some(ApproximatedCodec(codec, true))
+    field.getType.getStandardType match {
+      case StandardSQLTypeName.STRING => exact(Codec.String)
+      case StandardSQLTypeName.BYTES => exact(Codec.Bytes)
+      case StandardSQLTypeName.INT64 => exact(Codec.Long)
+      case StandardSQLTypeName.FLOAT64 => exact(Codec.Double)
+      case StandardSQLTypeName.BOOL => exact(Codec.Boolean)
+      case StandardSQLTypeName.TIMESTAMP => exact(Codec.TimestampMicros)
+      case StandardSQLTypeName.DATE => exact(Codec.Date)
+      case StandardSQLTypeName.NUMERIC => exact(decimalCodec(field, defaultPrecision = 38, defaultScale = 9))
+      case StandardSQLTypeName.BIGNUMERIC =>
+        exact(decimalCodec(field, defaultPrecision = 76, defaultScale = 38))
+      case StandardSQLTypeName.STRUCT => Some(recordCodec(field.getSubFields))
+      case _ => None
+    }
+  }
+
+  // TODO: Check valid size
+  private def decimalCodec(field: BqField, defaultPrecision: Int, defaultScale: Int): Codec[?] = {
+    val precision = Option(field.getPrecision).map(_.toInt).getOrElse(defaultPrecision)
+    val scale = Option(field.getScale).map(_.toInt).getOrElse(defaultScale)
+    decimalCodec2(precision, scale)
+  }
+
+  private def decimalCodec2[P <: Int, S <: Int](p: P, s: S): Codec[Decimal[P, S]] = {
+    assert(s <= p && s >= 0 && p >= 1 && p <= Decimal.MaxPrecision)
+    // TYPE SAFETY: Spark only supports 128 bit decimal types
+    given ((S <= P && S >= 0 && P >= 1 && P <= Decimal.MaxPrecision) =:= true) =
+      summon[true =:= true].asInstanceOf
+    given ValueOf[P] = ValueOf(p)
+    given ValueOf[S] = ValueOf(s)
+    Codec.Decimal[P, S](p, s)
+  }
+}

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteBigQuery.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteBigQuery.scala
@@ -17,6 +17,7 @@ import com.choreograph.tyda.Format
 import com.choreograph.tyda.NumericsReadMode
 import com.choreograph.tyda.Runner
 import com.choreograph.tyda.RunnerArgs
+import com.choreograph.tyda.RunnerArgs.ValidateSchema
 import com.choreograph.tyda.TypeName
 import com.choreograph.tyda.iterator.IteratorRunner
 import com.choreograph.tyda.rewrite.ArrayCodec
@@ -51,7 +52,7 @@ class BigQueryTestRunner(args: RunnerArgs.BigQuery) extends BigQueryRunner(args)
 trait WithConfiguredBigQueryTestRunner {
   def runner: BigQueryTestRunner = {
     val projectId = BigQueryIntegrationTestEnvVariables.getProjectIdOrSkip
-    new BigQueryTestRunner(RunnerArgs.BigQuery(projectId, RunnerArgs.ValidateSchema.Off))
+    new BigQueryTestRunner(RunnerArgs.BigQuery(projectId, ValidateSchema.Strict))
   }
 }
 

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/SchemaToCodecSpec.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/SchemaToCodecSpec.scala
@@ -1,0 +1,117 @@
+package com.choreograph.tyda.bigquery
+
+import com.google.cloud.bigquery.Field as BqField
+import com.google.cloud.bigquery.Field.Mode
+import com.google.cloud.bigquery.Schema
+import com.google.cloud.bigquery.StandardSQLTypeName
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.choreograph.tyda.Binary
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Date
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Field
+import com.choreograph.tyda.Timestamp
+
+class SchemaToCodecSpec extends AnyFunSuite {
+
+  test("maps standard BigQuery types") {
+    val schema = Schema.of(
+      BqField.newBuilder("long_field", StandardSQLTypeName.INT64).setMode(Mode.REQUIRED).build(),
+      BqField.newBuilder("double_field", StandardSQLTypeName.FLOAT64).setMode(Mode.REQUIRED).build(),
+      BqField.newBuilder("bool_field", StandardSQLTypeName.BOOL).setMode(Mode.REQUIRED).build(),
+      BqField.newBuilder("string_field", StandardSQLTypeName.STRING).setMode(Mode.REQUIRED).build(),
+      BqField.newBuilder("bytes_field", StandardSQLTypeName.BYTES).setMode(Mode.REQUIRED).build(),
+      BqField.newBuilder("timestamp_field", StandardSQLTypeName.TIMESTAMP).setMode(Mode.REQUIRED).build(),
+      BqField.newBuilder("date_field", StandardSQLTypeName.DATE).setMode(Mode.REQUIRED).build()
+    )
+    val approx = SchemaToCodec(schema)
+    assert(approx.isExact)
+    val expected = Codec[
+      (
+          long_field: Long,
+          double_field: Double,
+          bool_field: Boolean,
+          string_field: String,
+          bytes_field: Binary,
+          timestamp_field: Timestamp,
+          date_field: Date
+      )
+    ]
+    assert(approx.codec == expected)
+  }
+
+  test("maps nullable (optional) and repeated (seq) fields") {
+    val schema = Schema.of(
+      BqField.newBuilder("opt_string", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build(),
+      BqField.newBuilder("seq_long", StandardSQLTypeName.INT64).setMode(Mode.REPEATED).build()
+    )
+    val approx = SchemaToCodec(schema)
+    assert(approx.isExact)
+    val expected = Codec[(opt_string: Option[String], seq_long: Seq[Long])]
+    assert(approx.codec == expected)
+  }
+
+  test("maps standard NUMERIC decimal") {
+    val schema = Schema.of(
+      BqField.newBuilder("numeric_field", StandardSQLTypeName.NUMERIC).setMode(Mode.REQUIRED).build()
+    )
+    val approx = SchemaToCodec(schema)
+    assert(approx.isExact)
+    val expected = Codec[(numeric_field: Decimal[38, 9])]
+    assert(approx.codec == expected)
+  }
+
+  test("standard BIGNUMERIC throws AssertionError because default precision 76 exceeds MaxPrecision 38") {
+    val schema = Schema.of(
+      BqField.newBuilder("bignumeric_field", StandardSQLTypeName.BIGNUMERIC).setMode(Mode.REQUIRED).build()
+    )
+    intercept[AssertionError] { SchemaToCodec(schema) }
+  }
+
+  test("maps decimals with custom precision and scale") {
+    val schema = Schema.of(
+      BqField
+        .newBuilder("numeric_custom", StandardSQLTypeName.NUMERIC)
+        .setPrecision(10L)
+        .setScale(2L)
+        .setMode(Mode.REQUIRED)
+        .build(),
+      BqField
+        .newBuilder("bignumeric_custom", StandardSQLTypeName.BIGNUMERIC)
+        .setPrecision(38L)
+        .setScale(30L)
+        .setMode(Mode.REQUIRED)
+        .build()
+    )
+    val approx = SchemaToCodec(schema)
+    assert(approx.isExact)
+    val expected = Codec[(numeric_custom: Decimal[10, 2], bignumeric_custom: Decimal[38, 30])]
+    assert(approx.codec == expected)
+  }
+
+  test("maps nested structs") {
+    val subField1 = BqField.newBuilder("a", StandardSQLTypeName.INT64).setMode(Mode.REQUIRED).build()
+    val subField2 = BqField.newBuilder("b", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build()
+    val schema = Schema.of(
+      BqField
+        .newBuilder("nested", StandardSQLTypeName.STRUCT, subField1, subField2)
+        .setMode(Mode.REQUIRED)
+        .build()
+    )
+    val approx = SchemaToCodec(schema)
+    assert(approx.isExact)
+    val expected = Codec[(nested: (a: Long, b: Option[String]))]
+    assert(approx.codec == expected)
+  }
+
+  test("skips unsupported BigQuery types") {
+    val schema = Schema.of(
+      BqField.newBuilder("valid", StandardSQLTypeName.INT64).setMode(Mode.REQUIRED).build(),
+      BqField.newBuilder("invalid", StandardSQLTypeName.GEOGRAPHY).setMode(Mode.NULLABLE).build()
+    )
+    val approx = SchemaToCodec(schema)
+    assert(!approx.isExact)
+    assert(approx.codec == Codec.unsafeNamedTuple(Seq(Field("valid", Codec.Long))))
+  }
+}

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/ApproximatedCodec.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/ApproximatedCodec.scala
@@ -1,0 +1,10 @@
+package com.choreograph.tyda.rewrite
+
+import com.choreograph.tyda.Codec
+
+/** This represent a Codec[T] that been approximated from an external schema.
+  *
+  * `isExact` being false means that the external schema had extra fields that
+  * were not possible to represent inside Codec.
+  */
+final case class ApproximatedCodec[T](codec: Codec[T], isExact: Boolean)

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/Coercion.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/Coercion.scala
@@ -1,0 +1,265 @@
+package com.choreograph.tyda.rewrite
+import scala.compiletime.ops.int.-
+import scala.compiletime.ops.int.>=
+
+import com.choreograph.tyda.CanCast
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Expr
+import com.choreograph.tyda.ExprNode
+import com.choreograph.tyda.Field
+import com.choreograph.tyda.NonEmpty
+import com.choreograph.tyda.functions.some
+import com.choreograph.tyda.shapeless3extras.mapConst
+import com.choreograph.tyda.unreachable
+
+private[tyda] enum Coercion[+A] {
+  case Exact
+  case Widen(value: A)
+  case Incompatible(errors: NonEmpty[Seq[Coercion.Error]]) extends Coercion[Nothing]
+
+  def map[B](f: A => B): Coercion[B] =
+    this match {
+      case Exact => Exact
+      case Widen(value) => Widen(f(value))
+      case Incompatible(errors) => Incompatible(errors)
+    }
+}
+
+private[tyda] object Coercion {
+  enum PathSegment {
+    case Field(name: String)
+    case Element
+    case Key
+    case Value
+  }
+
+  final case class Error(path: Seq[PathSegment], tpe: ErrorType)
+  enum ErrorType {
+    case MissingRequired(expected: Codec[?])
+    case Mismatch(from: Codec[?], to: Codec[?])
+    case WideningMap
+  }
+
+  extension (errors: NonEmpty[Seq[Error]]) { def fmt: String = formatErrors(errors) }
+
+  private def formatErrors(errors: NonEmpty[Seq[Error]]): String = {
+    val formattedErrors = errors.map(e => s"  - ${formatError(e)}").mkString("\n")
+    s"Could not coerce the value:\n${formattedErrors}"
+  }
+
+  private def formatError(error: Error): String = {
+    val where = render(error.path)
+    error.tpe match {
+      case ErrorType.MissingRequired(expected) => s"required field $where (expected $expected) is missing"
+      case ErrorType.Mismatch(from, to) => s"$where has type $from, which cannot be coerced to $to"
+      case ErrorType.WideningMap => s"$where is a Map whose entries need widening, which is not supported yet"
+    }
+  }
+
+  private def render(path: Seq[PathSegment]): String = {
+    val sb = path.foldLeft(StringBuilder()) { (sb, seg) =>
+      seg match {
+        case PathSegment.Field(name) => sb.append('.').append(name)
+        case PathSegment.Element => sb.append("[*]")
+        case PathSegment.Key => sb.append("{key}")
+        case PathSegment.Value => sb.append("{value}")
+      }
+    }
+    if sb.isEmpty then "<root>" else sb.result().stripPrefix(".")
+  }
+
+  /** Try and create a coersion from one codec to another.
+    *
+    * Allowed coersions are promotion of numerical types and optional fields are
+    * allowed to be mising.
+    */
+  def apply[From, To](from: ApproximatedCodec[From], to: Codec[To]): Coercion[Expr[From] => Expr[To]] =
+    coerceWithValueFieldRemoval(from, to, Seq.empty)
+
+  def exact[From, To](from: Codec[From], to: Codec[To]): Coercion[Expr[From] => Expr[To]] =
+    apply(ApproximatedCodec(from, true), to)
+
+  def apply[T, P, M](
+      from: ApproximatedCodec[T],
+      toPartition: Codec[P],
+      toModel: Codec[M]
+  ): Coercion[Expr[T] => Expr[(P, M)]] = {
+    val makeTuple = unflatten(toPartition, toModel)
+    apply(from, makeTuple.arg.codec).map(_.andThen(r =>
+      Expr.lift(makeTuple.expr.replace(makeTuple.arg, r.node))
+    ))
+  }
+
+  private def incompatible(path: Seq[PathSegment], tpe: ErrorType): Coercion[Nothing] =
+    Incompatible(NonEmpty(Error(path, tpe)))
+
+  private object SingleValueFieldStruct {
+    def unapply(codec: Codec[?]): Option[Codec[?]] =
+      codec match {
+        case Codec.Product(_, fields, _) => fields.mapConst([t] => identity(_)) match {
+            case Seq(Field("value", value)) => Some(value)
+            case _ => None
+          }
+        case _ => None
+      }
+  }
+
+  // We allow the from Codec to comes from an external schama and must therefore handle that we introdced
+  // extra structs with a single field value for top level values of nested Options.
+  private def coerceWithValueFieldRemoval[From, To](
+      from: ApproximatedCodec[From],
+      to: Codec[To],
+      path: Seq[PathSegment],
+      requireOptionValue: Boolean = false
+  ): Coercion[Expr[From] => Expr[To]] =
+    def isOption(c: Codec[?]) = c.isInstanceOf[Codec.Option[?]]
+    (from.codec, to) match {
+      case (SingleValueFieldStruct(inner), elem)
+          if !requireOptionValue || (isOption(inner) && isOption(elem)) =>
+        def select[T](e: Expr[From]): Expr[T] = Expr.lift(ExprNode.Select(Expr.unlift(e), "value"))
+        coerce(from.copy(codec = inner), elem, path) match {
+          case Exact => Widen(select)
+          case Incompatible(_) => coerce(from, to, path)
+          case Widen(coerceValue) => Widen(coerceValue.compose(select))
+        }
+      case _ => coerce(from, to, path)
+    }
+
+  private def coerce[From, To](
+      approxFrom: ApproximatedCodec[From],
+      to: Codec[To],
+      path: Seq[PathSegment]
+  ): Coercion[Expr[From] => Expr[To]] = {
+    extension [T](c: Codec[T]) def asApprox = approxFrom.copy(codec = c)
+    val from = approxFrom.codec
+    to match {
+      case `from` => return Exact
+      case codec @ Codec.FromInjection(_, toInjected) => return coerce(approxFrom, toInjected, path).map(
+          _.andThen(e => Expr.lift(ExprNode.FromRepr(Expr.unlift(e), codec)))
+        )
+      case Codec.Option(`from`) => return Widen((e: Expr[From]) => some(e))
+      case Codec.Option(elem) if !from.isInstanceOf[Codec.Option[?]] =>
+        return coerce(approxFrom, elem, path).map(_.andThen(some))
+      case _ => ()
+    }
+
+    def mismatch = incompatible(path, ErrorType.Mismatch(from, to))
+
+    from match {
+      case Codec.Boolean | Codec.TimestampMicros | Codec.Date | Codec.DurationMicros | Codec.String | Codec
+            .Bytes | Codec.Long | Codec.Double => mismatch
+      case Codec.Byte => to match {
+          case Codec.Short => Widen((e: Expr[Byte]) => e.cast[Short])
+          case Codec.Int => Widen((e: Expr[Byte]) => e.cast[Int])
+          case Codec.Long => Widen((e: Expr[Byte]) => e.cast[Long])
+          case _ => mismatch
+        }
+      case Codec.Short => to match {
+          case Codec.Int => Widen((e: Expr[Short]) => e.cast[Int])
+          case Codec.Long => Widen((e: Expr[Short]) => e.cast[Long])
+          case _ => mismatch
+        }
+      case Codec.Int => to match {
+          case Codec.Long => Widen((e: Expr[Int]) => e.cast[Long])
+          case _ => mismatch
+        }
+      case Codec.Float => to match {
+          case Codec.Double => Widen((e: Expr[Float]) => e.cast[Double])
+          case _ => mismatch
+        }
+      case d1: Codec.Decimal[p1, s1] => to match {
+          case d2: Codec.Decimal[p2, s2]
+              if d2.scale >= d1.scale && d2.precision - d2.scale >= d1.precision - d1.scale =>
+            // TYPE SAFETY: Checked in the if guard above
+            given scaleIncrease: (s2 >= s1 =:= true) = summon[true =:= true].asInstanceOf
+            // TYPE SAFETY: Checked in the if guard above
+            given maxIncrease: (p2 - s2 >= p1 - s1 =:= true) = summon[true =:= true].asInstanceOf
+            given Decimal.Valid[p2, s2] = d2.valid
+            Widen((e: Expr[Decimal[p1, s1]]) => e.cast[Decimal[p2, s2]])
+          case _ => mismatch
+        }
+
+      case Codec.Option(elemFrom: Codec[a]) => to match {
+          case Codec.Option(elemTo) =>
+            coerceWithValueFieldRemoval(elemFrom.asApprox, elemTo, path, requireOptionValue = true).map(
+              fixElem => (r: Expr[Option[a]]) => r.map(fixElem)
+            )
+          case _ => mismatch
+        }
+      case Codec.Seq(elemFrom: Codec[a]) => to match {
+          case Codec.Seq(elemTo) => coerce(elemFrom.asApprox, elemTo, path :+ PathSegment.Element).map(
+              fixElem => (r: Expr[Seq[a]]) => r.map(fixElem)
+            )
+          case _ => mismatch
+        }
+      case Codec.Map(keyFrom, valueFrom) => to match {
+          case Codec.Map(keyTo, valueTo) => (
+              coerce(keyFrom.asApprox, keyTo, path :+ PathSegment.Key),
+              coerce(valueFrom.asApprox, valueTo, path :+ PathSegment.Value)
+            ) match {
+              case (Exact, Exact) => Exact
+              // TODO: Support widening here after we support map on Maps
+              case (Widen(_), _) | (_, Widen(_)) => incompatible(path, ErrorType.WideningMap)
+              case (Incompatible(e1), Incompatible(e2)) => Incompatible(e1 ++ e2)
+              case (e @ Incompatible(_), _) => e
+              case (_, e @ Incompatible(_)) => e
+            }
+          case _ => mismatch
+        }
+      case Codec.Product(_, fromFields, _) =>
+        val fromFieldsSeq = fromFields.mapConst([t] => identity(_))
+        to match {
+          case to @ Codec.Product(_, toFields, _) =>
+            val fromNameToCodec = fromFieldsSeq.map(f => f.name -> f.codec).toMap
+            val fieldAndCoercions = toFields.mapConst([t] =>
+              f =>
+                (
+                  f,
+                  fromNameToCodec
+                    .get(f.name)
+                    .map(_.asApprox)
+                    .map(coerce(_, f.codec, path :+ PathSegment.Field(f.name)))
+                )
+            )
+
+            val isExact = approxFrom.isExact && fieldAndCoercions.corresponds(fromFieldsSeq) {
+              case ((toField, maybeCoersion), fromField) => fromField.name == toField.name &&
+                maybeCoersion.contains(Exact)
+            }
+            if isExact then return Exact
+            val allErrors = fieldAndCoercions
+              .collect {
+                case (Field(_, Codec.Option(_)), None) => Seq.empty
+                case (Field(name, codec), None) =>
+                  Seq(Error(path :+ PathSegment.Field(name), ErrorType.MissingRequired(codec)))
+                case (_, Some(Incompatible(errors))) => errors.toSeq
+              }
+              .flatten
+            NonEmpty.from(allErrors) match {
+              case Some(errors) => return Incompatible(errors)
+              case None => ()
+            }
+
+            Widen((expr: Expr[From]) =>
+              val node = Expr.unlift(expr)
+              val elements = fieldAndCoercions.map {
+                case (field, Some(Coercion.Exact)) => ExprNode.Select(node, field.name)
+                case (field, Some(Coercion.Widen(widen))) =>
+                  // TYPE SAFETY: The compiler seems to infer `Nothing => Expr[?]` for widen, but we know it
+                  // actually a Expr input
+                  val widenFixed = widen.asInstanceOf[Expr[?] => Expr[?]]
+                  widenFixed(Expr.lift(ExprNode.Select(node, field.name))).node
+                case (Field(_, Codec.Option(nonNullCodec)), None) => ExprNode.none(using nonNullCodec)
+                case (_, _) => unreachable("earlier guards handle Incompatible and mising required fields")
+              }
+              Expr.lift(ExprNode.makeProductUnsafe(elements, to))
+            )
+          case _ => mismatch
+        }
+      case codec @ Codec.FromInjection(_, fromInjected) => coerce(fromInjected.asApprox, to, path).map(
+          _.compose(e => Expr.lift(ExprNode.ToRepr(Expr.unlift(e), codec)))
+        )
+    }
+  }
+}

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/unflatten.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/unflatten.scala
@@ -1,0 +1,60 @@
+package com.choreograph.tyda.rewrite
+
+import scala.NamedTuple.AnyNamedTuple
+import scala.deriving.Mirror
+import scala.reflect.ClassTag
+
+import shapeless3.deriving.K0
+import shapeless3.deriving.Labelling
+import shapeless3.deriving.internals.ErasedProductInstances1
+import shapeless3.deriving.internals.ErasedProductInstancesN
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.CompiledExpr
+import com.choreograph.tyda.ExprNode
+import com.choreograph.tyda.Field
+import com.choreograph.tyda.NonEmpty
+import com.choreograph.tyda.shapeless3extras.mapConst
+
+private def getFields(c: Codec[?]): Seq[Field[?]] =
+  c match {
+    case Codec.Product(_, fields, _) => fields.mapConst[Field[?]]([t] => identity(_))
+    case s @ Codec.Sum(_) => s.reprFields
+    case other => Seq(Field("value", other))
+  }
+
+// This can be seens as a codec for NamedTuple.Concat[NamedTuple.From[P], NamedTuple.From[T]]
+private def combinedFlatCodec[P: Codec, T: Codec]: Codec[?] = {
+  val fields = getFields(Codec[P]) ++ getFields(Codec[T])
+  assert(fields.map(_.name).distinct.size == fields.size, "Field names in combined codec must be unique")
+  val tag: ClassTag[AnyNamedTuple] = Codec.tupleClassTag(fields.size)
+  // TYPE SAFETY: NamedTuples mirror is just a Tuple mirror with different refinements
+  val mirror = new scala.runtime.TupleMirror(fields.size).asInstanceOf[Mirror.ProductOf[AnyNamedTuple]]
+  val labelling = Labelling[AnyNamedTuple](s"Tuple${fields.size}", fields.map(_.name).toIndexedSeq)
+  val instances: K0.ProductInstances[Codec, AnyNamedTuple] = fields.size match {
+    case 1 => new ErasedProductInstances1(mirror, () => fields.head.codec)
+    case _ => new ErasedProductInstancesN(mirror, () => fields.toArray.map(_.codec: Any))
+  }
+  Codec.product(using tag, mirror, labelling, instances)
+}
+
+def unflatten[P, T](partitionCodec: Codec[P], modelCodec: Codec[T]): CompiledExpr[?, (P, T)] = {
+  val arg = ExprNode.Reference(codec = combinedFlatCodec(using partitionCodec, modelCodec))
+  def fields[C](codec: Codec[C]): ExprNode[C] =
+    codec match {
+      case codec @ (Codec.Product(_, _, _) | Codec.Sum(_, _)) =>
+        val fieldsExprs = getFields(codec).map(f => ExprNode.Select(arg, f.name))
+        def product[I](prod: Codec.Product[I]) =
+          ExprNode.MakeProduct(
+            // TYPE SAFETY: Each element in fieldsExprs has type ExprNode[?]
+            values = Tuple.fromArray(fieldsExprs.toArray).asInstanceOf[Tuple.Map[Tuple, ExprNode]],
+            codec = prod
+          )
+        codec match {
+          case prod @ Codec.Product(_, _, _) => product(prod)
+          case sum @ Codec.Sum(_, _) => ExprNode.FromRepr(product(sum.reprCodec), sum)
+        }
+      case _ => ExprNode.Select(arg, "value")
+    }
+  CompiledExpr(arg, ExprNode.makeTuple[(P, T)]((fields(partitionCodec), fields(modelCodec))))
+}

--- a/tyda-rewrite/src/test/scala/com/choreograph/tyda/rewrite/CoersionSpec.scala
+++ b/tyda-rewrite/src/test/scala/com/choreograph/tyda/rewrite/CoersionSpec.scala
@@ -1,0 +1,181 @@
+package com.choreograph.tyda.rewrite
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.choreograph.tyda.Arbitrary
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.SimpleTypeName
+import com.choreograph.tyda.SimpleTypeName.name as typeName
+import com.choreograph.tyda.iterator.ExprEvaluation
+import com.choreograph.tyda.rewrite.Coercion.PathSegment
+
+object CoersionSpec {
+  given Arbitrary[Float] = Arbitrary.float.filter(!_.isNaN)
+}
+
+class CoercionSpec extends AnyFunSuite {
+  import CoersionSpec.given
+
+  private def testExact[From: Codec: SimpleTypeName, To: Codec: SimpleTypeName]: Unit =
+    test(s"${typeName[From]} => ${typeName[To]} is Exact") {
+      assert(Coercion.exact(Codec[From], Codec[To]) == Coercion.Exact)
+    }
+
+  private def testExact[T: Codec: SimpleTypeName]: Unit = testExact[T, T]
+
+  private def testWiden[F: Arbitrary: Codec: SimpleTypeName, T: Codec: SimpleTypeName](ref: F => T): Unit =
+    test(s"${typeName[F]} widens to ${typeName[T]}") {
+      Coercion.exact(Codec[F], Codec[T]) match {
+        case Coercion.Widen(f) => (0 to 10).foreach(_ =>
+            val v = Arbitrary[F]()
+            val eval = ExprEvaluation.lambda(f)
+            assert(eval(v) == ref(v), s"Unexpected coercion for $v")
+          )
+        case other => fail(s"Expected Coercion.Widen but got: $other")
+      }
+    }
+
+  private def testIncompatible[F: Codec: SimpleTypeName, T: Codec: SimpleTypeName](
+      expectedErrors: Coercion.Error*
+  ): Unit =
+    test(s"${typeName[F]} => ${typeName[T]} is Incompatible") {
+      Coercion.exact(Codec[F], Codec[T]) match {
+        case Coercion.Incompatible(errors) => assert(errors == expectedErrors)
+        case other => fail(s"Expected Coercion.Incompatible but got: $other")
+      }
+    }
+
+  private def testMismatch[F: Codec: SimpleTypeName, T: Codec: SimpleTypeName]: Unit =
+    testIncompatible[F, T](Coercion.Error(Seq.empty, Coercion.ErrorType.Mismatch(Codec[F], Codec[T])))
+
+  testExact[Byte]
+  testExact[Short]
+  testExact[Int]
+  testExact[Long]
+  testExact[Float]
+  testExact[Double]
+  testExact[Boolean]
+  testExact[String]
+  testExact[Option[Int]]
+  testExact[Seq[Int]]
+  testExact[Map[String, Int]]
+  testExact[(a: Int, b: Int)]
+  testExact[(a: Int, b: String, c: Boolean)]
+  testExact[(head: (x: Int, y: Int), tail: Int)] // nested product
+  testExact[Seq[(a: Int, b: Int)]]
+  testExact[Option[(a: Int, b: Int)]]
+  testExact[Map[String, (a: Int, b: Int)]]
+  testExact[Option[Option[Int]]]
+  testExact[Seq[Seq[Int]]]
+  testExact[Map[String, Seq[Int]]]
+
+  testWiden[Byte, Short](_.toShort)
+  testWiden[Byte, Int](_.toInt)
+  testWiden[Byte, Long](_.toLong)
+  testWiden[Short, Int](_.toInt)
+  testWiden[Short, Long](_.toLong)
+  testWiden[Int, Long](_.toLong)
+  testWiden[Float, Double](_.toDouble)
+
+  testWiden[Byte, Option[Byte]](Some(_))
+  testWiden[Short, Option[Short]](Some(_))
+  testWiden[Int, Option[Int]](Some(_))
+  testWiden[Long, Option[Long]](Some(_))
+  testWiden[(value: Long), Option[Long]](v => Some(v.value))
+  testWiden[(value: Option[Long]), Option[Long]](v => v.value)
+
+  testWiden[Option[Short], Option[Long]](_.map(_.toLong))
+  testWiden[Option[Option[Short]], Option[Option[Long]]](_.map(_.map(_.toLong)))
+  testWiden[Option[Option[Option[Short]]], Option[Option[Option[Long]]]](_.map(_.map(_.map(_.toLong))))
+  testWiden[Option[Float], Option[Double]](_.map(_.toDouble))
+  testWiden[Option[(a: Int, b: Int)], Option[(a: Long, b: Long)]](_.map(t =>
+    (a = t.a.toLong, b = t.b.toLong)
+  ))
+  testWiden[Option[(value: Option[Int])], Option[Option[Long]]](_.map(_.value.map(_.toLong)))
+  testWiden[Option[(value: Option[Int])], Option[Option[Int]]](_.map(_.value))
+
+  testWiden[Seq[Byte], Seq[Short]](_.map(_.toShort))
+  testWiden[Seq[Float], Seq[Double]](_.map(_.toDouble))
+  testWiden[Seq[(a: Int, b: Int)], Seq[(a: Long, b: Long)]](_.map(t => (a = t.a.toLong, b = t.b.toLong)))
+  testWiden[(value: Seq[Int]), Seq[Int]](_.value)
+
+  testWiden[Byte, Option[Long]](b => Some(b.toLong))
+  testWiden[Int, Option[Long]](i => Some(i.toLong))
+  testWiden[Float, Option[Double]](f => Some(f.toDouble))
+  testWiden[(b: Int, a: Int), (a: Int, b: Int)](t => (a = t.a, b = t.b))
+  testWiden[(a: Int, b: Int), (a: Long, b: Long)](t => (a = t.a.toLong, b = t.b.toLong))
+  testWiden[(a: Int), (a: Int, b: Option[String])](t => (a = t.a, b = None))
+  testWiden[(a: Int, b: Int), (a: Int, b: Option[Int])](t => (a = t.a, b = Some(t.b)))
+  testWiden[(head: (x: Int, y: Int), tail: Int), (head: (x: Long, y: Long), tail: Int)](t =>
+    (head = (x = t.head.x.toLong, y = t.head.y.toLong), tail = t.tail)
+  )
+  testWiden[(a: Int, b: Int, c: Int), (a: Int, b: Int)](t => (a = t.a, b = t.b))
+
+  testMismatch[Long, Int]
+  testMismatch[Long, Short]
+  testMismatch[Int, Short]
+  testMismatch[Int, Byte]
+  testMismatch[Double, Float]
+  testMismatch[String, Int]
+  testMismatch[Int, String]
+  testMismatch[Int, Boolean]
+  testMismatch[Boolean, Int]
+  testMismatch[Option[Int], Int]
+  testMismatch[Seq[Int], Int]
+  testMismatch[Int, Seq[Int]]
+  testMismatch[Map[String, Int], Seq[Int]]
+  testMismatch[(a: Int, b: Int), Int]
+
+  testIncompatible[Option[(value: Option[String])], Option[Option[Int]]](Coercion.Error(
+    Seq.empty,
+    Coercion.ErrorType.Mismatch(Codec[(value: Option[String])], Codec[Int])
+  ))
+
+  testIncompatible[Map[Int, Int], Map[Long, Int]](Coercion.Error(Seq.empty, Coercion.ErrorType.WideningMap))
+  testIncompatible[Seq[Int], Seq[Short]](
+    Coercion.Error(Seq(PathSegment.Element), Coercion.ErrorType.Mismatch(Codec[Int], Codec[Short]))
+  )
+  testIncompatible[Seq[(a: Int, b: Int)], Seq[(a: Int, b: Short)]](Coercion.Error(
+    Seq(PathSegment.Element, PathSegment.Field("b")),
+    Coercion.ErrorType.Mismatch(Codec[Int], Codec[Short])
+  ))
+  testIncompatible[Map[String, Int], Map[String, Long]](
+    Coercion.Error(Seq.empty, Coercion.ErrorType.WideningMap)
+  )
+  testIncompatible[(a: Int, b: Int), (a: Int, b: String)](
+    Coercion.Error(Seq(PathSegment.Field("b")), Coercion.ErrorType.Mismatch(Codec[Int], Codec[String]))
+  )
+  testIncompatible[(head: (x: Int, y: Int), tail: Int), (head: (x: String, y: Int), tail: Int)](
+    Coercion.Error(
+      Seq("head", "x").map(PathSegment.Field(_)),
+      Coercion.ErrorType.Mismatch(Codec[Int], Codec[String])
+    )
+  )
+  testIncompatible[(a: Long, b: Long), (a: Int, b: Int)](
+    Coercion.Error(Seq(PathSegment.Field("a")), Coercion.ErrorType.Mismatch(Codec[Long], Codec[Int])),
+    Coercion.Error(Seq(PathSegment.Field("b")), Coercion.ErrorType.Mismatch(Codec[Long], Codec[Int]))
+  )
+  testIncompatible[Option[Long], Option[Int]](
+    Coercion.Error(Seq.empty, Coercion.ErrorType.Mismatch(Codec[Long], Codec[Int]))
+  )
+  testIncompatible[(p: Int, q: Int), (a: Int, b: Int)](
+    Coercion.Error(Seq(PathSegment.Field("a")), Coercion.ErrorType.MissingRequired(Codec[Int])),
+    Coercion.Error(Seq(PathSegment.Field("b")), Coercion.ErrorType.MissingRequired(Codec[Int]))
+  )
+  testIncompatible[(a: Long, b: Int), (a: Int, c: String)](
+    Coercion.Error(Seq(PathSegment.Field("a")), Coercion.ErrorType.Mismatch(Codec[Long], Codec[Int])),
+    Coercion.Error(Seq(PathSegment.Field("c")), Coercion.ErrorType.MissingRequired(Codec[String]))
+  )
+
+  test("formatErrors renders every problem in a record") {
+    Coercion.exact(Codec[(a: Seq[String], b: Long)], Codec[(a: Seq[Int], b: Int)]) match {
+      case Coercion.Incompatible(errors) =>
+        val expected = s"""Could not coerce the value:
+           |  - a[*] has type ${Codec[String]}, which cannot be coerced to ${Codec[Int]}
+           |  - b has type ${Codec[Long]}, which cannot be coerced to ${Codec[Int]}""".stripMargin
+        assert(errors.fmt == expected)
+      case other => fail(s"Expected Coercion.Incompatible but got: $other")
+    }
+  }
+
+}

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
@@ -41,6 +41,7 @@ import com.choreograph.tyda.TableLocation
 import com.choreograph.tyda.TreeApi.Continue
 import com.choreograph.tyda.TreeApi.Skip
 import com.choreograph.tyda.functions.some
+import com.choreograph.tyda.rewrite.Coercion
 import com.choreograph.tyda.rewrite.ExplodeOptionToFilter
 import com.choreograph.tyda.rewrite.ReplacementMap
 import com.choreograph.tyda.rewrite.ReplacementMap.Replacement
@@ -208,10 +209,23 @@ object DatasetOnSpark {
     def compute: IntermediateDataset[T] =
       ds match {
         case SparkJsonCompatability.AdaptReads(adapted) => toIntermediate(adapted)
-        case read @ Dataset.ReadTable(identifier, location, _, _) => readWithFlatPartitions(_ =>
-            location match {
+        case read @ Dataset.ReadTable(identifier, location, partitionCodec, modelCodec) =>
+          readWithFlatPartitions(schema =>
+            val df = location match {
               case TableLocation.Native => spark.read.table(identifier)
               case TableLocation.BigQuery => spark.read.format("bigquery").load(identifier)
+            }
+            val physical = StructTypeToCodec(df.schema)
+            // We use StructTypeToCodec also for the read schema so that the nullability matches Sparks
+            // version.
+            val read = StructTypeToCodec(schema).codec
+            Coercion(physical, read) match {
+              case Coercion.Exact => df
+              case Coercion.Widen(widen) =>
+                val cf = ColumnFactory.fromDF(df, physical.codec)
+                val coerced = ExprOnSpark.resolved(cf, CompiledExpr(widen)(using physical.codec))
+                selectAndUnpack(df, coerced)(using read).toDF
+              case Coercion.Incompatible(errors) => throw RuntimeException(errors.fmt)
             }
           )(using read.partitionCodec, read.modelCodec)
         case Dataset.ReadPath(path, format, false, filenameGlobFilter, _) =>

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/StructTypeToCodec.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/StructTypeToCodec.scala
@@ -1,0 +1,89 @@
+package com.choreograph.tyda.spark
+
+import scala.compiletime.ops.boolean.&&
+import scala.compiletime.ops.int.<=
+import scala.compiletime.ops.int.>=
+
+import org.apache.spark.sql.types.ArrayType
+import org.apache.spark.sql.types.BinaryType
+import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.types.ByteType
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DateType
+import org.apache.spark.sql.types.DecimalType
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.FloatType
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.types.MapType
+import org.apache.spark.sql.types.ShortType
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.TimestampType
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Field
+import com.choreograph.tyda.rewrite.ApproximatedCodec
+
+object StructTypeToCodec {
+
+  /** Build a Codec mirroring a Spark schema. A nullable column / element /
+    * map-value becomes `Codec.Option`, so it lines up with how optionality is
+    * modelled everywhere else.
+    *
+    * Fields whose Spark type has no corresponding tyda Codec are skipped. This
+    * propagates through containers: an array/map whose element/value type is
+    * unsupported is itself skipped.
+    */
+  def apply(schema: StructType): ApproximatedCodec[?] = structCodec(schema)
+
+  private def structCodec(struct: StructType): ApproximatedCodec[?] = {
+    val nameAndApproximatedCodec = struct
+      .fields
+      .flatMap(f => codecOf(f.dataType, f.nullable).map(f.name -> _))
+      .toSeq
+    val tydaFields = nameAndApproximatedCodec.map((name, approx) => Field(name, approx.codec))
+    val isExact = struct.size == tydaFields.size && nameAndApproximatedCodec.forall(_._2.isExact)
+    ApproximatedCodec(Codec.unsafeNamedTuple(tydaFields), isExact)
+  }
+
+  private def codecOf(dataType: DataType, nullable: Boolean): Option[ApproximatedCodec[?]] =
+    val inner = codecOf(dataType)
+    if !nullable then inner else inner.map(approx => approx.copy(codec = Codec.Option(approx.codec)))
+
+  private def codecOf(dataType: DataType): Option[ApproximatedCodec[?]] =
+    def exact[T](codec: Codec[T]) = Some(ApproximatedCodec(codec, true))
+    dataType match {
+      case ByteType => exact(Codec.Byte)
+      case ShortType => exact(Codec.Short)
+      case IntegerType => exact(Codec.Int)
+      case LongType => exact(Codec.Long)
+      case FloatType => exact(Codec.Float)
+      case DoubleType => exact(Codec.Double)
+      case BooleanType => exact(Codec.Boolean)
+      case _: StringType => exact(Codec.String)
+      case BinaryType => exact(Codec.Bytes)
+      case DateType => exact(Codec.Date)
+      case TimestampType => exact(Codec.TimestampMicros)
+      case d: DecimalType => exact(decimalCodec(d.precision, d.scale))
+      case a: ArrayType =>
+        codecOf(a.elementType, a.containsNull).map(approx => approx.copy(Codec.Seq(approx.codec)))
+      case m: MapType => for {
+          key <- codecOf(m.keyType)
+          value <- codecOf(m.valueType, m.valueContainsNull)
+        } yield ApproximatedCodec(Codec.Map(key.codec, value.codec), key.isExact && value.isExact)
+      case s: StructType => Some(structCodec(s))
+      case _ => None
+    }
+
+  private def decimalCodec[P <: Int, S <: Int](p: P, s: S): Codec[Decimal[P, S]] = {
+    assert(s <= p && s >= 0 && p >= 1 && p <= Decimal.MaxPrecision)
+    // TYPE SAFETY: Spark only supports 128 bit decimal types
+    given ((S <= P && S >= 0 && P >= 1 && P <= Decimal.MaxPrecision) =:= true) =
+      summon[true =:= true].asInstanceOf
+    given ValueOf[P] = ValueOf(p)
+    given ValueOf[S] = ValueOf(s)
+    Codec.Decimal[P, S](p, s)
+  }
+}

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/StructTypeToCodecSpec.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/StructTypeToCodecSpec.scala
@@ -1,0 +1,75 @@
+package com.choreograph.tyda.spark
+
+import org.apache.spark.sql.types.*
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.choreograph.tyda.Binary
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Date
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Field
+import com.choreograph.tyda.Timestamp
+import com.choreograph.tyda.TypeName
+
+class StructTypeToCodecSpec extends AnyFunSuite {
+  private def roundTrip[T: {Codec, TypeName}]: Unit = {
+    test(s"StructTypeToCodec round-trip for ${TypeName.name[T]}") {
+      val schema = CodecToEncoder.convert[T].schema
+      val approx = StructTypeToCodec(schema)
+      assert(approx.isExact, s"Codec for schema $schema was not exact")
+      assert(
+        approx.codec == Codec[T],
+        s"Round trip codec did not match for schema $schema\nReconstructed: ${approx
+            .codec}\nOriginal: ${Codec[T]}"
+      )
+    }
+  }
+
+  // Note: Since we follow Sparks nullability in CodecToEncoder all Strings, collections and products needs to
+  // be wrapped in Option for them to round trip.
+  roundTrip[(a: Boolean)]
+  roundTrip[(a: Byte)]
+  roundTrip[(a: Short)]
+  roundTrip[(a: Int)]
+  roundTrip[(a: Float)]
+  roundTrip[(a: Double)]
+  roundTrip[(a: Option[Decimal[10, 2]])]
+  roundTrip[(a: Option[Binary])]
+  roundTrip[(a: Option[Timestamp])]
+  roundTrip[(a: Option[Date])]
+  roundTrip[(a: Option[Int])]
+  roundTrip[(a: Option[Seq[Int]])]
+  roundTrip[(a: Option[Seq[Option[(c: Int, d: Int)]]])]
+  roundTrip[(a: Option[Seq[Option[String]]])]
+  roundTrip[(a: Option[Map[Int, Int]])]
+  roundTrip[(a: Option[(b: Long, c: Option[String])])]
+
+  test("skips unsupported types") {
+    val schema =
+      StructType(Seq(StructField("valid", IntegerType, false), StructField("invalid", NullType, true)))
+    val approx = StructTypeToCodec(schema)
+    assert(!approx.isExact)
+    assert(approx.codec == Codec.unsafeNamedTuple(Seq(Field("valid", Codec.Int))))
+  }
+
+  test("skips array with unsupported element type") {
+    val schema = StructType(Seq(StructField("invalid_array", ArrayType(NullType), false)))
+    val approx = StructTypeToCodec(schema)
+    assert(!approx.isExact)
+    assert(approx.codec == Codec.unsafeNamedTuple(Seq.empty))
+  }
+
+  test("skips map with unsupported key type") {
+    val schema = StructType(Seq(StructField("invalid_map", MapType(NullType, IntegerType), false)))
+    val approx = StructTypeToCodec(schema)
+    assert(!approx.isExact)
+    assert(approx.codec == Codec.unsafeNamedTuple(Seq.empty))
+  }
+
+  test("skips map with unsupported value type") {
+    val schema = StructType(Seq(StructField("invalid_map", MapType(IntegerType, NullType), false)))
+    val approx = StructTypeToCodec(schema)
+    assert(!approx.isExact)
+    assert(approx.codec == Codec.unsafeNamedTuple(Seq.empty))
+  }
+}

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -1,15 +1,10 @@
 package com.choreograph.tyda.sql
-
-import scala.NamedTuple.AnyNamedTuple
 import scala.collection.mutable
-import scala.deriving.Mirror
 import scala.reflect.ClassTag
 
 import shapeless3.deriving.Complete
 import shapeless3.deriving.K0
 import shapeless3.deriving.Labelling
-import shapeless3.deriving.internals.ErasedProductInstances1
-import shapeless3.deriving.internals.ErasedProductInstancesN
 
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.CompiledAggregateExpr
@@ -30,6 +25,7 @@ import com.choreograph.tyda.functions.lit
 import com.choreograph.tyda.rewrite.ArrayCodec
 import com.choreograph.tyda.rewrite.Nullable
 import com.choreograph.tyda.rewrite.StructFields
+import com.choreograph.tyda.rewrite.unflatten
 import com.choreograph.tyda.shapeless3extras.mapConst
 import com.choreograph.tyda.shapeless3extras.toTuple
 import com.choreograph.tyda.shapeless3extras.tupleInstances
@@ -611,28 +607,6 @@ private object SelectBuilder {
     case Empty[T]() extends FinalSelect[T]
   }
 
-  private def getFields(c: Codec[?]): Seq[Field[?]] =
-    c match {
-      case Codec.Product(_, fields, _) => fields.mapConst[Field[?]]([t] => identity(_))
-      case s @ Codec.Sum(_) => s.reprFields
-      case other => Seq(Field("value", other))
-    }
-
-  // This can be seens as a codec for NamedTuple.Concat[NamedTuple.From[P], NamedTuple.From[T]]
-  private def combinedFlatCodec[P: Codec, T: Codec]: Codec[?] = {
-    val fields = getFields(Codec[P]) ++ getFields(Codec[T])
-    assert(fields.map(_.name).distinct.size == fields.size, "Field names in combined codec must be unique")
-    val tag: ClassTag[AnyNamedTuple] = Codec.tupleClassTag(fields.size)
-    // TYPE SAFETY: NamedTuples mirror is just a Tuple mirror with different refinements
-    val mirror = new scala.runtime.TupleMirror(fields.size).asInstanceOf[Mirror.ProductOf[AnyNamedTuple]]
-    val labelling = Labelling[AnyNamedTuple](s"Tuple${fields.size}", fields.map(_.name).toIndexedSeq)
-    val instances: K0.ProductInstances[Codec, AnyNamedTuple] = fields.size match {
-      case 1 => new ErasedProductInstances1(mirror, () => fields.head.codec)
-      case _ => new ErasedProductInstancesN(mirror, () => fields.toArray.map(_.codec: Any))
-    }
-    Codec.product(using tag, mirror, labelling, instances)
-  }
-
   def empty[T](codec: Codec[T], args: UnparserArgs): Result[SelectBuilder[T, T]] =
     TypedFrom
       .dummy(codec, args)
@@ -649,26 +623,9 @@ private object SelectBuilder {
       modelCodec: Codec[T],
       args: UnparserArgs
   ): SelectBuilder[?, (P, T)] = {
-    val arg = ExprNode.Reference(codec = combinedFlatCodec(using partitionCodec, modelCodec))
-    def fields[C](codec: Codec[C]): ExprNode[C] =
-      codec match {
-        case codec @ (Codec.Product(_, _, _) | Codec.Sum(_, _)) =>
-          val fieldsExprs = getFields(codec).map(f => ExprNode.Select(arg, f.name))
-          def product[I](prod: Codec.Product[I]) =
-            ExprNode.MakeProduct(
-              // TYPE SAFETY: Each element in fieldsExprs has type ExprNode[?]
-              values = Tuple.fromArray(fieldsExprs.toArray).asInstanceOf[Tuple.Map[Tuple, ExprNode]],
-              codec = prod
-            )
-          codec match {
-            case prod @ Codec.Product(_, _, _) => product(prod)
-            case sum @ Codec.Sum(_, _) => ExprNode.FromRepr(product(sum.reprCodec), sum)
-          }
-        case _ => ExprNode.Select(arg, "value")
-      }
-    val from = TypedFrom.named(name, arg)
-    val select = CompiledExpr(arg, ExprNode.makeTuple[(P, T)]((fields(partitionCodec), fields(modelCodec))))
-    SelectBuilder(args = args, from = from, select = select)
+    val makeTuple = unflatten(partitionCodec, modelCodec)
+    val from = TypedFrom.named(name, makeTuple.arg)
+    SelectBuilder(args = args, from = from, select = makeTuple)
   }
 
   private def combinePredicates[T](

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetReadBigQueryTableSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetReadBigQueryTableSuite.scala
@@ -1,13 +1,19 @@
 package com.choreograph.tyda.testsuites
 
+import scala.NamedTuple.NamedTuple
+
 import org.scalatest.funsuite.AnyFunSuite
 
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.TableLocation
 import com.choreograph.tyda.aggregates.count
+import com.choreograph.tyda.aggregates.countIf
 
 object DatasetReadBigQueryTableSuite {
   final case class UtilityUs(region_code: Option[String])
+  final case class Extras(extra1: Option[Int])
+
+  type UtilityUsWithExtras = NamedTuple.Concat[NamedTuple.From[UtilityUs], NamedTuple.From[Extras]]
 }
 
 abstract class DatasetReadBigQueryTableSuite extends DatasetSuite {
@@ -24,6 +30,23 @@ abstract class DatasetReadBigQueryTableSuite extends DatasetSuite {
       .aggregate(count)
     implementation.collect(ds) match {
       case Seq(Some(count)) => assert(count > 50)
+      case Seq(None) => fail("Expected a count, but got None")
+      case Seq() => fail("Expected a count, but got an empty sequence")
+    }
+  }
+
+  test("read bigquery table with extra optional fields") {
+    BigQueryIntegrationTestEnvVariables.skipIfProjectNotSet()
+
+    val ds = Dataset
+      .readTable[UtilityUsWithExtras, EmptyTuple](
+        "bigquery-public-data.utility_us.us_states_area",
+        TableLocation.BigQuery
+      )
+      .select(_._1)
+      .aggregate(r => (count = count(r), extra = countIf(r.extra1.isEmpty)))
+    implementation.collect(ds) match {
+      case Seq(Some((total, extraNone))) => assert(total == extraNone)
       case Seq(None) => fail("Expected a count, but got None")
       case Seq() => fail("Expected a count, but got an empty sequence")
     }

--- a/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
@@ -508,6 +508,15 @@ object Dataset {
       private[tyda] def transformUp(f: [t] => Dataset[t] => StopOrContinue[Dataset[t]]): Action =
         datasetApi.transformUp(action, f)
 
+      /** Transform the all expression trees from the bottom up.
+        *
+        * For details see
+        * [[com.choreograph.tyda.TreeApi.transformAccumulateDown]]
+        */
+      private[tyda] def transformAccumulateDown[Acc](initial: Acc)(
+          f: [t] => (Acc, Dataset[t]) => Control[(Acc, Dataset[t])]
+      ): (Acc, Action) = datasetApi.transformAccumulateDown(initial, action)(f)
+
       /** Transform the all expression trees from the top down.
         *
         * For details see [[com.choreograph.tyda.TreeApi.transformDown]]
@@ -991,6 +1000,15 @@ object Dataset {
       */
     private[tyda] def transformDown(f: [t] => Dataset[t] => Control[Dataset[t]]): Dataset[T] =
       api.transformDown(ds, f)
+
+      /** Transform the all expression trees from the bottom up.
+        *
+        * For details see
+        * [[com.choreograph.tyda.TreeApi.transformAccumulateDown]]
+        */
+    private[tyda] def transformAccumulateDown[Acc](initial: Acc)(
+        f: [t] => (Acc, Dataset[t]) => Control[(Acc, Dataset[t])]
+    ): (Acc, Dataset[T]) = api.transformAccumulateDown(initial, ds)(f)
 
     /** Check if any node in the dataset tree satisfies the predicate `f`.
       *


### PR DESCRIPTION
When reading parquet we allowed provided Spark with a read schema which
allows Spark to do type coercion and replace missing nullable fields
with nulls (which is needed to making adding nullable fields backwards
compatible). The problem is that when reading a BigQuery table we are not
allowed to supply a schema and we therefore got different semantics.

This patch aims to solve this by adding the coercion at the expr level
instead so that we can have the same logic shared across different
backends. To make this possible we approximate a Codec from the external
schema and then use that to construct a coercion from the actual schema.
