### PR TITLE
Type the nulls in empty products un ExprUnparser

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -42,6 +42,10 @@ Disallowed.methods = [
   {
     "symbol": "com.google.common.io.Resources.getResource",
     "message": "Instead of getResource please use com.choreograph.superspine.connectors.GetResource"
+  },
+  {
+    "symbol": "com.choreograph.tyda.sql.ast.SqlExpr.LiteralNull"
+    "message": "Untyped nulls commonly leads to bugs, use com.choreograph.tyda.sql.typedNull helper instead"
   }
 ]
 

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -989,11 +989,11 @@ private def literalToSqlExpr[T](value: T, codec: Codec.Primitive[T], dialect: Sq
   }
 }
 
-def typedNull(tpe: DdlType): SqlExpr =
+private def typedNull(tpe: DdlType): SqlExpr =
   // We use scalafix to force use of this helper when creating nulls.
   SqlExpr.Cast(SqlExpr.LiteralNull, tpe) // scalafix:ok Disallowed.Method
 
-def emptyProductFieldNull(dialect: SqlDialect): SqlExpr =
+private def emptyProductFieldNull(dialect: SqlDialect): SqlExpr =
   typedNull(DdlType.Primitive(dialect.ddl.emptyStructFieldType))
 
 /** Generate a dummy value for the given codec. This is used to create a empty

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -557,7 +557,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
                 )
             }
         }
-      case ExprNode.None(_) => Right(cast(SqlExpr.LiteralNull, expr.codec, dialect))
+      case ExprNode.None(_) => Right(typedNull(ToDdl.toDdlType(expr.codec, dialect.ddl)))
       case ExprNode.ToJson(value) =>
         val hasNestedArray = Codec
           .iterate(value.codec)
@@ -989,8 +989,12 @@ private def literalToSqlExpr[T](value: T, codec: Codec.Primitive[T], dialect: Sq
   }
 }
 
+def typedNull(tpe: DdlType): SqlExpr =
+  // We use scalafix to force use of this helper when creating nulls.
+  SqlExpr.Cast(SqlExpr.LiteralNull, tpe) // scalafix:ok Disallowed.Method
+
 def emptyProductFieldNull(dialect: SqlDialect): SqlExpr =
-  SqlExpr.Cast(SqlExpr.LiteralNull, DdlType.Primitive(dialect.ddl.emptyStructFieldType))
+  typedNull(DdlType.Primitive(dialect.ddl.emptyStructFieldType))
 
 /** Generate a dummy value for the given codec. This is used to create a empty
   * relation with the correct schema.

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -803,7 +803,7 @@ private def makeStruct(names: Seq[String], fields: Seq[SqlExpr], dialect: SqlDia
       if names.length == 0 then {
         // Empty structs are generally poorly supported, so we create a dummy fields instead
         // In the long run we should probably disallow codec for empty structs.
-        SqlExpr.Function(name, Seq(SqlExpr.LiteralString(Forbidden.column), SqlExpr.LiteralNull))
+        SqlExpr.Function(name, Seq(SqlExpr.LiteralString(Forbidden.column), emptyProductFieldNull(dialect)))
       } else {
         val nameExprs = names.map(n => SqlExpr.LiteralString(n))
         val args = nameExprs.zip(fields).flatMap { case (n, e) => Seq(n, e) }
@@ -813,7 +813,7 @@ private def makeStruct(names: Seq[String], fields: Seq[SqlExpr], dialect: SqlDia
       if names.length == 0 then {
         // Empty structs are generally poorly supported, so we create a dummy fields instead
         // In the long run we should probably disallow codec for empty structs.
-        SqlExpr.Function(name, Seq(SqlExpr.As(SqlExpr.LiteralNull, Forbidden.column)))
+        SqlExpr.Function(name, Seq(SqlExpr.As(emptyProductFieldNull(dialect), Forbidden.column)))
       } else {
         val args = fields.zip(names).map { case (e, n) => SqlExpr.As(e, n) }
         SqlExpr.Function(name, args)
@@ -938,7 +938,7 @@ private def literalProductToFields[T](
       (acc, f, elem) => acc :+ exprToSqlExpr(ExprNode.Literal.create(elem, f.codec), args)
     )
     .sequence
-    .map(NonEmpty.from(_).getOrElse(NonEmpty(SqlExpr.LiteralNull)))
+    .map(NonEmpty.from(_).getOrElse(NonEmpty(emptyProductFieldNull(args.dialect))))
 
 private def literalToSqlExpr[T](value: T, codec: Codec.Primitive[T], dialect: SqlDialect): SqlExpr = {
   def floatingPoint(value: Double, sqlType: DdlType, isFinite: Boolean): SqlExpr =
@@ -989,6 +989,9 @@ private def literalToSqlExpr[T](value: T, codec: Codec.Primitive[T], dialect: Sq
   }
 }
 
+def emptyProductFieldNull(dialect: SqlDialect): SqlExpr =
+  SqlExpr.Cast(SqlExpr.LiteralNull, DdlType.Primitive(dialect.ddl.emptyStructFieldType))
+
 /** Generate a dummy value for the given codec. This is used to create a empty
   * relation with the correct schema.
   *
@@ -1000,7 +1003,8 @@ private def dummyValue[T](
     args: UnparserArgs
 ): Result[(NonEmpty[Seq[SqlExpr]], NonEmpty[Seq[String]])] =
   codec match {
-    case Codec.Product(_, _, Some(_)) => Right((NonEmpty(SqlExpr.LiteralNull), NonEmpty(Forbidden.column)))
+    case Codec.Product(_, _, Some(_)) =>
+      Right((NonEmpty(emptyProductFieldNull(args.dialect)), NonEmpty(Forbidden.column)))
     case Codec.Product(_, fields, _) =>
       val names = NonEmpty.from(fields.mapConst[String]([t] => _.name))
       fields

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -541,7 +541,7 @@ private final case class SelectBuilder[T, R](
             SqlExpr.As(SqlExpr.Case(Seq((condition = nonEmpty, result = sqlAgg))), "value")
           )
           .map(NonEmpty[Seq](_))
-      case FinalSelect.Empty() => Right(NonEmpty[Seq](SqlExpr.LiteralNull))
+      case FinalSelect.Empty() => Right(NonEmpty[Seq](emptyProductFieldNull(args.dialect)))
     }
     for {
       select <- maybeSelect

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
@@ -13,7 +13,7 @@ private[sql] enum SqlExpr {
   case LiteralByteEscapeString(value: Array[Byte])
   case LiteralNumeric(value: String)
   case LiteralBool(value: Boolean)
-  case LiteralNull
+  case LiteralNull // scalafix:ok Disallowed.Method
   case UnaryOp(op: String, expr: SqlExpr, isPrefix: Boolean)
   case Case(whens: Seq[(condition: SqlExpr, result: SqlExpr)], elseExpr: Option[SqlExpr] = None)
   case Cast(variant: String, expr: SqlExpr, to: DdlType)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
@@ -60,7 +60,7 @@ private[tyda] final case class SqlWriter(writer: Writer) {
         write("'")
       case SqlExpr.LiteralNumeric(value) => write(value)
       case SqlExpr.LiteralBool(value) => if value then write("TRUE") else write("FALSE")
-      case SqlExpr.LiteralNull => write("NULL")
+      case SqlExpr.LiteralNull => write("NULL") // scalafix:ok Disallowed.Method
       case SqlExpr.Case(whens, elseExpr) =>
         write("CASE")
         whens.foreach { case (cond, result) => writeSql" WHEN $cond THEN $result" }

--- a/tyda-sql/src/test/resources/golden/DatasetJoinBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetJoinBigQueryGoldenSuite.golden
@@ -83,7 +83,7 @@ SELECT struct(t1._1 AS _1, t1._2 AS _2) AS _1, t0.value AS _2 FROM t1 LEFT JOIN 
 ------ end
 
 ------ Test: leftOuterJoin singleton
-SELECT t1.value AS _1, t0.value AS _2 FROM t1 LEFT JOIN (SELECT struct(NULL AS `the cake is a lie 🎂`) AS value FROM t2) AS t0 ON TRUE
+SELECT t1.value AS _1, t0.value AS _2 FROM t1 LEFT JOIN (SELECT struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) AS value FROM t2) AS t0 ON TRUE
 ------ end
 
 ------ Test: pair fullOuterJoin

--- a/tyda-sql/src/test/resources/golden/DatasetJoinSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetJoinSparkSqlGoldenSuite.golden
@@ -83,7 +83,7 @@ SELECT named_struct('_1', t1._1, '_2', t1._2) AS _1, t0.value AS _2 FROM t1 LEFT
 ------ end
 
 ------ Test: leftOuterJoin singleton
-SELECT t1.value AS _1, t0.value AS _2 FROM t1 LEFT JOIN (SELECT named_struct('the cake is a lie 🎂', NULL) AS value FROM t2) AS t0 ON TRUE
+SELECT t1.value AS _1, t0.value AS _2 FROM t1 LEFT JOIN (SELECT named_struct('the cake is a lie 🎂', CAST(NULL AS void)) AS value FROM t2) AS t0 ON TRUE
 ------ end
 
 ------ Test: pair fullOuterJoin

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -107,11 +107,11 @@ SELECT t1.a AS a, t1.b AS b, t1.c AS c FROM t1
 ------ end
 
 ------ Test: apply to empty named tuple inside struct
-SELECT struct(NULL AS `the cake is a lie 🎂`) AS empty FROM t1
+SELECT struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) AS empty FROM t1
 ------ end
 
 ------ Test: apply to empty tuple inside struct
-SELECT struct(NULL AS `the cake is a lie 🎂`) AS empty FROM t1
+SELECT struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) AS empty FROM t1
 ------ end
 
 ------ Test: apply to named tuple
@@ -175,7 +175,7 @@ SELECT coalesce(struct(t1.i AS i), CAST(error('Failed to invert asBase') AS STRU
 ------ end
 
 ------ Test: asBase inverts asCase for enum singleton case
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: asBase inverts asCase for sealed trait product case
@@ -183,11 +183,11 @@ SELECT coalesce(struct(t1.i AS i), CAST(error('Failed to invert asBase') AS STRU
 ------ end
 
 ------ Test: asBase inverts asCase for sealed trait singleton case
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: asBase inverts asCase for string enum singleton case
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: asCase from enum to product case
@@ -195,7 +195,7 @@ SELECT t1.c AS value FROM t1
 ------ end
 
 ------ Test: asCase from enum to singleton case
-SELECT CASE WHEN (t1.discriminant = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END AS value FROM t1
+SELECT CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END AS value FROM t1
 ------ end
 
 ------ Test: asCase from sealed trait to product case
@@ -203,11 +203,11 @@ SELECT t1.b AS value FROM t1
 ------ end
 
 ------ Test: asCase from sealed trait to singleton case
-SELECT CASE WHEN (t1.discriminant = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END AS value FROM t1
+SELECT CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END AS value FROM t1
 ------ end
 
 ------ Test: asCase from string enum to singleton case
-SELECT CASE WHEN (t1.value = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END AS value FROM t1
+SELECT CASE WHEN (t1.value = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for enum product case
@@ -215,7 +215,7 @@ SELECT CASE WHEN (t1.c IS NOT NULL) THEN struct('c' AS discriminant, t1.c AS c, 
 ------ end
 
 ------ Test: asCase inverts asBase for enum singleton case
-SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN struct('a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d) END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN struct('a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for sealed trait product case
@@ -223,15 +223,15 @@ SELECT CASE WHEN (t1.b IS NOT NULL) THEN struct('b' AS discriminant, t1.b AS b) 
 ------ end
 
 ------ Test: asCase inverts asBase for sealed trait singleton case
-SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN struct('a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS b) END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN struct('a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS b) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for string enum singleton case
-SELECT CASE WHEN (CASE WHEN (t1.value = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN 'a' END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.value = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN 'a' END AS value FROM t1
 ------ end
 
 ------ Test: asCase: in option map
-SELECT CASE WHEN (t1.value IS NOT NULL) THEN struct(CASE WHEN (t1.value.discriminant = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END AS value) END AS value FROM t1
+SELECT CASE WHEN (t1.value IS NOT NULL) THEN struct(CASE WHEN (t1.value.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END AS value) END AS value FROM t1
 ------ end
 
 ------ Test: asCase: select from product case
@@ -447,7 +447,7 @@ SELECT '' AS value FROM t1
 ------ end
 
 ------ Test: create literal () scala.Tuple$package.EmptyTuple.type
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: create literal (a,1) scala.NamedTuple.NamedTuple[scala.Tuple2["a", "b"], scala.Tuple2[scala.Predef.String, scala.Int]]
@@ -554,6 +554,10 @@ SELECT CAST(NULL AS BIGINT) AS value FROM t1
 SELECT CAST(NULL AS STRUCT<a INT,b STRING,c BOOLEAN>) AS value FROM t1
 ------ end
 
+------ Test: create literal None scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum.A]
+SELECT CAST(NULL AS STRUCT<`the cake is a lie 🎂` BOOL>) AS value FROM t1
+------ end
+
 ------ Test: create literal None scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum]
 SELECT CAST(NULL AS STRUCT<discriminant STRING,c STRUCT<i INT>,d STRUCT<i INT>>) AS value FROM t1
 ------ end
@@ -619,11 +623,11 @@ SELECT CAST(1 AS INT) AS a, 'a' AS b, FALSE AS c FROM t1
 ------ end
 
 ------ Test: create literal WithEmptyTuple(()) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithEmptyTuple
-SELECT struct(NULL AS `the cake is a lie 🎂`) AS empty FROM t1
+SELECT struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) AS empty FROM t1
 ------ end
 
 ------ Test: create literal WithNamedTupleEmpty(()) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithNamedTupleEmpty
-SELECT struct(NULL AS `the cake is a lie 🎂`) AS empty FROM t1
+SELECT struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) AS empty FROM t1
 ------ end
 
 ------ Test: create literal false scala.Boolean
@@ -775,7 +779,7 @@ SELECT ['\b', '', '\n', '\r', '\t', '', '\'', '\\', '"', '`', '${var}'] AS val
 ------ end
 
 ------ Test: identity enum singleton
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: identity primitive
@@ -783,11 +787,11 @@ SELECT t1.value AS value FROM t1
 ------ end
 
 ------ Test: identity sealed trait singleton
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: identity string enum singleton
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: identity tuple
@@ -895,7 +899,7 @@ SELECT CAST(CAST([] AS ARRAY<STRUCT<_1 INT,_2 STRING>>) AS ARRAY<STRUCT<key INT,
 ------ end
 
 ------ Test: make empty namedTuple
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: make empty seq
@@ -903,7 +907,7 @@ SELECT CAST([] AS ARRAY<INT>) AS value FROM t1
 ------ end
 
 ------ Test: make empty tuple
-SELECT NULL FROM t1
+SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: make map
@@ -1015,11 +1019,11 @@ SELECT (SELECT c2.value FROM unnest(CASE WHEN (array_length([struct(t1._1 AS _1,
 ------ end
 
 ------ Test: match-case all cases sealed trait
-SELECT CASE WHEN (t1.b IS NOT NULL) THEN t1.b.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(error('Unknown case') AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.b IS NOT NULL) THEN t1.b.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(error('Unknown case') AS INT) END AS value FROM t1
 ------ end
 
 ------ Test: match-case all cases string enum
-SELECT CASE WHEN (CASE WHEN (t1.value = 'b') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN 'B' WHEN (CASE WHEN (t1.value = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN 'A' ELSE CAST(error('Unknown case') AS STRING) END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.value = 'b') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN 'B' WHEN (CASE WHEN (t1.value = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN 'A' ELSE CAST(error('Unknown case') AS STRING) END AS value FROM t1
 ------ end
 
 ------ Test: match-case only otherwise
@@ -1027,11 +1031,11 @@ SELECT CAST(99 AS INT) AS value FROM t1
 ------ end
 
 ------ Test: match-case only when cases
-SELECT CASE WHEN (t1.d IS NOT NULL) THEN t1.d.i WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'b') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(2 AS INT) WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(error('Unknown case') AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.d IS NOT NULL) THEN t1.d.i WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'b') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(2 AS INT) WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(error('Unknown case') AS INT) END AS value FROM t1
 ------ end
 
 ------ Test: match-case when cases + otherwise
-SELECT CASE WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(NULL AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(99 AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(99 AS INT) END AS value FROM t1
 ------ end
 
 ------ Test: max

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -107,11 +107,11 @@ SELECT t1.a AS a, t1.b AS b, t1.c AS c FROM t1
 ------ end
 
 ------ Test: apply to empty named tuple inside struct
-SELECT named_struct('the cake is a lie 🎂', NULL) AS empty FROM t1
+SELECT named_struct('the cake is a lie 🎂', CAST(NULL AS void)) AS empty FROM t1
 ------ end
 
 ------ Test: apply to empty tuple inside struct
-SELECT named_struct('the cake is a lie 🎂', NULL) AS empty FROM t1
+SELECT named_struct('the cake is a lie 🎂', CAST(NULL AS void)) AS empty FROM t1
 ------ end
 
 ------ Test: apply to named tuple
@@ -175,7 +175,7 @@ SELECT coalesce(named_struct('i', t1.i), CAST(raise_error('Failed to invert asBa
 ------ end
 
 ------ Test: asBase inverts asCase for enum singleton case
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: asBase inverts asCase for sealed trait product case
@@ -183,11 +183,11 @@ SELECT coalesce(named_struct('i', t1.i), CAST(raise_error('Failed to invert asBa
 ------ end
 
 ------ Test: asBase inverts asCase for sealed trait singleton case
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: asBase inverts asCase for string enum singleton case
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: asCase from enum to product case
@@ -195,7 +195,7 @@ SELECT t1.c AS value FROM t1
 ------ end
 
 ------ Test: asCase from enum to singleton case
-SELECT CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END AS value FROM t1
+SELECT CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END AS value FROM t1
 ------ end
 
 ------ Test: asCase from sealed trait to product case
@@ -203,11 +203,11 @@ SELECT t1.b AS value FROM t1
 ------ end
 
 ------ Test: asCase from sealed trait to singleton case
-SELECT CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END AS value FROM t1
+SELECT CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END AS value FROM t1
 ------ end
 
 ------ Test: asCase from string enum to singleton case
-SELECT CASE WHEN (t1.value = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END AS value FROM t1
+SELECT CASE WHEN (t1.value = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for enum product case
@@ -215,7 +215,7 @@ SELECT CASE WHEN (t1.c IS NOT NULL) THEN named_struct('discriminant', 'c', 'c', 
 ------ end
 
 ------ Test: asCase inverts asBase for enum singleton case
-SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN named_struct('discriminant', 'a', 'c', CAST(NULL AS STRUCT<i INT NOT NULL>), 'd', CAST(NULL AS STRUCT<i INT NOT NULL>)) END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN named_struct('discriminant', 'a', 'c', CAST(NULL AS STRUCT<i INT NOT NULL>), 'd', CAST(NULL AS STRUCT<i INT NOT NULL>)) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for sealed trait product case
@@ -223,15 +223,15 @@ SELECT CASE WHEN (t1.b IS NOT NULL) THEN named_struct('discriminant', 'b', 'b', 
 ------ end
 
 ------ Test: asCase inverts asBase for sealed trait singleton case
-SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN named_struct('discriminant', 'a', 'b', CAST(NULL AS STRUCT<i INT NOT NULL>)) END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN named_struct('discriminant', 'a', 'b', CAST(NULL AS STRUCT<i INT NOT NULL>)) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for string enum singleton case
-SELECT CASE WHEN (CASE WHEN (t1.value = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN 'a' END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.value = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN 'a' END AS value FROM t1
 ------ end
 
 ------ Test: asCase: in option map
-SELECT CASE WHEN (t1.value IS NOT NULL) THEN named_struct('value', CASE WHEN (t1.value.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END) END AS value FROM t1
+SELECT CASE WHEN (t1.value IS NOT NULL) THEN named_struct('value', CASE WHEN (t1.value.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END) END AS value FROM t1
 ------ end
 
 ------ Test: asCase: select from product case
@@ -447,7 +447,7 @@ SELECT '' AS value FROM t1
 ------ end
 
 ------ Test: create literal () scala.Tuple$package.EmptyTuple.type
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: create literal (a,1) scala.NamedTuple.NamedTuple[scala.Tuple2["a", "b"], scala.Tuple2[scala.Predef.String, scala.Int]]
@@ -554,6 +554,10 @@ SELECT CAST(NULL AS BIGINT) AS value FROM t1
 SELECT CAST(NULL AS STRUCT<a INT NOT NULL,b STRING NOT NULL,c BOOLEAN NOT NULL>) AS value FROM t1
 ------ end
 
+------ Test: create literal None scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum.A]
+SELECT CAST(NULL AS STRUCT<`the cake is a lie 🎂` void>) AS value FROM t1
+------ end
+
 ------ Test: create literal None scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum]
 SELECT CAST(NULL AS STRUCT<discriminant STRING NOT NULL,c STRUCT<i INT NOT NULL>,d STRUCT<i INT NOT NULL>>) AS value FROM t1
 ------ end
@@ -619,11 +623,11 @@ SELECT CAST(1 AS INT) AS a, 'a' AS b, FALSE AS c FROM t1
 ------ end
 
 ------ Test: create literal WithEmptyTuple(()) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithEmptyTuple
-SELECT named_struct('the cake is a lie 🎂', NULL) AS empty FROM t1
+SELECT named_struct('the cake is a lie 🎂', CAST(NULL AS void)) AS empty FROM t1
 ------ end
 
 ------ Test: create literal WithNamedTupleEmpty(()) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithNamedTupleEmpty
-SELECT named_struct('the cake is a lie 🎂', NULL) AS empty FROM t1
+SELECT named_struct('the cake is a lie 🎂', CAST(NULL AS void)) AS empty FROM t1
 ------ end
 
 ------ Test: create literal false scala.Boolean
@@ -775,7 +779,7 @@ SELECT array('\b', '', '\n', '\r', '\t', '', '\'', '\\', '"', '`', '${var}') A
 ------ end
 
 ------ Test: identity enum singleton
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: identity primitive
@@ -783,11 +787,11 @@ SELECT t1.value AS value FROM t1
 ------ end
 
 ------ Test: identity sealed trait singleton
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: identity string enum singleton
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: identity tuple
@@ -895,7 +899,7 @@ SELECT map_from_entries(CAST(array() AS ARRAY<STRUCT<_1 INT NOT NULL,_2 STRING N
 ------ end
 
 ------ Test: make empty namedTuple
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: make empty seq
@@ -903,7 +907,7 @@ SELECT CAST(array() AS ARRAY<INT>) AS value FROM t1
 ------ end
 
 ------ Test: make empty tuple
-SELECT NULL FROM t1
+SELECT CAST(NULL AS void) FROM t1
 ------ end
 
 ------ Test: make map
@@ -1015,11 +1019,11 @@ SELECT element_at(map_from_entries(array(named_struct('_1', t1._1, '_2', t1._2))
 ------ end
 
 ------ Test: match-case all cases sealed trait
-SELECT CASE WHEN (t1.b IS NOT NULL) THEN t1.b.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(raise_error('Unknown case') AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.b IS NOT NULL) THEN t1.b.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(raise_error('Unknown case') AS INT) END AS value FROM t1
 ------ end
 
 ------ Test: match-case all cases string enum
-SELECT CASE WHEN (CASE WHEN (t1.value = 'b') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN 'B' WHEN (CASE WHEN (t1.value = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN 'A' ELSE CAST(raise_error('Unknown case') AS STRING) END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.value = 'b') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN 'B' WHEN (CASE WHEN (t1.value = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN 'A' ELSE CAST(raise_error('Unknown case') AS STRING) END AS value FROM t1
 ------ end
 
 ------ Test: match-case only otherwise
@@ -1027,11 +1031,11 @@ SELECT CAST(99 AS INT) AS value FROM t1
 ------ end
 
 ------ Test: match-case only when cases
-SELECT CASE WHEN (t1.d IS NOT NULL) THEN t1.d.i WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'b') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN CAST(2 AS INT) WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(raise_error('Unknown case') AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.d IS NOT NULL) THEN t1.d.i WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'b') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN CAST(2 AS INT) WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(raise_error('Unknown case') AS INT) END AS value FROM t1
 ------ end
 
 ------ Test: match-case when cases + otherwise
-SELECT CASE WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', NULL) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(99 AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN named_struct('the cake is a lie 🎂', CAST(NULL AS void)) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(99 AS INT) END AS value FROM t1
 ------ end
 
 ------ Test: max

--- a/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
@@ -95,7 +95,7 @@ SELECT (t0.value = 'second') AS value FROM (SELECT 'first' AS value) AS t0
 ------ end
 
 ------ Test: literal singleton
-SELECT NULL AS `the cake is a lie 🎂`
+SELECT CAST(NULL AS BOOL) AS `the cake is a lie 🎂`
 ------ end
 
 ------ Test: make named struct

--- a/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
@@ -95,7 +95,7 @@ SELECT (t0.value = 'second') AS value FROM VALUES ('first') AS t0(value)
 ------ end
 
 ------ Test: literal singleton
-SELECT NULL FROM VALUES (NULL) AS t0(`the cake is a lie 🎂`)
+SELECT CAST(NULL AS void) FROM VALUES (CAST(NULL AS void)) AS t0(`the cake is a lie 🎂`)
 ------ end
 
 ------ Test: make named struct

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -1136,8 +1136,8 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testTryCast[Decimal[19, 1], Decimal[19, 0]](v => Decimal[19, 0](v.toBigDecimal))
   testTryCast[Decimal[19, 3], Decimal[10, 3]](v => Decimal[10, 3](v.toBigDecimal))
 
-  def testLiteralCreation[T: Codec: TypeName](fixed: T) =
-    testHasSameBehavior[EmptyTuple, T](
+  def testLiteralCreation[T: ClassTag: Arbitrary: Codec: TypeName](fixed: T) =
+    testHasSameBehavior[T, T](
       s"create literal ${fixed.toString} ${TypeName.name[T]}",
       _ => lit(fixed),
       _ => fixed
@@ -1179,6 +1179,7 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testLiteralCreation[Option[Struct]](Some(Struct(1, "a", false)))
   testLiteralCreation[TestEnum](TestEnum.A)
   testLiteralCreation[Option[TestEnum]](None)
+  testLiteralCreation[Option[TestEnum.A.type]](None)
   testLiteralCreation[Option[TestEnum]](Some(TestEnum.C(1)))
   testLiteralCreation[Timestamp](Timestamp.fromMicros(1))
   testLiteralCreation[Timestamp](Timestamp.fromMicros(148600399274030924L))


### PR DESCRIPTION
Without we will generate queries containing code like this for
`Option[? <: Singleton]`
```
SELECT CAST(NULL AS STRUCT<`the cake is a lie 🎂` BOOL>) AS value UNION ALL SELECT struct(NULL AS `the cake is a lie 🎂`) AS value
```
which for BigQuery will fail with
```
Column 1 in UNION ALL has incompatible types: STRUCT<`the cake is a lie 🎂` BOOL>, STRUCT<`the cake is a lie 🎂` INT64> at [1:1018]
```

This patch solves this by adding explicit type information to all such
nulls.
