### PR TITLE
Add more tuple operations to ExprApi

### DIFF
--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -635,7 +635,7 @@ SELECT FALSE AS value FROM t1
 ------ end
 
 ------ Test: derive type WithoutStrings
-SELECT t1.b AS b, struct(t1.c.e AS e) AS c FROM t1
+SELECT t1.b AS b, struct(t1.c.e AS e) AS c, t1.f AS f, t1.g AS g, t1.i AS i, t1.j AS j, t1.p AS p, t1.q AS q, struct(t1.l.n AS n, t1.l.o AS o) AS l FROM t1
 ------ end
 
 ------ Test: distinct on Seq[Int]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -634,6 +634,10 @@ SELECT struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) AS empty FROM t1
 SELECT FALSE AS value FROM t1
 ------ end
 
+------ Test: derive type WithoutStrings
+SELECT t1.b AS b, struct(t1.c.e AS e) AS c FROM t1
+------ end
+
 ------ Test: distinct on Seq[Int]
 SELECT array((SELECT DISTINCT c0 FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -635,7 +635,7 @@ SELECT FALSE AS value FROM t1
 ------ end
 
 ------ Test: derive type WithoutStrings
-SELECT t1.b AS b, named_struct('e', t1.c.e) AS c FROM t1
+SELECT t1.b AS b, named_struct('e', t1.c.e) AS c, t1.f AS f, t1.g AS g, t1.i AS i, t1.j AS j, t1.p AS p, t1.q AS q, named_struct('n', t1.l.n, 'o', t1.l.o) AS l FROM t1
 ------ end
 
 ------ Test: distinct on Seq[Int]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -634,6 +634,10 @@ SELECT named_struct('the cake is a lie 🎂', CAST(NULL AS void)) AS empty FROM 
 SELECT FALSE AS value FROM t1
 ------ end
 
+------ Test: derive type WithoutStrings
+SELECT t1.b AS b, named_struct('e', t1.c.e) AS c FROM t1
+------ end
+
 ------ Test: distinct on Seq[Int]
 SELECT array_distinct(t1.value) AS value FROM t1
 ------ end

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -36,7 +36,6 @@ import com.choreograph.tyda.Remover
 import com.choreograph.tyda.Selector
 import com.choreograph.tyda.StringLiterals
 import com.choreograph.tyda.Timestamp
-import com.choreograph.tyda.TupleOperations.EqualSize
 import com.choreograph.tyda.TypeName
 import com.choreograph.tyda.functions.coalesce
 import com.choreograph.tyda.functions.concat
@@ -138,15 +137,11 @@ object ExprEvaluationSuiteBase {
     // TODO: Should be remove all instead of Remove
     given derive[T: Mirror.ProductOf as m](using
         remover: Remover[T, String],
-        mOut: Mirror.ProductOf[remover.Out],
-        recurse: Mapper[WithoutStrings, mOut.MirroredElemTypes],
-        names: StringLiterals[NamedTuple.Names[remover.Out]],
-        sizeEv: EqualSize[recurse.Out, NamedTuple.Names[remover.Out]]
-    ): WithoutStrings.Aux[T, NamedTuple[NamedTuple.Names[remover.Out], recurse.Out]] =
+        recurse: Mapper[WithoutStrings, remover.Out]
+    ): WithoutStrings.Aux[T, recurse.Out] =
       new WithoutStrings[T] {
-        type Out = NamedTuple[NamedTuple.Names[remover.Out], recurse.Out]
-        def apply(e: Expr[T]): Expr[Out] =
-          recurse(e.remove[String].toTuple).withNames[NamedTuple.Names[remover.Out]]
+        type Out = recurse.Out
+        def apply(e: Expr[T]): Expr[Out] = recurse(e.remove[String])
       }
   }
 

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -28,7 +28,9 @@ import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
 import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Expr
+import com.choreograph.tyda.ExprDepFn1
 import com.choreograph.tyda.JsonArrayOrObject
+import com.choreograph.tyda.Mapper
 import com.choreograph.tyda.Ord
 import com.choreograph.tyda.Remover
 import com.choreograph.tyda.Selector
@@ -121,33 +123,9 @@ object ExprEvaluationSuiteBase {
     }
   }
 
-  private trait WithoutStrings[T] {
-    type Out
-    def apply(e: Expr[T]): Expr[Out]
-  }
+  private trait WithoutStrings[T] extends ExprDepFn1[T]
   private object WithoutStrings {
     type Aux[T, Out1] = WithoutStrings[T] { type Out = Out1 }
-
-    trait WithoutStringsTuple[T <: Tuple] {
-      type Out <: Tuple
-      def apply(e: Expr[T]): Expr[Out]
-    }
-    object WithoutStringsTuple {
-      type Aux[T <: Tuple, Out1] = WithoutStringsTuple[T] { type Out = Out1 }
-    }
-    given WithoutStringsTuple.Aux[EmptyTuple, EmptyTuple] =
-      new WithoutStringsTuple[EmptyTuple] {
-        type Out = EmptyTuple
-        def apply(e: Expr[EmptyTuple]): Expr[Out] = e
-      }
-    given [T <: Tuple, H](using
-        removeHead: WithoutStrings[H],
-        removeTail: WithoutStringsTuple[T]
-    ): WithoutStringsTuple.Aux[H *: T, removeHead.Out *: removeTail.Out] =
-      new WithoutStringsTuple[H *: T] {
-        type Out = removeHead.Out *: removeTail.Out
-        def apply(e: Expr[H *: T]): Expr[Out] = removeHead(e.head) *: removeTail(e.tail)
-      }
 
     trait KeepAsIs[T] extends WithoutStrings[T] {
       type Out = T
@@ -161,7 +139,7 @@ object ExprEvaluationSuiteBase {
     given derive[T: Mirror.ProductOf as m](using
         remover: Remover[T, String],
         mOut: Mirror.ProductOf[remover.Out],
-        recurse: WithoutStringsTuple[mOut.MirroredElemTypes],
+        recurse: Mapper[WithoutStrings, mOut.MirroredElemTypes],
         names: StringLiterals[NamedTuple.Names[remover.Out]],
         sizeEv: EqualSize[recurse.Out, NamedTuple.Names[remover.Out]]
     ): WithoutStrings.Aux[T, NamedTuple[NamedTuple.Names[remover.Out], recurse.Out]] =

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -32,7 +32,9 @@ import com.choreograph.tyda.JsonArrayOrObject
 import com.choreograph.tyda.Ord
 import com.choreograph.tyda.Remover
 import com.choreograph.tyda.Selector
+import com.choreograph.tyda.StringLiterals
 import com.choreograph.tyda.Timestamp
+import com.choreograph.tyda.TupleOperations.EqualSize
 import com.choreograph.tyda.TypeName
 import com.choreograph.tyda.functions.coalesce
 import com.choreograph.tyda.functions.concat
@@ -119,6 +121,64 @@ object ExprEvaluationSuiteBase {
     }
   }
 
+  private trait WithoutStrings[T] {
+    type Out
+    def apply(e: Expr[T]): Expr[Out]
+  }
+  private object WithoutStrings {
+    type Aux[T, Out1] = WithoutStrings[T] { type Out = Out1 }
+
+    trait WithoutStringsTuple[T <: Tuple] {
+      type Out <: Tuple
+      def apply(e: Expr[T]): Expr[Out]
+    }
+    object WithoutStringsTuple {
+      type Aux[T <: Tuple, Out1] = WithoutStringsTuple[T] { type Out = Out1 }
+    }
+    given WithoutStringsTuple.Aux[EmptyTuple, EmptyTuple] =
+      new WithoutStringsTuple[EmptyTuple] {
+        type Out = EmptyTuple
+        def apply(e: Expr[EmptyTuple]): Expr[Out] = e
+      }
+    given [T <: Tuple, H](using
+        removeHead: WithoutStrings[H],
+        removeTail: WithoutStringsTuple[T]
+    ): WithoutStringsTuple.Aux[H *: T, removeHead.Out *: removeTail.Out] =
+      new WithoutStringsTuple[H *: T] {
+        type Out = removeHead.Out *: removeTail.Out
+        def apply(e: Expr[H *: T]): Expr[Out] = removeHead(e.head) *: removeTail(e.tail)
+      }
+
+    trait KeepAsIs[T] extends WithoutStrings[T] {
+      type Out = T
+      def apply(e: Expr[T]): Expr[T] = e
+    }
+
+    given KeepAsIs[Int] = new KeepAsIs[Int] {}
+    given KeepAsIs[Long] = new KeepAsIs[Long] {}
+
+    // TODO: Should be remove all instead of Remove
+    given derive[T: Mirror.ProductOf as m](using
+        remover: Remover[T, String],
+        mOut: Mirror.ProductOf[remover.Out],
+        recurse: WithoutStringsTuple[mOut.MirroredElemTypes],
+        names: StringLiterals[NamedTuple.Names[remover.Out]],
+        sizeEv: EqualSize[recurse.Out, NamedTuple.Names[remover.Out]]
+    ): WithoutStrings.Aux[T, NamedTuple[NamedTuple.Names[remover.Out], recurse.Out]] =
+      new WithoutStrings[T] {
+        type Out = NamedTuple[NamedTuple.Names[remover.Out], recurse.Out]
+        def apply(e: Expr[T]): Expr[Out] =
+          recurse(e.remove[String].toTuple).withNames[NamedTuple.Names[remover.Out]]
+      }
+  }
+
+  private final case class HasStrings(a: String, b: Int, c: (d: String, e: Long))
+  private object HasStrings {
+    val removeStrings = WithoutStrings.derive[HasStrings]
+    type Without = removeStrings.Out
+    val a: Without = (b = 1, c = (e = 1L))
+  }
+
   val errorMessage = "My error message"
 }
 
@@ -132,7 +192,7 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   import ExprEvaluationSuiteBase.{
     CustomIntSeq, Full, Projected, Struct, NestedOption, NamedTuple1, NamedTuple2, NamedTupleAlias,
     NamedTupleAliasWithUnused, TestEnum, TestSealedTrait, TestEnumString, WithEmptyTuple, WithNamedTupleEmpty,
-    WithOptionField, TreeBounded, Leaf, Node, errorMessage
+    WithOptionField, TreeBounded, Leaf, Node, errorMessage, HasStrings
   }
 
   /** Evaluate the expression on a sequence of inputs.
@@ -1344,4 +1404,10 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
     )
   }
   testHasSameBehavior[Seq[Int], String]("toJson Seq[Int]", toJson, _.mkString("[", ",", "]"))
+
+  testHasSameBehavior[HasStrings, HasStrings.Without](
+    "derive type WithoutStrings",
+    HasStrings.removeStrings(_),
+    r => (b = r.b, c = (e = r.c.e))
+  )
 }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -172,11 +172,22 @@ object ExprEvaluationSuiteBase {
       }
   }
 
-  private final case class HasStrings(a: String, b: Int, c: (d: String, e: Long))
+  private final case class HasStrings(
+      a: String,
+      b: Int,
+      c: (d: String, e: Long),
+      f: Int,
+      g: Long,
+      i: Int,
+      j: Long,
+      p: Int,
+      q: Long,
+      l: (m: String, n: Int, o: Long)
+  )
   private object HasStrings {
     val removeStrings = WithoutStrings.derive[HasStrings]
     type Without = removeStrings.Out
-    val a: Without = (b = 1, c = (e = 1L))
+    val a: Without = (b = 1, c = (e = 1L), f = 2, g = 3L, i = 4, j = 5L, p = 6, q = 7L, l = (n = 8, o = 9L))
   }
 
   val errorMessage = "My error message"
@@ -1408,6 +1419,17 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testHasSameBehavior[HasStrings, HasStrings.Without](
     "derive type WithoutStrings",
     HasStrings.removeStrings(_),
-    r => (b = r.b, c = (e = r.c.e))
+    r =>
+      (
+        b = r.b,
+        c = (e = r.c.e),
+        f = r.f,
+        g = r.g,
+        i = r.i,
+        j = r.j,
+        p = r.p,
+        q = r.q,
+        l = (n = r.l.n, o = r.l.o)
+      )
   )
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
@@ -969,20 +969,32 @@ trait ExprApi[Expr[T]] {
     }
   }
 
+  // We need to eagerly simplify selects on products to avoid exponential growth when recursing over a tuple.
+  private def tupleSelect[T <: Tuple](node: ExprNode[T]): Int => ExprNode[?] =
+    node match {
+      case ExprNode.MakeProduct(elements, _) =>
+        // TYPE SAFETY: elements is Tuple.Map[?, ExprNode] so all elements are of type ExprNode[?]
+        i => elements.apply(i).asInstanceOf[ExprNode[?]]
+      case other => i => ExprNode.Select(other, s"_${i + 1}")
+    }
+
   extension [T <: Tuple, H](e: Expr[H *: T]) {
 
     /** Returns the head element of this non-empty tuple expression.
       */
-    def head: Expr[H] = lift(ExprNode.Select(unlift(e), "_1"))
+    def head: Expr[H] =
+      // TYPE SAFETY: The types being H *: T proves that head is H
+      lift(tupleSelect(unlift(e))(0).asInstanceOf[ExprNode[H]])
 
     /** Returns a tuple expression containing all elements after the first one
       * of this non-empty tuple expression.
       */
     def tail: Expr[T] =
       val node = unlift(e)
+      val select = tupleSelect(node)
       node.codec match {
         case Codec.Product(_, fields, _) =>
-          val elements = (2 to fields.arity).map(i => ExprNode.Select(node, s"_$i"))
+          val elements = (1 until fields.arity).map(select)
           lift(ExprNode.makeTupleUnsafe(elements))
         case unsupported => unreachable(s"Tuple must be encoded using Product, but found ${unsupported}")
       }
@@ -994,9 +1006,10 @@ trait ExprApi[Expr[T]] {
       */
     infix def *:[T <: Tuple](tail: Expr[T]): Expr[H *: T] =
       val tailNode = unlift(tail)
+      val select = tupleSelect(tailNode)
       tailNode.codec match {
         case Codec.Product(_, fields, _) =>
-          val tailNodes = (1 to fields.arity).map(i => ExprNode.Select(tailNode, s"_$i"))
+          val tailNodes = (0 until fields.arity).map(select)
           val elements = unlift(head) +: tailNodes
           // TYPE SAFET
           lift(ExprNode.makeTupleUnsafe(elements))

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
@@ -950,6 +950,15 @@ trait ExprApi[Expr[T]] {
       }
   }
 
+  // We need to eagerly simplify selects on products to avoid exponential growth when recursing over a tuple.
+  private def tupleSelect[T <: Tuple](node: ExprNode[T]): Int => ExprNode[?] =
+    node match {
+      case ExprNode.MakeProduct(elements, _) =>
+        // TYPE SAFETY: elements is Tuple.Map[?, ExprNode] so all elements are of type ExprNode[?]
+        i => elements.apply(i).asInstanceOf[ExprNode[?]]
+      case other => i => ExprNode.Select(other, s"_${i + 1}")
+    }
+
   extension [T <: Tuple](e: Expr[T]) {
 
     /** Create a named tuple expression by associating field names with the
@@ -959,7 +968,8 @@ trait ExprApi[Expr[T]] {
       val node = unlift(e)
       node.codec match {
         case Codec.Product(_, fields, _) =>
-          val nodes: Seq[ExprNode[?]] = (1 to fields.arity).map(i => ExprNode.Select(node, s"_$i"))
+          val select = tupleSelect(node)
+          val nodes: Seq[ExprNode[?]] = (0 until fields.arity).map(select)
 
           val namedFields = StringLiterals.apply[N].zip(nodes.map(_.codec)).map(Field(_, _))
           // TYPE SAFETY: The equal size and StringLiterals evidence ensure correctness
@@ -968,15 +978,6 @@ trait ExprApi[Expr[T]] {
       }
     }
   }
-
-  // We need to eagerly simplify selects on products to avoid exponential growth when recursing over a tuple.
-  private def tupleSelect[T <: Tuple](node: ExprNode[T]): Int => ExprNode[?] =
-    node match {
-      case ExprNode.MakeProduct(elements, _) =>
-        // TYPE SAFETY: elements is Tuple.Map[?, ExprNode] so all elements are of type ExprNode[?]
-        i => elements.apply(i).asInstanceOf[ExprNode[?]]
-      case other => i => ExprNode.Select(other, s"_${i + 1}")
-    }
 
   extension [T <: Tuple, H](e: Expr[H *: T]) {
 
@@ -991,9 +992,9 @@ trait ExprApi[Expr[T]] {
       */
     def tail: Expr[T] =
       val node = unlift(e)
-      val select = tupleSelect(node)
       node.codec match {
         case Codec.Product(_, fields, _) =>
+          val select = tupleSelect(node)
           val elements = (1 until fields.arity).map(select)
           lift(ExprNode.makeTupleUnsafe(elements))
         case unsupported => unreachable(s"Tuple must be encoded using Product, but found ${unsupported}")
@@ -1011,7 +1012,6 @@ trait ExprApi[Expr[T]] {
         case Codec.Product(_, fields, _) =>
           val tailNodes = (0 until fields.arity).map(select)
           val elements = unlift(head) +: tailNodes
-          // TYPE SAFET
           lift(ExprNode.makeTupleUnsafe(elements))
         case unsupported => unreachable(s"Tuple must be encoded using Product, but found ${unsupported}")
       }

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
@@ -12,9 +12,9 @@ import scala.reflect.ClassTag
 
 import shapeless3.deriving.K0
 
-import com.choreograph.tyda.TupleOperations.`-`
+import com.choreograph.tyda.TupleOperations.-
+import com.choreograph.tyda.TupleOperations.EqualSize
 import com.choreograph.tyda.shapeless3extras.mapConst
-import com.choreograph.tyda.shapeless3extras.toTuple
 import com.choreograph.tyda.shapeless3extras.tupleInstances
 
 /** Contains the public api for a Expr[T] the api is provided as extension
@@ -858,6 +858,11 @@ trait ExprApi[Expr[T]] {
       val codec = Codec.namedTuple(e.codec)
       lift(ExprNode.makeProductUnsafe(exprs, codec))
 
+    /** Create an expression of a tuple from a product.
+      */
+    def toTuple: Expr[m.MirroredElemTypes] =
+      val exprs = tupleInstances(unapply(e)).mapConst([t] => unlift(_))
+      lift(ExprNode.makeTupleUnsafe(exprs))
   }
 
   /** Extractor that allows Expr of Products being unwrapped to Expr of each
@@ -924,17 +929,78 @@ trait ExprApi[Expr[T]] {
 
     given expr[T]: AsExpr[Expr[T], T] = identity(_)
 
+    // We call shapeless3extras.toTuple explicitly here since there is an Expr extension method with the same
+    // name and renaming as part of the import hits this compiler bug
+    // https://github.com/scala/scala3/issues/26431
     given tuple[TRes <: Tuple, T <: Tuple: TupleAsExpr.Of[TRes]]: AsExpr[T, TRes] =
       inputTuple => {
         val tupledExpression = tupleInstances(TupleAsExpr(inputTuple)).mapK([t] => unlift(_))
-        lift(ExprNode.makeTuple(tupledExpression.toTuple))
+        lift(ExprNode.makeTuple(com.choreograph.tyda.shapeless3extras.toTuple(tupledExpression)))
       }
 
     given namedTuple[Fields <: Tuple: StringLiterals, TRes <: Tuple, T <: Tuple: TupleAsExpr.Of[TRes]]
         : AsExpr[NamedTuple[Fields, T], NamedTuple[Fields, TRes]] =
       inputTuple => {
-        val nodes = tupleInstances(TupleAsExpr(inputTuple)).mapK([t] => unlift(_)).toTuple
+        val nodes = com
+          .choreograph
+          .tyda
+          .shapeless3extras
+          .toTuple(tupleInstances(TupleAsExpr(inputTuple)).mapK([t] => unlift(_)))
         lift(ExprNode.makeNamedTuple(nodes))
+      }
+  }
+
+  extension [T <: Tuple](e: Expr[T]) {
+
+    /** Create a named tuple expression by associating field names with the
+      * elements of this tuple.
+      */
+    def withNames[N <: Tuple: StringLiterals](using EqualSize[T, N]): Expr[NamedTuple[N, T]] = {
+      val node = unlift(e)
+      node.codec match {
+        case Codec.Product(_, fields, _) =>
+          val nodes: Seq[ExprNode[?]] = (1 to fields.arity).map(i => ExprNode.Select(node, s"_$i"))
+
+          val namedFields = StringLiterals.apply[N].zip(nodes.map(_.codec)).map(Field(_, _))
+          // TYPE SAFETY: The equal size and StringLiterals evidence ensure correctness
+          lift(ExprNode.makeProductUnsafe(nodes, Codec.unsafeNamedTuple(namedFields).asInstanceOf))
+        case unsupported => unreachable(s"Tuple must be encoded using Product, but found ${unsupported}")
+      }
+    }
+  }
+
+  extension [T <: Tuple, H](e: Expr[H *: T]) {
+
+    /** Returns the head element of this non-empty tuple expression.
+      */
+    def head: Expr[H] = lift(ExprNode.Select(unlift(e), "_1"))
+
+    /** Returns a tuple expression containing all elements after the first one
+      * of this non-empty tuple expression.
+      */
+    def tail: Expr[T] =
+      val node = unlift(e)
+      node.codec match {
+        case Codec.Product(_, fields, _) =>
+          val elements = (2 to fields.arity).map(i => ExprNode.Select(node, s"_$i"))
+          lift(ExprNode.makeTupleUnsafe(elements))
+        case unsupported => unreachable(s"Tuple must be encoded using Product, but found ${unsupported}")
+      }
+  }
+
+  extension [H](head: Expr[H]) {
+
+    /** Prepend an element expression to this tuple expression.
+      */
+    infix def *:[T <: Tuple](tail: Expr[T]): Expr[H *: T] =
+      val tailNode = unlift(tail)
+      tailNode.codec match {
+        case Codec.Product(_, fields, _) =>
+          val tailNodes = (1 to fields.arity).map(i => ExprNode.Select(tailNode, s"_$i"))
+          val elements = unlift(head) +: tailNodes
+          // TYPE SAFET
+          lift(ExprNode.makeTupleUnsafe(elements))
+        case unsupported => unreachable(s"Tuple must be encoded using Product, but found ${unsupported}")
       }
   }
 

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprDepFn1.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprDepFn1.scala
@@ -1,0 +1,7 @@
+package com.choreograph.tyda
+
+/** Dependently typed function on a Expr */
+trait ExprDepFn1[T] {
+  type Out
+  def apply(e: Expr[T]): Expr[Out]
+}

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
@@ -117,6 +117,10 @@ private object ExprNode extends ExprApi[ExprNode] {
   def makeTuple[T <: Tuple](values: Tuple.Map[T, ExprNode]): ExprNode[T] =
     new MakeProduct[T, T](values, Codec.tuple(tupleInstances(values).mapK([t] => _.codec)))
 
+  def makeTupleUnsafe[T <: Tuple](values: Seq[ExprNode[?]]): ExprNode[T] =
+    // TYPE SAFETY: All elments in values is of type ExprNode
+    makeTuple(Tuple.fromArray(values.toArray).asInstanceOf)
+
   def makeNamedTuple[NT <: AnyNamedTuple](values: NamedTuple.Map[NT, ExprNode])(using
       StringLiterals[NamedTuple.Names[NT]]
   ): ExprNode[NT] = new MakeProduct(values, Codec.namedTuple(tupleInstances(values).mapK([t] => _.codec)))

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
@@ -118,7 +118,7 @@ private object ExprNode extends ExprApi[ExprNode] {
     new MakeProduct[T, T](values, Codec.tuple(tupleInstances(values).mapK([t] => _.codec)))
 
   def makeTupleUnsafe[T <: Tuple](values: Seq[ExprNode[?]]): ExprNode[T] =
-    // TYPE SAFETY: All elments in values is of type ExprNode
+    // TYPE SAFETY: All elements in values is of type ExprNode
     makeTuple(Tuple.fromArray(values.toArray).asInstanceOf)
 
   def makeNamedTuple[NT <: AnyNamedTuple](values: NamedTuple.Map[NT, ExprNode])(using

--- a/tyda/src/main/scala/com/choreograph/tyda/Mapper.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Mapper.scala
@@ -1,27 +1,39 @@
 package com.choreograph.tyda
 
-import com.choreograph.tyda.Expr
+import scala.NamedTuple.NamedTuple
+import scala.deriving.Mirror
 
-/** Helper class for applying [[ExprDepFn1]] to each element of tuple. */
-trait Mapper[HK[X] <: ExprDepFn1[X], T <: Tuple] extends ExprDepFn1[T] {
-  type Out <: Tuple
+import com.choreograph.tyda.TupleOperations.EqualSize
+
+/** Type class for applying an [[ExprDepFn1]] to each field of a product type.
+  *
+  * Unlike [[TupleMapper]] which operates on positional tuples, `Mapper` works
+  * with any type that has a `Mirror.ProductOf` (case classes, named tuples,
+  * etc.) and produces a named tuple preserving the original field names.
+  *
+  * Example:
+  * {{{
+  * trait ToStr[T] extends ExprDepFn1[T] { type Out = String }
+  * given ToStr[Int] with { def apply(e: Expr[Int]): Expr[String] = e.cast[String] }
+  *
+  * val mapper = summon[Mapper[ToStr, (name: String, age: Int)]]
+  * // mapper.Out =:= (name: String, age: String)
+  * }}}
+  */
+trait Mapper[HK[X] <: ExprDepFn1[X], T] extends ExprDepFn1[T] {
+  type Out
 }
 
 object Mapper {
-  type Aux[HK[X] <: ExprDepFn1[X], T <: Tuple, Out1 <: Tuple] = Mapper[HK, T] { type Out = Out1 }
+  type Aux[HK[X] <: ExprDepFn1[X], T, Out0] = Mapper[HK, T] { type Out = Out0 }
 
-  given empty[HK[X] <: ExprDepFn1[X]]: Aux[HK, EmptyTuple, EmptyTuple] =
-    new Mapper[HK, EmptyTuple] {
-      type Out = EmptyTuple
-      def apply(e: Expr[EmptyTuple]): Expr[Out] = e
-    }
-
-  given cons[HK[X] <: ExprDepFn1[X], T <: Tuple, H](using
-      mapHead: HK[H],
-      mapTail: Mapper[HK, T]
-  ): Aux[HK, H *: T, mapHead.Out *: mapTail.Out] =
-    new Mapper[HK, H *: T] {
-      type Out = mapHead.Out *: mapTail.Out
-      def apply(e: Expr[H *: T]): Expr[mapHead.Out *: mapTail.Out] = mapHead(e.head) *: mapTail(e.tail)
+  given product[HK[X] <: ExprDepFn1[X], T: Mirror.ProductOf as m](using
+      tupleMapper: TupleMapper[HK, m.MirroredElemTypes],
+      names: StringLiterals[m.MirroredElemLabels],
+      sizeEv: EqualSize[tupleMapper.Out, m.MirroredElemLabels]
+  ): Aux[HK, T, NamedTuple[m.MirroredElemLabels, tupleMapper.Out]] =
+    new Mapper[HK, T] {
+      type Out = NamedTuple[m.MirroredElemLabels, tupleMapper.Out]
+      def apply(e: Expr[T]): Expr[Out] = tupleMapper(e.toTuple).withNames[m.MirroredElemLabels]
     }
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/Mapper.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Mapper.scala
@@ -1,0 +1,27 @@
+package com.choreograph.tyda
+
+import com.choreograph.tyda.Expr
+
+/** Helper class for applying [[ExprDepFn1]] to each element of tuple. */
+trait Mapper[HK[X] <: ExprDepFn1[X], T <: Tuple] extends ExprDepFn1[T] {
+  type Out <: Tuple
+}
+
+object Mapper {
+  type Aux[HK[X] <: ExprDepFn1[X], T <: Tuple, Out1 <: Tuple] = Mapper[HK, T] { type Out = Out1 }
+
+  given empty[HK[X] <: ExprDepFn1[X]]: Aux[HK, EmptyTuple, EmptyTuple] =
+    new Mapper[HK, EmptyTuple] {
+      type Out = EmptyTuple
+      def apply(e: Expr[EmptyTuple]): Expr[Out] = e
+    }
+
+  given cons[HK[X] <: ExprDepFn1[X], T <: Tuple, H](using
+      mapHead: HK[H],
+      mapTail: Mapper[HK, T]
+  ): Aux[HK, H *: T, mapHead.Out *: mapTail.Out] =
+    new Mapper[HK, H *: T] {
+      type Out = mapHead.Out *: mapTail.Out
+      def apply(e: Expr[H *: T]): Expr[mapHead.Out *: mapTail.Out] = mapHead(e.head) *: mapTail(e.tail)
+    }
+}

--- a/tyda/src/main/scala/com/choreograph/tyda/Remover.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Remover.scala
@@ -1,5 +1,6 @@
 package com.choreograph.tyda
 
+import scala.NamedTuple.AnyNamedTuple
 import scala.NamedTuple.NamedTuple
 import scala.compiletime.constValue
 import scala.deriving.Mirror
@@ -13,7 +14,7 @@ import scala.deriving.Mirror
   * https://github.com/milessabin/shapeless/blob/de11db9ff9e26ea60dced5c6a745ad2a56f9f724/core/shared/src/main/scala/shapeless/ops/records.scala#L433-L439
   */
 sealed trait Remover[T, E] {
-  type Out
+  type Out <: AnyNamedTuple
   def apply(p: T): Out
 }
 

--- a/tyda/src/main/scala/com/choreograph/tyda/TupleMapper.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/TupleMapper.scala
@@ -1,0 +1,27 @@
+package com.choreograph.tyda
+
+import com.choreograph.tyda.Expr
+
+/** Helper class for applying [[ExprDepFn1]] to each element of tuple. */
+trait TupleMapper[HK[X] <: ExprDepFn1[X], T <: Tuple] extends ExprDepFn1[T] {
+  type Out <: Tuple
+}
+
+object TupleMapper {
+  type Aux[HK[X] <: ExprDepFn1[X], T <: Tuple, Out1 <: Tuple] = TupleMapper[HK, T] { type Out = Out1 }
+
+  given empty[HK[X] <: ExprDepFn1[X]]: Aux[HK, EmptyTuple, EmptyTuple] =
+    new TupleMapper[HK, EmptyTuple] {
+      type Out = EmptyTuple
+      def apply(e: Expr[EmptyTuple]): Expr[Out] = e
+    }
+
+  given cons[HK[X] <: ExprDepFn1[X], T <: Tuple, H](using
+      mapHead: HK[H],
+      mapTail: TupleMapper[HK, T]
+  ): Aux[HK, H *: T, mapHead.Out *: mapTail.Out] =
+    new TupleMapper[HK, H *: T] {
+      type Out = mapHead.Out *: mapTail.Out
+      def apply(e: Expr[H *: T]): Expr[mapHead.Out *: mapTail.Out] = mapHead(e.head) *: mapTail(e.tail)
+    }
+}

--- a/tyda/src/main/scala/com/choreograph/tyda/TupleOperations.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/TupleOperations.scala
@@ -34,3 +34,5 @@ object TupleOperations:
   type TupleN[T, N <: Int] <: Tuple = Max[N, 0] match
     case 0 => EmptyTuple
     case S[n] => T *: TupleN[T, n]
+
+  type EqualSize[T1 <: Tuple, T2 <: Tuple] = Tuple.Size[T1] =:= Tuple.Size[T2]

--- a/tyda/src/test/scala/com/choreograph/tyda/MapperSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/MapperSpec.scala
@@ -1,0 +1,44 @@
+package com.choreograph.tyda
+
+import org.scalatest.funsuite.AnyFunSuite
+
+object MapperSpec {
+
+  /** A simple ExprDepFn1 that casts any numeric type to String. */
+  trait ToStr[T] extends ExprDepFn1[T] {
+    type Out = String
+  }
+
+  given ToStr[Int] = _.cast[String]
+  given ToStr[Short] = _.cast[String]
+  given ToStr[Long] = _.cast[String]
+}
+
+class MapperSpec extends AnyFunSuite {
+  import MapperSpec.*
+
+  test("Mapper maps EmptyTuple") {
+    val mapper = summon[Mapper[ToStr, EmptyTuple]]
+    val input: Expr[EmptyTuple] = Expr.lift(ExprNode.Reference[EmptyTuple]())
+    val result = mapper(input)
+    // Verify the compiler knows the full resulting type
+    summon[mapper.Out =:= EmptyTuple]
+    assert(result.codec == Codec[EmptyTuple])
+  }
+
+  test("Mapper maps a single-element tuple") {
+    val mapper = summon[Mapper[ToStr, Int *: EmptyTuple]]
+    summon[mapper.Out =:= (String *: EmptyTuple)]
+    val input: Expr[Int *: EmptyTuple] = Expr.lift(ExprNode.Reference[Int *: EmptyTuple]())
+    val result: Expr[String *: EmptyTuple] = mapper(input)
+    assert(result.codec == Codec[String *: EmptyTuple])
+  }
+
+  test("Mapper maps a multi-element tuple") {
+    val mapper = summon[Mapper[ToStr, (Int, Long, Short)]]
+    summon[mapper.Out =:= (String, String, String)]
+    val input = Expr.lift(ExprNode.Reference[(Int, Long, Short)]())
+    val result: Expr[(String, String, String)] = mapper(input)
+    assert(result.codec == Codec[(String, String, String)])
+  }
+}

--- a/tyda/src/test/scala/com/choreograph/tyda/MapperSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/MapperSpec.scala
@@ -1,44 +1,46 @@
 package com.choreograph.tyda
 
+import scala.NamedTuple.NamedTuple
+
 import org.scalatest.funsuite.AnyFunSuite
 
 object MapperSpec {
 
-  /** A simple ExprDepFn1 that casts any numeric type to String. */
   trait ToStr[T] extends ExprDepFn1[T] {
     type Out = String
   }
 
   given ToStr[Int] = _.cast[String]
-  given ToStr[Short] = _.cast[String]
   given ToStr[Long] = _.cast[String]
+  given ToStr[Short] = _.cast[String]
+  given ToStr[String] = e => e
+  final case class Person(name: String, age: Int) derives Codec
 }
 
 class MapperSpec extends AnyFunSuite {
   import MapperSpec.*
 
-  test("Mapper maps EmptyTuple") {
-    val mapper = summon[Mapper[ToStr, EmptyTuple]]
-    val input: Expr[EmptyTuple] = Expr.lift(ExprNode.Reference[EmptyTuple]())
-    val result = mapper(input)
-    // Verify the compiler knows the full resulting type
-    summon[mapper.Out =:= EmptyTuple]
-    assert(result.codec == Codec[EmptyTuple])
+  test("Mapper maps a named tuple preserving field names") {
+    val mapper = summon[Mapper[ToStr, (name: String, age: Int)]]
+    summon[mapper.Out =:= (name: String, age: String)]
+    val input = Expr.lift(ExprNode.Reference[(name: String, age: Int)]())
+    val result: Expr[(name: String, age: String)] = mapper(input)
+    assert(result.codec == Codec[(name: String, age: String)])
   }
 
-  test("Mapper maps a single-element tuple") {
-    val mapper = summon[Mapper[ToStr, Int *: EmptyTuple]]
-    summon[mapper.Out =:= (String *: EmptyTuple)]
-    val input: Expr[Int *: EmptyTuple] = Expr.lift(ExprNode.Reference[Int *: EmptyTuple]())
-    val result: Expr[String *: EmptyTuple] = mapper(input)
-    assert(result.codec == Codec[String *: EmptyTuple])
+  test("Mapper maps a case class producing a named tuple") {
+    val mapper = summon[Mapper[ToStr, Person]]
+    summon[mapper.Out =:= (name: String, age: String)]
+    val input = Expr.lift(ExprNode.Reference[Person]())
+    val result: Expr[(name: String, age: String)] = mapper(input)
+    assert(result.codec == Codec[(name: String, age: String)])
   }
 
-  test("Mapper maps a multi-element tuple") {
+  test("Mapper maps an unnamed tuple as named tuple") {
     val mapper = summon[Mapper[ToStr, (Int, Long, Short)]]
-    summon[mapper.Out =:= (String, String, String)]
+    summon[mapper.Out =:= NamedTuple[("_1", "_2", "_3"), (String, String, String)]]
     val input = Expr.lift(ExprNode.Reference[(Int, Long, Short)]())
-    val result: Expr[(String, String, String)] = mapper(input)
+    val result = mapper(input)
     assert(result.codec == Codec[(String, String, String)])
   }
 }

--- a/tyda/src/test/scala/com/choreograph/tyda/TupleMapperSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/TupleMapperSpec.scala
@@ -9,17 +9,9 @@ object TupleMapperSpec {
     type Out = String
   }
 
-  given ToStr[Int] with {
-    def apply(e: Expr[Int]): Expr[String] = e.cast[String]
-  }
-
-  given ToStr[Long] with {
-    def apply(e: Expr[Long]): Expr[String] = e.cast[String]
-  }
-
-  given ToStr[Short] with {
-    def apply(e: Expr[Short]): Expr[String] = e.cast[String]
-  }
+  given ToStr[Int] = _.cast[String]
+  given ToStr[Long] = _.cast[String]
+  given ToStr[Short] = _.cast[String]
 }
 
 class TupleMapperSpec extends AnyFunSuite {

--- a/tyda/src/test/scala/com/choreograph/tyda/TupleMapperSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/TupleMapperSpec.scala
@@ -1,0 +1,52 @@
+package com.choreograph.tyda
+
+import org.scalatest.funsuite.AnyFunSuite
+
+object TupleMapperSpec {
+
+  /** A simple ExprDepFn1 that casts any numeric type to String. */
+  trait ToStr[T] extends ExprDepFn1[T] {
+    type Out = String
+  }
+
+  given ToStr[Int] with {
+    def apply(e: Expr[Int]): Expr[String] = e.cast[String]
+  }
+
+  given ToStr[Long] with {
+    def apply(e: Expr[Long]): Expr[String] = e.cast[String]
+  }
+
+  given ToStr[Short] with {
+    def apply(e: Expr[Short]): Expr[String] = e.cast[String]
+  }
+}
+
+class TupleMapperSpec extends AnyFunSuite {
+  import TupleMapperSpec.*
+
+  test("TupleMapper maps EmptyTuple") {
+    val mapper = summon[TupleMapper[ToStr, EmptyTuple]]
+    val input: Expr[EmptyTuple] = Expr.lift(ExprNode.Reference[EmptyTuple]())
+    val result = mapper(input)
+    // Verify the compiler knows the full resulting type
+    summon[mapper.Out =:= EmptyTuple]
+    assert(result.codec == Codec[EmptyTuple])
+  }
+
+  test("TupleMapper maps a single-element tuple") {
+    val mapper = summon[TupleMapper[ToStr, Int *: EmptyTuple]]
+    summon[mapper.Out =:= (String *: EmptyTuple)]
+    val input: Expr[Int *: EmptyTuple] = Expr.lift(ExprNode.Reference[Int *: EmptyTuple]())
+    val result: Expr[String *: EmptyTuple] = mapper(input)
+    assert(result.codec == Codec[String *: EmptyTuple])
+  }
+
+  test("TupleMapper maps a multi-element tuple") {
+    val mapper = summon[TupleMapper[ToStr, (Int, Long, Short)]]
+    summon[mapper.Out =:= (String, String, String)]
+    val input = Expr.lift(ExprNode.Reference[(Int, Long, Short)]())
+    val result: Expr[(String, String, String)] = mapper(input)
+    assert(result.codec == Codec[(String, String, String)])
+  }
+}


### PR DESCRIPTION
The goal here is to make the api and make it easier to do more type
level computations. For example the tests case shows how to recurse over
a model removing all instances of String.
