### PR TITLE
Deprecate EnumStatbleHashCode

### DIFF
--- a/tyda-json/src/test/scala/com/choreograph/tyda/json/CodecToJsonSchemaConformanceSpec.scala
+++ b/tyda-json/src/test/scala/com/choreograph/tyda/json/CodecToJsonSchemaConformanceSpec.scala
@@ -16,7 +16,6 @@ import com.choreograph.tyda.Codec.EnumAsString
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.TypeName
 
@@ -24,11 +23,11 @@ object CodecToJsonSchemaConformanceSpec {
   final case class SimpleProduct(a: Int, b: Option[String]) derives Arbitrary, Codec
   final case class AllOptionalProduct(a: Option[Int], b: Option[String]) derives Arbitrary, Codec
 
-  enum Color extends EnumStableHashCode derives EnumAsString, Arbitrary {
+  enum Color derives EnumAsString, Arbitrary {
     case Red, Green, Blue
   }
 
-  enum Animal extends EnumStableHashCode derives Codec, Arbitrary {
+  enum Animal derives Codec, Arbitrary {
     case Dog(name: String)
     case Cat
   }

--- a/tyda-json/src/test/scala/com/choreograph/tyda/json/CodecToJsonSchemaSpec.scala
+++ b/tyda-json/src/test/scala/com/choreograph/tyda/json/CodecToJsonSchemaSpec.scala
@@ -7,7 +7,6 @@ import com.choreograph.tyda.Codec.EnumAsString
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.TypeName
 
@@ -15,10 +14,10 @@ object CodecToJsonSchemaSpec {
   final case class SimpleProduct(a: Int, b: Option[String]) derives Codec
   final case class AllOptionalProduct(a: Option[Int], b: Option[String]) derives Codec
 
-  enum Color extends EnumStableHashCode derives EnumAsString {
+  enum Color derives EnumAsString {
     case Red, Green, Blue
   }
-  enum Animal extends EnumStableHashCode derives Codec {
+  enum Animal derives Codec {
     case Dog(name: String)
     case Cat
   }

--- a/tyda-metadata/src/test/scala/com/choreograph/tyda/metadata/ExtractedMetadataSpec.scala
+++ b/tyda-metadata/src/test/scala/com/choreograph/tyda/metadata/ExtractedMetadataSpec.scala
@@ -3,8 +3,6 @@ package com.choreograph.tyda.metadata
 import org.scalatest.compatible.Assertion
 import org.scalatest.funsuite.AnyFunSuite
 
-import com.choreograph.tyda.EnumStableHashCode
-
 object ExtractedMetadataSpec {
 
   /** person scaladoc
@@ -29,7 +27,7 @@ object ExtractedMetadataSpec {
 
   /** enum scaladoc
     */
-  enum Enum extends EnumStableHashCode {
+  enum Enum {
 
     /** singleton scaladoc
       */

--- a/tyda-parquet/src/test/scala/com/choreograph/tyda/parquet/ParquetRoundTripSuite.scala
+++ b/tyda-parquet/src/test/scala/com/choreograph/tyda/parquet/ParquetRoundTripSuite.scala
@@ -17,7 +17,6 @@ import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Ord
 import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.TypeName
@@ -25,7 +24,7 @@ import com.choreograph.tyda.TypeName
 object ParquetRoundTripSuite {
   private final case class MyProduct(a: Option[Int], b: String, c: (Int, Option[Int]))
       derives Arbitrary, Codec
-  private enum MyEnum extends EnumStableHashCode derives Arbitrary, Codec {
+  private enum MyEnum derives Arbitrary, Codec {
     case A, B
     case C(a: Int, b: Option[Int])
     case D(a: Int, b: Option[Int])
@@ -33,7 +32,7 @@ object ParquetRoundTripSuite {
     case F(prod: MyProduct)
   }
 
-  private enum SimpleEnum extends EnumStableHashCode derives Arbitrary, Codec.EnumAsString {
+  private enum SimpleEnum derives Arbitrary, Codec.EnumAsString {
     case X, Y, Z
   }
 

--- a/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
+++ b/tyda-spark/src/test/scala/com/choreograph/tyda/spark/CodecToEncoderSpecBase.scala
@@ -27,7 +27,6 @@ import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Ord
 import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.TypeName
@@ -38,7 +37,7 @@ object CodecToEncoderSpecBase {
   final case class Person(name: String, age: Int, alias: Option[String] = None) derives Codec, Ord
   final case class Employee(person: Person, salary: Double) derives Codec, Ord
 
-  enum Location extends EnumStableHashCode derives Codec, Ord {
+  enum Location derives Codec, Ord {
     case Null extends Location
     case City(name: String) extends Location
     case Country(name: String) extends Location
@@ -46,12 +45,12 @@ object CodecToEncoderSpecBase {
     case Missing extends Location
     case Region(name: Int) extends Location
   }
-  enum OnlySingletons extends EnumStableHashCode derives Codec, Ord {
+  enum OnlySingletons derives Codec, Ord {
     case A
     case B
   }
 
-  enum MyOption[+T] extends EnumStableHashCode derives Codec, Ord {
+  enum MyOption[+T] derives Codec, Ord {
     case Some(x: T)
     case None
   }
@@ -74,11 +73,11 @@ object CodecToEncoderSpecBase {
     case Enum(location: Location)
   }
 
-  enum Generic extends EnumStableHashCode derives Codec, Ord {
+  enum Generic derives Codec, Ord {
     case A
   }
 
-  enum GenericEmptyVariants[+T <: Generic] extends EnumStableHashCode {
+  enum GenericEmptyVariants[+T <: Generic] {
     case Empty1, Empty2
   }
   object GenericEmptyVariants {
@@ -86,7 +85,7 @@ object CodecToEncoderSpecBase {
     given Ordering[GenericEmptyVariants[Nothing]] = Ord.sum[GenericEmptyVariants[Nothing]]
   }
 
-  enum EnumString extends EnumStableHashCode derives Codec.EnumAsString, Ord {
+  enum EnumString derives Codec.EnumAsString, Ord {
     case A
     case B
   }

--- a/tyda-sparksql/src/test/scala/com/choreograph/tyda/sparksql/ToDdlSparkSpec.scala
+++ b/tyda-sparksql/src/test/scala/com/choreograph/tyda/sparksql/ToDdlSparkSpec.scala
@@ -10,7 +10,6 @@ import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.TypeName
 import com.choreograph.tyda.spark.CodecToEncoder
@@ -23,12 +22,12 @@ object ToDdlSparkSpec {
   private final case class NestedFields(optionalFields: Option[Fields]) derives Codec
   private final case class NotOptionalFields(name: String, age: Int) derives Codec
   private final case class NestedNotOptionalFields(notOptionalFields: NotOptionalFields) derives Codec
-  private enum Enum extends EnumStableHashCode derives Codec {
+  private enum Enum derives Codec {
     case Singleton
     case Product1(a: Int, b: String)
     case Product2(c: Int, d: Long)
   }
-  private enum EnumString extends EnumStableHashCode derives Codec.EnumAsString {
+  private enum EnumString derives Codec.EnumAsString {
     case A
     case B
   }

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/ToDdlSpec.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/ToDdlSpec.scala
@@ -9,7 +9,6 @@ import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.SimpleTypeName
 import com.choreograph.tyda.Timestamp
 import com.choreograph.tyda.sql.DdlDialect.MapSupport
@@ -28,14 +27,14 @@ object ToDdlSpec {
       boolean: Boolean,
       string: String
   ) derives Codec
-  enum Enum extends EnumStableHashCode derives Codec {
+  enum Enum derives Codec {
     case Singleton
     case Product1(a: Int, b: String)
     case Product2(c: Int, d: Option[Long])
     case Product3(c: Int, d: Product1)
   }
 
-  enum EnumString extends EnumStableHashCode derives Codec.EnumAsString {
+  enum EnumString derives Codec.EnumAsString {
     case A
     case B
   }

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/UnparserSuite.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/UnparserSuite.scala
@@ -5,7 +5,6 @@ import scala.reflect.ClassTag
 import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Expr
 import com.choreograph.tyda.Format
 import com.choreograph.tyda.aggregates.countIf
@@ -19,11 +18,11 @@ import com.choreograph.tyda.functions.tuple
 private object UnparserSuite {
   final case class O(a: Option[Option[Int]])
   final case class M1(a: Int, b: String, c: Boolean, d: Seq[Double])
-  enum E1 extends EnumStableHashCode {
+  enum E1 {
     case A(a: Int)
     case C
   }
-  enum E2 extends EnumStableHashCode derives Codec.EnumAsString {
+  enum E2 derives Codec.EnumAsString {
     case First
     case Second
   }

--- a/tyda-table/src/test/scala/com/choreograph/tyda/table/PartitionerSpec.scala
+++ b/tyda-table/src/test/scala/com/choreograph/tyda/table/PartitionerSpec.scala
@@ -4,10 +4,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import com.choreograph.tyda.Arbitrary
 import com.choreograph.tyda.Codec
-import com.choreograph.tyda.EnumStableHashCode
 
 object PartitionerSpec {
-  enum EnumPartitionValue extends EnumStableHashCode derives Codec.EnumAsString {
+  enum EnumPartitionValue derives Codec.EnumAsString {
     case A
     case B
   }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetReadWriteSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetReadWriteSuite.scala
@@ -18,7 +18,6 @@ import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Format
 import com.choreograph.tyda.NumericsReadMode
 import com.choreograph.tyda.Ord
@@ -39,7 +38,7 @@ object DatasetReadWriteSuite {
   }
   private final case class MyProduct(a: Option[Long], b: String, c: (Long, Option[Long]))
       derives Arbitrary, Codec
-  private enum MyEnum extends EnumStableHashCode derives Arbitrary, Codec {
+  private enum MyEnum derives Arbitrary, Codec {
     case A, B
     case C(a: Long, b: Option[Long])
     case D(a: Long, b: Option[Long])
@@ -47,20 +46,20 @@ object DatasetReadWriteSuite {
     case F(prod: MyProduct)
   }
 
-  private enum SimpleEnum extends EnumStableHashCode derives Arbitrary, Codec.EnumAsString {
+  private enum SimpleEnum derives Arbitrary, Codec.EnumAsString {
     case X, Y, Z
   }
 
   private final case class Model(column: String, value: String) derives Arbitrary, Codec
   private final case class ModelExtended(column: String, value: String, extra: Option[Int]) derives Codec
 
-  private enum Type extends EnumStableHashCode derives Arbitrary, Codec {
+  private enum Type derives Arbitrary, Codec {
     case FixedString(n: Int)
     case Int
     case Decimal
   }
 
-  private enum TypeExtended extends EnumStableHashCode derives Codec {
+  private enum TypeExtended derives Codec {
     case FixedByteArray(n: Int)
     case FixedString(n: Int)
     case Int

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSuite.scala
@@ -16,7 +16,6 @@ import com.choreograph.tyda.CanCast
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Comparable
 import com.choreograph.tyda.Dataset
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Groupable
 import com.choreograph.tyda.Runner
 import com.choreograph.tyda.SumMagnet
@@ -42,7 +41,7 @@ object DatasetSuite {
     given [T] => (canCast: CanCast[Byte, T]) => CanCast[TinyByte, T] = canCast
   }
   type Pair = (TinyByte, TinyByte)
-  enum MyEnum extends EnumStableHashCode derives Codec {
+  enum MyEnum derives Codec {
     case A(value: Int)
     case B(value: String)
     case C

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -27,7 +27,6 @@ import com.choreograph.tyda.Comparable
 import com.choreograph.tyda.Date
 import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Duration
-import com.choreograph.tyda.EnumStableHashCode
 import com.choreograph.tyda.Expr
 import com.choreograph.tyda.JsonArrayOrObject
 import com.choreograph.tyda.Ord
@@ -65,7 +64,7 @@ object ExprEvaluationSuiteBase {
   private type NamedTupleAlias = (a: Int, b: String, c: Boolean)
   private type NamedTupleAliasWithUnused = (a: Int, b: String, c: Boolean, unused: String)
 
-  private enum TestEnum extends EnumStableHashCode {
+  private enum TestEnum {
     case A, B
     case C(i: Int)
     case D(i: Int)
@@ -77,7 +76,7 @@ object ExprEvaluationSuiteBase {
     final case class B(i: Int) extends TestSealedTrait
   }
 
-  private enum TestEnumString extends EnumStableHashCode derives Codec.EnumAsString {
+  private enum TestEnumString derives Codec.EnumAsString {
     case A, B
   }
 

--- a/tyda/src/main/scala/com/choreograph/tyda/Codec.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Codec.scala
@@ -237,11 +237,8 @@ object Codec {
   }
 
   object EnumAsString {
-    inline def derived[T: ClassTag: AllSingletons as singletons]: Codec.EnumAsString[T] = {
-      val tag = summon[ClassTag[T]]
-      checkStableHashCode(tag)
+    inline def derived[T: ClassTag: AllSingletons as singletons]: Codec.EnumAsString[T] =
       SumAsString[T](summon, singletons)
-    }
   }
 
   private final case class SumAsStringInjection[T](values: scala.Seq[T], encodedValues: scala.Seq[String])
@@ -315,18 +312,6 @@ object Codec {
       def to: Codec[To] = withTo
       def classTag: ClassTag[From] = summon
     }
-
-  private def checkStableHashCode[S](tag: ClassTag[S]): Unit = {
-    val isEnum = classOf[scala.reflect.Enum].isAssignableFrom(tag.runtimeClass)
-    val hasWorkaround = classOf[EnumStableHashCode].isAssignableFrom(tag.runtimeClass)
-    if isEnum && !hasWorkaround then
-      throw new RuntimeException(
-        s"Enum ${tag
-            .runtimeClass
-            .getName} might not have stable hashCode due to https://github.com/scala/scala3/issues/19177." +
-          " Please mixing the trait EnumStableHashCode to make the hashCode stable."
-      )
-  }
 
   given byte: Codec[scala.Byte] = Byte
   given short: Codec[scala.Short] = Short
@@ -412,8 +397,6 @@ object Codec {
       throw new RuntimeException(
         s"Camel cased variant names of ${summon[ClassTag[T]].runtimeClass.getName} are not unique"
       )
-    if sum.variants.mapConst([t] => _.isInstanceOf[Variant.Singleton[t]]).exists(identity) then
-      checkStableHashCode(summon[ClassTag[T]])
     sum
 
   inline def derived[T: ClassTag](using m: Mirror.Of[T]): Codec[T] =

--- a/tyda/src/main/scala/com/choreograph/tyda/EnumStableHashCode.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/EnumStableHashCode.scala
@@ -13,6 +13,7 @@ import scala.util.hashing.MurmurHash3
   * Note: That stable here only promises that the hashCode is stable across jvm
   * executions but the implementation might be changed in the future.
   */
+@deprecated("No longer needed since Scala 3.7.3")
 trait EnumStableHashCode {
   self: scala.reflect.Enum =>
   override def hashCode(): Int = MurmurHash3.productHash(this)

--- a/tyda/src/test/scala/com/choreograph/tyda/CodecSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/CodecSpec.scala
@@ -14,12 +14,12 @@ object CodecSpec {
   final case class Person(name: String, age: Int) derives Codec
   final case class User(person: Person) derives Codec
 
-  enum AnimalEnum extends EnumStableHashCode derives Codec {
+  enum AnimalEnum derives Codec {
     case Dog(name: String)
     case Cat
   }
 
-  enum AnimalEnum2 extends EnumStableHashCode derives Codec {
+  enum AnimalEnum2 derives Codec {
     case Dog(name: String)
     case Cat(age: Option[Int])
   }
@@ -38,11 +38,11 @@ object CodecSpec {
     final case class Node1(id: Int) extends Hierarchy1
   }
 
-  enum Color extends EnumStableHashCode derives Codec.EnumAsString {
+  enum Color derives Codec.EnumAsString {
     case Red, Green, Blue
   }
 
-  enum EnumWithManyCase extends EnumStableHashCode derives Codec {
+  enum EnumWithManyCase derives Codec {
     case A
     case B(a: Int)
     case C(a: Int)

--- a/tyda/src/test/scala/com/choreograph/tyda/EnumStableHashCodeSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/EnumStableHashCodeSpec.scala
@@ -1,7 +1,10 @@
 package com.choreograph.tyda
 
+import scala.annotation.nowarn
+
 import org.scalatest.funsuite.AnyFunSuite
 
+@nowarn("cat=deprecation")
 object EnumStableHashCodeSpec {
   enum Color extends EnumStableHashCode {
     case Red, Green, Blue

--- a/tyda/src/test/scala/com/choreograph/tyda/ExprSpec.scala
+++ b/tyda/src/test/scala/com/choreograph/tyda/ExprSpec.scala
@@ -11,7 +11,7 @@ import com.choreograph.tyda.functions.tuple
 
 object ExprSpec {
   final case class Person(name: String, age: Int)
-  enum MyEnum extends EnumStableHashCode {
+  enum MyEnum {
     case A, B, C
     case D(i: Int)
   }


### PR DESCRIPTION
This workaround is no longer needed in the Scala 3.7.4 release that we
are using. So I vote for deprecation and then later removal.

The goal here is just to make it easier to use.