### PR TITLE
Override toString for Dataset and Expr

### DIFF
--- a/tyda/src/main/scala/com/choreograph/tyda/AggregateExpr.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/AggregateExpr.scala
@@ -19,6 +19,8 @@ final class AggregateExpr[T] private (private[tyda] val node: ExprNode[T]) exten
     new AggregateExpr(ExprNode.Equals(this.node, rhs.node))
   def ==(rhs: T): AggregateExpr[Boolean] =
     new AggregateExpr(ExprNode.Equals(this.node, ExprNode.Literal.create(rhs, codec)))
+
+  final override def toString: String = node.simpleShow
 }
 
 object AggregateExpr extends ExprApi[AggregateExpr] {

--- a/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
@@ -9,6 +9,7 @@ import shapeless3.deriving.K0
 
 import com.choreograph.tyda.Expr.AsExpr
 import com.choreograph.tyda.Expr.knownNotNull
+import com.choreograph.tyda.TreeApi.Continue
 import com.choreograph.tyda.TreeApi.Control
 import com.choreograph.tyda.TreeApi.StopOrContinue
 import com.choreograph.tyda.functions.coalesce
@@ -577,6 +578,14 @@ sealed trait Dataset[T: Codec] {
     * }}}
     */
   def exists: Expr[Boolean] = Expr.lift(ExprNode.ExistsSubquery(this.select(_ => 1)))
+
+  final override def toString: String = {
+    val children = Dataset
+      .api
+      .foldChildren(this)(Vector.empty[String])([t] => (acc, child) => Continue(acc :+ child.toString))
+    val name = getClass.getSimpleName
+    if children.isEmpty then name else children.mkString(s"$name(", ", ", ")")
+  }
 }
 
 object Dataset {

--- a/tyda/src/main/scala/com/choreograph/tyda/Expr.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Expr.scala
@@ -21,6 +21,8 @@ final class Expr[T] private (private[tyda] val node: ExprNode[T]) extends Select
       "Expr was compared using universal equals. " + "This is unlikely to be what was intended. " +
         "Please check the types being compared and make sure they match either Expr[T] == Expr[T] or Expr[T] == T"
     )
+
+  final override def toString: String = node.simpleShow
 }
 
 object Expr extends ExprApi[Expr] {

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
@@ -80,6 +80,14 @@ private sealed trait ExprNode[T] extends Selectable {
             case other => Continue(other)
           }
       )
+
+  final def simpleShow: String = {
+    val children = ExprNode
+      .api
+      .foldChildren(this)(Vector.empty[String])([t] => (acc, child) => Continue(acc :+ child.simpleShow))
+    val name = getClass.getSimpleName
+    if children.isEmpty then name else children.mkString(s"$name(", ", ", ")")
+  }
 }
 
 private object ExprNode extends ExprApi[ExprNode] {


### PR DESCRIPTION
The goal here is to improve the repl experience.

Before the repl would look like:
```
scala> val ds = Dataset.from(Seq((Seq(1,2,3), 2))).select { case com.choreograph.tyda.Expr(arr, value) => arr.map(_ < value) }
val ds: com.choreograph.tyda.Dataset[Seq[Boolean]] = Select1(FromSeq(List((List(1, 2, 3),2)),Product(scala.Tuple2,WrappedProductInstances(shapeless3.deriving.internals.ErasedProductInstancesN@25192b6e),None)),CompiledExpr(Reference(0,Product(scala.Tuple2,WrappedProductInstances(shapeless3.deriving.internals.ErasedProductInstancesN@25192b6e),None)),FromRepr(MapSeq(Select(Reference(0,Product(scala.Tuple2,WrappedProductInstances(shapeless3.deriving.internals.ErasedProductInstancesN@25192b6e),None)),_1),CompiledExpr(Reference(1,Int),LessThan(Int,Reference(1,Int),Select(Reference(0,Product(scala.Tuple2,WrappedProductInstances(shapeless3.deriving.internals.ErasedProductInstancesN@25192b6e),None)),_2)))),Iterable(scala.collection.immutable.Seq,Boolean))))
```
after
```
scala> val ds = Dataset.from(Seq((Seq(1,2,3), 2))).select { case com.choreograph.tyda.Expr(arr, value) => arr.map(_ < value) }
val ds: com.choreograph.tyda.Dataset[Seq[Boolean]] = Select1(FromSeq)
```

The thinking here is that we keep some strucutre since that is useful
for debugging. But we having creating walls of text for simple
operations.

We can always re-evaluate and make it more or/less detailed later. But
we already have `explain()` to get the full plan, so there should be no
reason to duplicate that for each toString invocation.

Fixes #143
