### PR TITLE
Drop tydaSpark3 dependency from tydaJobTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -435,7 +435,7 @@ lazy val tydaJobTest = (project in file("tyda-job-test"))
   .settings(tydaJobSettings)
   .settings(Dependencies.tydaJobTest)
   .dependsOn(scalafixRules % ScalafixConfig)
-  .dependsOn(tydaJob, tydaSpark3, tydaIterator)
+  .dependsOn(tydaJob, tydaIterator)
 
 lazy val tydaParquet = (project in file("tyda-parquet"))
   .settings(name := "tyda-parquet")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -117,5 +117,5 @@ object Dependencies {
     Seq(CompileDeps.slf4j, TestDeps.scalatest.exclude("org.scala-lang.modules", "scala-xml_3"))
 
   val tydaJobTest = libraryDependencies ++=
-    Seq(CompileDeps.scalatest.exclude("org.scala-lang.modules", "scala-xml_3"), CompileDeps.spark3Sql)
+    Seq(CompileDeps.scalatest.exclude("org.scala-lang.modules", "scala-xml_3"))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,8 @@ object Dependencies {
 
   val tydaCollection = libraryDependencies ++= Seq(TestDeps.scalatest)
 
-  val tydaDocs = libraryDependencies ++= Seq(CompileDeps.spark3Sql)
+  val tydaDocs = libraryDependencies ++=
+    Seq(CompileDeps.spark3Sql.exclude("org.scala-lang.modules", "scala-xml_2.13"))
 
   val tydaTestSuites = libraryDependencies ++= Seq(CompileDeps.scalatest, CompileDeps.commonsIo)
 
@@ -116,6 +117,5 @@ object Dependencies {
   val tydaJob = libraryDependencies ++=
     Seq(CompileDeps.slf4j, TestDeps.scalatest.exclude("org.scala-lang.modules", "scala-xml_3"))
 
-  val tydaJobTest = libraryDependencies ++=
-    Seq(CompileDeps.scalatest.exclude("org.scala-lang.modules", "scala-xml_3"))
+  val tydaJobTest = libraryDependencies ++= Seq(CompileDeps.scalatest)
 }

--- a/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/TestRunnerArg.scala
+++ b/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/TestRunnerArg.scala
@@ -1,6 +1,6 @@
 package com.choreograph.tyda.job.test
 
-// TODO: Ideally we should support all runners here, but we need to decide how to handle runners that takes extra arguments.
+// TODO: Ideally we should support all runners here, but we need to decide how to handle runners that take extra arguments.
 enum TestRunnerArg {
   case Iterator, Spark
 }

--- a/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/TestRunnerArg.scala
+++ b/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/TestRunnerArg.scala
@@ -1,0 +1,6 @@
+package com.choreograph.tyda.job.test
+
+// TODO: Ideally we should support all runners here, but we need to decide how to handle runners that takes extra arguments.
+enum TestRunnerArg {
+  case Iterator, Spark
+}

--- a/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/testJob.scala
+++ b/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/testJob.scala
@@ -1,6 +1,7 @@
 package com.choreograph.tyda.job.test
 
 import com.choreograph.tyda.RunnerArgs
+import com.choreograph.tyda.RunnerArgs.SparkLogLevels
 import com.choreograph.tyda.iterator.IteratorRunner
 import com.choreograph.tyda.job.TydaJob
 import com.choreograph.tyda.job.TydaJobContext
@@ -33,8 +34,10 @@ def testJob[Args](args: Args)(using job: TydaJob[Args]): Unit = {
   val runnerArg = getRunnerArg
   val runner = runnerArg match {
     case TestRunnerArg.Iterator => IteratorRunner
-    case TestRunnerArg.Spark =>
-      RunnerArgs.createRunner(RunnerArgs.Spark(master = Some("local[2]")), "unittest")
+    case TestRunnerArg.Spark => RunnerArgs.createRunner(
+        RunnerArgs.Spark(master = Some("local[2]"), logLevel = Some(SparkLogLevels.Warn)),
+        "unittest"
+      )
   }
   val context = TydaJobContext(runner)
   job.run(args)(using context)

--- a/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/testJob.scala
+++ b/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/testJob.scala
@@ -1,18 +1,12 @@
 package com.choreograph.tyda.job.test
 
-import org.apache.spark.sql.SparkSession
-
 import com.choreograph.tyda.RunnerArgs
-import com.choreograph.tyda.UnionMirror.derived
 import com.choreograph.tyda.iterator.IteratorRunner
 import com.choreograph.tyda.job.TydaJob
 import com.choreograph.tyda.job.TydaJobContext
 import com.choreograph.tyda.table.ArgsParser
 
 private val runnerEnvironmentVariable = "TYDA_JOB_TEST_RUNNER"
-
-// TODO: Ideally we should support all runners here, but we need to decide how to handle runners that takes extra arguments.
-type TestRunnerArg = RunnerArgs.Iterator.type | RunnerArgs.Spark.type
 
 /** Checks if the test runner is using spark
   *
@@ -32,23 +26,15 @@ private def getRunnerArg: TestRunnerArg =
             s"Invalid runner value for $runnerEnvironmentVariable: $str hint: ${parser.hint}"
           )
         )
-    case None => RunnerArgs.Iterator
+    case None => TestRunnerArg.Iterator
   }
 
 def testJob[Args](args: Args)(using job: TydaJob[Args]): Unit = {
   val runnerArg = getRunnerArg
   val runner = runnerArg match {
-    case RunnerArgs.Iterator => IteratorRunner
-    case RunnerArgs.Spark =>
-      val name = "unittest"
-      // Ensure a appropriately configured session exists
-      val _ = SparkSession
-        .builder()
-        .config("spark.log.level", "WARN")
-        .master("local[2]")
-        .appName(name)
-        .getOrCreate()
-      RunnerArgs.createRunner(runnerArg, name)
+    case TestRunnerArg.Iterator => IteratorRunner
+    case TestRunnerArg.Spark =>
+      RunnerArgs.createRunner(RunnerArgs.Spark(master = Some("local[2]")), "unittest")
   }
   val context = TydaJobContext(runner)
   job.run(args)(using context)

--- a/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/testJob.scala
+++ b/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/testJob.scala
@@ -14,7 +14,7 @@ private val runnerEnvironmentVariable = "TYDA_JOB_TEST_RUNNER"
   * This is needed because of existing code that is not compatible with spark.
   * But this should only be used as a last resort in new code and ideally never.
   */
-def isTestSparkRunner: Boolean = getRunnerArg == RunnerArgs.Spark
+def isTestSparkRunner: Boolean = getRunnerArg == TestRunnerArg.Spark
 
 private def getRunnerArg: TestRunnerArg =
   sys.env.get(runnerEnvironmentVariable) match {

--- a/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/testJob.scala
+++ b/tyda-job-test/src/main/scala/com/choreograph/tyda/job/test/testJob.scala
@@ -7,7 +7,6 @@ import com.choreograph.tyda.UnionMirror.derived
 import com.choreograph.tyda.iterator.IteratorRunner
 import com.choreograph.tyda.job.TydaJob
 import com.choreograph.tyda.job.TydaJobContext
-import com.choreograph.tyda.spark.SparkRunner
 import com.choreograph.tyda.table.ArgsParser
 
 private val runnerEnvironmentVariable = "TYDA_JOB_TEST_RUNNER"
@@ -41,13 +40,15 @@ def testJob[Args](args: Args)(using job: TydaJob[Args]): Unit = {
   val runner = runnerArg match {
     case RunnerArgs.Iterator => IteratorRunner
     case RunnerArgs.Spark =>
-      val spark = SparkSession
+      val name = "unittest"
+      // Ensure a appropriately configured session exists
+      val _ = SparkSession
         .builder()
         .config("spark.log.level", "WARN")
         .master("local[2]")
-        .appName("unittest")
+        .appName(name)
         .getOrCreate()
-      new SparkRunner(using spark)
+      RunnerArgs.createRunner(runnerArg, name)
   }
   val context = TydaJobContext(runner)
   job.run(args)(using context)

--- a/tyda-repl/src/main/scala/com/choreograph/tyda/repl/TydaRepl.scala
+++ b/tyda-repl/src/main/scala/com/choreograph/tyda/repl/TydaRepl.scala
@@ -22,7 +22,7 @@ object TydaRepl {
 
   def run(args: Args, initCode: Option[String] = None, infoMessage: Option[String] = None): Unit = {
     args.runner match
-      case RunnerArgs.Spark => if System.getProperty("spark.master") == null then
+      case RunnerArgs.Spark(master=_) => if System.getProperty("spark.master") == null then
           System.setProperty("spark.master", "local[*]"): Unit
       case _ =>
 

--- a/tyda-repl/src/main/scala/com/choreograph/tyda/repl/TydaRepl.scala
+++ b/tyda-repl/src/main/scala/com/choreograph/tyda/repl/TydaRepl.scala
@@ -22,7 +22,7 @@ object TydaRepl {
 
   def run(args: Args, initCode: Option[String] = None, infoMessage: Option[String] = None): Unit = {
     args.runner match
-      case RunnerArgs.Spark(master = _) => if System.getProperty("spark.master") == null then
+      case RunnerArgs.Spark(master = None) => if System.getProperty("spark.master") == null then
           System.setProperty("spark.master", "local[*]"): Unit
       case _ =>
 

--- a/tyda-repl/src/main/scala/com/choreograph/tyda/repl/TydaRepl.scala
+++ b/tyda-repl/src/main/scala/com/choreograph/tyda/repl/TydaRepl.scala
@@ -22,7 +22,7 @@ object TydaRepl {
 
   def run(args: Args, initCode: Option[String] = None, infoMessage: Option[String] = None): Unit = {
     args.runner match
-      case RunnerArgs.Spark(master=_) => if System.getProperty("spark.master") == null then
+      case RunnerArgs.Spark(master = _) => if System.getProperty("spark.master") == null then
           System.setProperty("spark.master", "local[*]"): Unit
       case _ =>
 

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/SparkRunner.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/SparkRunner.scala
@@ -1,7 +1,6 @@
 package com.choreograph.tyda.spark
 
 import scala.collection.immutable.ArraySeq
-import scala.util.chaining.given
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ExtendedMode
@@ -22,7 +21,19 @@ class SparkRunner(using spark: SparkSession) extends Runner {
 }
 
 object SparkRunner {
+  extension (b: SparkSession.Builder) {
+    private def withOpt[T](
+        opt: Option[T],
+        f: (SparkSession.Builder, T) => SparkSession.Builder
+    ): SparkSession.Builder = opt.fold(b)(f(b, _))
+  }
+
   def apply(name: String, args: RunnerArgs.Spark): SparkRunner =
-    val spark = SparkSession.builder().appName(name).pipe(b => args.master.fold(b)(b.master(_))).getOrCreate()
+    val spark = SparkSession
+      .builder()
+      .appName(name)
+      .withOpt(args.master, _.master(_))
+      .withOpt(args.logLevel.map(_.toSparkConf), _.config("spark.log.level", _))
+      .getOrCreate()
     new SparkRunner(using spark)
 }

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/SparkRunner.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/SparkRunner.scala
@@ -1,6 +1,7 @@
 package com.choreograph.tyda.spark
 
 import scala.collection.immutable.ArraySeq
+import scala.util.chaining.given
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ExtendedMode
@@ -21,6 +22,7 @@ class SparkRunner(using spark: SparkSession) extends Runner {
 }
 
 object SparkRunner {
-  def apply(name: String, args: RunnerArgs.Spark.type): SparkRunner =
-    new SparkRunner(using SparkSession.builder().appName(name).getOrCreate())
+  def apply(name: String, args: RunnerArgs.Spark): SparkRunner =
+    val spark = SparkSession.builder().appName(name).pipe(b => args.master.fold(b)(b.master(_))).getOrCreate()
+    new SparkRunner(using spark)
 }

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/SparkRunnerSpec.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/SparkRunnerSpec.scala
@@ -9,7 +9,7 @@ class SparkRunnerSpec extends AnyFunSuite with SharedSparkSession {
     // Force shared spark session initialization before calling createRunner
     // This should be replaced by making RunnerArg.Spark contain the neccessary args.
     val _ = spark
-    val runner = RunnerArgs.createRunner(RunnerArgs.Spark, "test-app")
+    val runner = RunnerArgs.createRunner(RunnerArgs.Spark(), "test-app")
     assert(runner.isInstanceOf[SparkRunner])
   }
 }

--- a/tyda/src/main/scala/com/choreograph/tyda/RunnerArgs.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/RunnerArgs.scala
@@ -6,10 +6,16 @@ enum RunnerArgs {
       validateSchemas: RunnerArgs.ValidateSchema = RunnerArgs.ValidateSchema.Strict
   )
   case Iterator
-  case Spark(master: Option[String] = None)
+  case Spark(master: Option[String] = None, logLevel: Option[RunnerArgs.SparkLogLevels] = None)
 }
 
 object RunnerArgs {
+  enum SparkLogLevels {
+    case All, Debug, Error, Fatal, Info, Off, Trace, Warn
+
+    def toSparkConf: String = toString.toUpperCase
+  }
+
   enum ValidateSchema {
     case Strict, Warn, Off
   }

--- a/tyda/src/main/scala/com/choreograph/tyda/RunnerArgs.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/RunnerArgs.scala
@@ -6,7 +6,7 @@ enum RunnerArgs {
       validateSchemas: RunnerArgs.ValidateSchema = RunnerArgs.ValidateSchema.Strict
   )
   case Iterator
-  case Spark
+  case Spark(master: Option[String] = None)
 }
 
 object RunnerArgs {
@@ -17,14 +17,14 @@ object RunnerArgs {
     arg match {
       case BigQuery(projectId = _) => "com.choreograph.tyda.bigquery.BigQueryRunner$"
       case Iterator => "com.choreograph.tyda.iterator.IteratorRunner$"
-      case Spark => "com.choreograph.tyda.spark.SparkRunner$"
+      case Spark(master = _) => "com.choreograph.tyda.spark.SparkRunner$"
     }
 
   private def dependencyName(arg: RunnerArgs): String =
     arg match {
       case BigQuery(projectId = _) => "tyda-big-query"
       case Iterator => "tyda-iterator"
-      case Spark => "tyda-spark"
+      case Spark(master = _) => "tyda-spark"
     }
 
   // We dynamically load the runner classes so that users only need to include
@@ -38,9 +38,9 @@ object RunnerArgs {
             s"Runner for '$arg' not found. Make sure that '${dependencyName(arg)}' is on your classpath."
           )
     val argsClass = arg match {
-      case BigQuery(projectId = _) => arg.getClass
+      case BigQuery(projectId = _) | Spark(master = _) => arg.getClass
       // Singletons are erased to the base type.
-      case Iterator | Spark => classOf[RunnerArgs]
+      case Iterator => classOf[RunnerArgs]
     }
     val companion = companionClass.getDeclaredField("MODULE$").get(null)
     val applyMethod = companionClass.getMethod("apply", classOf[String], argsClass)

--- a/tyda/src/test/scala/com/choreograph/tyda/RunnerArgSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/RunnerArgSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class RunnerArgSpec extends AnyFunSuite {
   test("should throw helpful error when runner class is not on classpath") {
     val exception =
-      intercept[RuntimeException] { RunnerArgs.createRunner(Arbitrary[RunnerArgs.Spark.type](), "test-app") }
+      intercept[RuntimeException] { RunnerArgs.createRunner(Arbitrary[RunnerArgs.Spark](), "test-app") }
     assert(exception.getMessage.contains("tyda-spark"))
     assert(exception.getMessage.contains("classpath"))
   }


### PR DESCRIPTION
Users of tydaJobTest should pick which backend to include on their own.
For example they might want to have tydaSpark4 instead.
