### PR TITLE
Remove inputs from name in testOrderBy

### DIFF
--- a/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
@@ -110,10 +110,6 @@ SELECT t1.value AS value FROM t1 ORDER BY t1.value
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy literal
-SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY CAST(NULL AS INT)
------- end
-
 ------ Test: orderBy nested struct inner field
 SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a.x, t1.a.y
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
@@ -38,76 +38,80 @@ SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS
 SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS _6, t1._7 AS _7 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5, t1._6, t1._7
 ------ end
 
------- Test: orderBy Boolean, input: ArraySeq()
+------ Test: orderBy Boolean
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Byte, input: ArraySeq()
+------ Test: orderBy Byte
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Date, input: ArraySeq()
+------ Test: orderBy Date
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Decimal[Int,Int], input: ArraySeq()
+------ Test: orderBy Decimal[Int,Int]
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Double, input: ArraySeq()
+------ Test: orderBy Double
 SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
 ------ end
 
------- Test: orderBy Float, input: ArraySeq()
+------ Test: orderBy Float
 SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
 ------ end
 
------- Test: orderBy Inner, input: ArraySeq()
+------ Test: orderBy Inner
 SELECT t1.x AS x, t1.y AS y FROM t1 ORDER BY t1.x, t1.y
 ------ end
 
------- Test: orderBy Int, input: ArraySeq()
+------ Test: orderBy Int
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Long, input: ArraySeq()
+------ Test: orderBy Long
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[AllNullable], input: ArraySeq()
+------ Test: orderBy Option[AllNullable]
 SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.a, t1.value.b
 ------ end
 
------- Test: orderBy Option[Double], input: ArraySeq(List(None, Some(NaN), Some(Infinity), Some(-Infinity), Some(-0.0), Some(0.0)))
+------ Test: orderBy Option[Double]
 SELECT t1.value AS value FROM t1 ORDER BY is_nan(t1.value), t1.value
 ------ end
 
------- Test: orderBy Option[Inner], input: ArraySeq()
+------ Test: orderBy Option[Inner]
 SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.x, t1.value.y
 ------ end
 
------- Test: orderBy Option[Int], input: ArraySeq()
+------ Test: orderBy Option[Int]
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[Option[Int]], input: ArraySeq()
+------ Test: orderBy Option[Option[Int]]
 SELECT t1.value AS value FROM t1 ORDER BY (t1.value IS NOT NULL), t1.value.value
 ------ end
 
------- Test: orderBy Outer, input: ArraySeq()
+------ Test: orderBy Outer
 SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a.x, t1.a.y, t1.b
 ------ end
 
------- Test: orderBy Short, input: ArraySeq()
+------ Test: orderBy Short
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy String, input: ArraySeq()
+------ Test: orderBy String
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Timestamp, input: ArraySeq()
+------ Test: orderBy Timestamp
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy literal
+SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY CAST(NULL AS INT)
 ------ end
 
 ------ Test: orderBy nested struct inner field

--- a/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
@@ -110,10 +110,6 @@ SELECT t1.value AS value FROM t1 ORDER BY t1.value
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy literal
-SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY CAST(NULL AS INT)
------- end
-
 ------ Test: orderBy nested struct inner field
 SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
@@ -38,76 +38,80 @@ SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS
 SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS _6, t1._7 AS _7 FROM t1 ORDER BY t1._1, t1._2, t1._3, t1._4, t1._5, t1._6, t1._7
 ------ end
 
------- Test: orderBy Boolean, input: ArraySeq()
+------ Test: orderBy Boolean
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Byte, input: ArraySeq()
+------ Test: orderBy Byte
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Date, input: ArraySeq()
+------ Test: orderBy Date
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Decimal[Int,Int], input: ArraySeq()
+------ Test: orderBy Decimal[Int,Int]
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Double, input: ArraySeq()
+------ Test: orderBy Double
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Float, input: ArraySeq()
+------ Test: orderBy Float
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Inner, input: ArraySeq()
+------ Test: orderBy Inner
 SELECT t1.x AS x, t1.y AS y FROM t1 ORDER BY t1.x, t1.y
 ------ end
 
------- Test: orderBy Int, input: ArraySeq()
+------ Test: orderBy Int
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Long, input: ArraySeq()
+------ Test: orderBy Long
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[AllNullable], input: ArraySeq()
+------ Test: orderBy Option[AllNullable]
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[Double], input: ArraySeq(List(None, Some(NaN), Some(Infinity), Some(-Infinity), Some(-0.0), Some(0.0)))
+------ Test: orderBy Option[Double]
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[Inner], input: ArraySeq()
+------ Test: orderBy Option[Inner]
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[Int], input: ArraySeq()
+------ Test: orderBy Option[Int]
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Option[Option[Int]], input: ArraySeq()
+------ Test: orderBy Option[Option[Int]]
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Outer, input: ArraySeq()
+------ Test: orderBy Outer
 SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY t1.a, t1.b
 ------ end
 
------- Test: orderBy Short, input: ArraySeq()
+------ Test: orderBy Short
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy String, input: ArraySeq()
+------ Test: orderBy String
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
 ------ end
 
------- Test: orderBy Timestamp, input: ArraySeq()
+------ Test: orderBy Timestamp
 SELECT t1.value AS value FROM t1 ORDER BY t1.value
+------ end
+
+------ Test: orderBy literal
+SELECT t1.a AS a, t1.b AS b FROM t1 ORDER BY CAST(NULL AS INT)
 ------ end
 
 ------ Test: orderBy nested struct inner field

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
@@ -22,7 +22,7 @@ trait DatasetOrderBySuite extends DatasetSuite {
   import DatasetOrderBySuite.*
 
   def testOrderBy[T: Arbitrary: Codec: Equality: SimpleTypeName: Orderable](inputs: Seq[T]*): Unit =
-    testOrdered[T, T](s"orderBy ${SimpleTypeName.name}, input: ${inputs}", _.orderBy(identity), inputs*)
+    testOrdered[T, T](s"orderBy ${SimpleTypeName.name}", _.orderBy(identity), inputs*)
 
   testOrderBy[Int]()
   testOrderBy[Long]()


### PR DESCRIPTION
The helper testOrdered will already added them to the test cases that
are generated from the specific inputs.
