### PR TITLE
Implement Codec.Transparent wrapper

### DIFF
--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
@@ -90,6 +90,8 @@ object CodecToEncoderSpecBase {
     case A
     case B
   }
+
+  final case class UserId(value: Int) derives Codec.Transparent
   private final case class JavaKeyword(`class`: String) derives Codec, Ord
   private final case class JavaInvalidIdentifiers(`0`: String) derives Codec, Ord
 
@@ -301,4 +303,5 @@ trait CodecToEncoderSpecBase extends AnyFunSuite with SharedSparkSession {
   ))
 
   schemaTest[EnumString](StringType)
+  schemaTest[UserId](StructType(Seq(StructField("value", IntegerType, true))))
 }

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/ToDdlSpec.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/ToDdlSpec.scala
@@ -40,6 +40,8 @@ object ToDdlSpec {
     case B
   }
 
+  final case class TransparentProduct(value: Int) derives Codec.Transparent
+
   final case class Containers(arr: List[Person], map: Map[String, List[Person]], opt: Option[List[Person]])
       derives Codec
 
@@ -393,4 +395,5 @@ class ToDdlSpec extends AnyFunSuite {
   testSparkDdlType[Seq[Int]]("ARRAY<INT>")
   testSparkDdlType[Seq[Option[Int]]]("ARRAY<INT>")
   testSparkDdlType[(value: Int)]("STRUCT<value INT NOT NULL>")
+  testSparkDdlType[ToDdlSpec.TransparentProduct]("INT")
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/Codec.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Codec.scala
@@ -4,6 +4,8 @@ import scala.NamedTuple.AnyNamedTuple
 import scala.NamedTuple.NamedTuple
 import scala.annotation.targetName
 import scala.collection.Factory
+import scala.compiletime.erasedValue
+import scala.compiletime.error
 import scala.deriving.Mirror
 import scala.reflect.ClassTag
 import scala.reflect.classTag
@@ -257,6 +259,49 @@ object Codec {
     def encodedValues: scala.Seq[String] = values.map(s => pascalCaseToCamelCase(s.toString))
     def to: Codec[String] = Codec.String
     def inj: Injection[T, String] = SumAsStringInjection(values, encodedValues)
+  }
+
+  /** A codec for single-field product types that encodes them as the inner
+    * field type directly, removing the struct wrapper.
+    *
+    * It can be used for newtype wrappers where the wrapper should not appear in
+    * the serialized schema.
+    *
+    * ```scala
+    * case class UserId(value: Int) derives Codec.Transparent
+    * ```
+    *
+    * A `UserId` will be encoded as a plain `Int` rather than a
+    * `Struct(value: Int)`.
+    */
+  sealed trait Transparent[T] extends Codec[T]
+
+  object Transparent {
+    private[tyda] final class TransparentInjection[T, F](mirror: Mirror.ProductOf[T])
+        extends Injection[T, F] {
+      def apply(from: T): F = {
+        // TYPE SAFETY: T is a case class with exactly one field of type F, enforced at the inline call site.
+        val product = from.asInstanceOf[scala.Product]
+        // TYPE SAFETY: The single element is of type F per the inline match on MirroredElemTypes.
+        product.productElement(0).asInstanceOf[F]
+      }
+      def invert(to: F): T = mirror.fromProduct(Tuple1(to))
+    }
+
+    private[tyda] final class Impl[T, F](
+        val classTag: ClassTag[T],
+        val to: Codec[F],
+        val inj: Injection[T, F]
+    ) extends Transparent[T] with FromInjection[T, F]
+
+    inline def derived[T](using m: Mirror.ProductOf[T]): Transparent[T] =
+      inline erasedValue[m.MirroredElemTypes] match {
+        case _: (f *: EmptyTuple) =>
+          val ct = scala.compiletime.summonInline[ClassTag[T]]
+          val fieldCodec = scala.compiletime.summonInline[Codec[f]]
+          Impl[T, f](ct, fieldCodec, TransparentInjection[T, f](m))
+        case _ => error("Codec.Transparent requires exactly one field")
+      }
   }
 
   /** A codec that encodes an [[Binary]] as a binary type.

--- a/tyda/src/test/scala/com/choreograph/tyda/CodecSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/CodecSpec.scala
@@ -42,6 +42,9 @@ object CodecSpec {
     case Red, Green, Blue
   }
 
+  final case class TransparentInt(eraseMePlease: Int) derives Codec.Transparent
+  final case class TransparentString(value: String) derives Codec.Transparent
+
   enum EnumWithManyCase extends EnumStableHashCode derives Codec {
     case A
     case B(a: Int)
@@ -164,6 +167,57 @@ class CodecSpec extends AnyFunSuite {
   testSumAsInjection[Hierarchy1]
   testSumAsInjection[Color]
   testSumAsInjection[EnumWithManyCase]
+
+  test("Transparent codec should encode single-field case class as inner type") {
+    val codec = Codec[TransparentInt]
+    codec match {
+      case Codec.FromInjection(inj, innerCodec) =>
+        assert(innerCodec == Codec.Int)
+        assert(inj(TransparentInt(42)) == 42)
+        val encoded = inj(TransparentInt(42))
+        assert(inj.invert(encoded) == TransparentInt(42))
+      case _ => fail("Expected a FromInjection codec")
+    }
+  }
+
+  test("Transparent codec should roundtrip correctly") {
+    val codec = Codec[TransparentInt] match {
+      case inj: Codec.FromInjection[TransparentInt, ?] => inj
+      case _ => fail("Expected a FromInjection codec")
+    }
+    val original = TransparentInt(123)
+    assert(codec.inj.invert(codec.inj(original)) == original)
+  }
+
+  test("Transparent codec should work with String field") {
+    val codec = Codec[TransparentString]
+    codec match {
+      case Codec.FromInjection(inj, innerCodec) =>
+        assert(innerCodec == Codec.String)
+        assert(inj(TransparentString("hello")) == "hello")
+        val encoded = inj(TransparentString("hello"))
+        assert(inj.invert(encoded) == TransparentString("hello"))
+      case _ => fail("Expected a FromInjection codec")
+    }
+  }
+
+  test("Transparent codec should work with named tuple") {
+    Codec.Transparent.derived[(name: String)] match {
+      case Codec.FromInjection(inj, innerCodec) =>
+        assert(innerCodec == Codec.String)
+        val value = (name = "hello")
+        assert(inj(value) == "hello")
+        val encoded = inj(value)
+        assert(inj.invert(encoded) == value)
+    }
+  }
+
+  test("Transparent codec should not compile for multi-field case class") {
+    assertCompileTimeError(
+      """case class Pair(a: Int, b: Int) derives Codec.Transparent""",
+      "Codec.Transparent requires exactly one field"
+    )
+  }
 
   test("allow adding Option parameters to singletons") {
     def inj[T: Codec]: Injection[T, ?] = {


### PR DESCRIPTION
This implements a Codec for product types with a single field where the encoded type should not contain the field. 

This is inspired by the container attribute in rust's serde library: https://serde.rs/container-attrs.html#transparent

