### PR TITLE
Remove workaround for SPARK-47241

### DIFF
--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/DatasetOnSpark.scala
@@ -268,25 +268,6 @@ object DatasetOnSpark {
           IntermediateDataset(filtered)
         case ExplodeOptionToFilter(ds) => toIntermediate(ds)
         case select: Dataset.Select1[?, T] => IntermediateDataset(select1(select))
-        // Workaround for https://issues.apache.org/jira/browse/SPARK-47241 that is present in Spark 3.5.1
-        // The bug means that multiple explodes in the same select lead to planning issues, but planning them
-        // as concecutive selects works.
-        case selectN: Dataset.SelectN[?, ?] if multipleExplodes(selectN) =>
-          val input = toIntermediate(selectN.input).toDataset
-          val exprs = tupleInstances(selectN.exprs)
-          val rowColumnName = "row"
-          val (df, _) =
-            exprs.foldLeft0((input.select(struct("*").as(rowColumnName)), 0)) { [t] => (dsAndCount, expr) =>
-              val (ds, resultExprCount) = dsAndCount
-              val cf = ColumnFactory(ds(rowColumnName))(using selectN.input.codec)
-              val select = convertExplodeExpr(cf, expr)
-              val existingResultColumns = (1 to resultExprCount).map(i => ds(s"_$i"))
-              val columns = existingResultColumns ++
-                Seq(select.as(s"_${resultExprCount + 1}"), ds(rowColumnName))
-              (ds.select(columns*), resultExprCount + 1)
-            }
-          val columns = (1 to exprs.arity).map(i => df(s"_$i"))
-          IntermediateDataset(df.select(columns*).as[T])
         case selectN: Dataset.SelectN[?, ?] =>
           val (input, cf) = toIntermediate(selectN.input).toDataFrameAndColumnFactory
           val columns = tupleInstances(selectN.exprs)
@@ -389,17 +370,6 @@ object DatasetOnSpark {
         val column = convertExplodeExpr(cf, other)
         selectAndUnpack(df, column)
     }
-  }
-
-  private def multipleExplodes(select: Dataset.SelectN[?, ?]): Boolean = {
-    val explodes = tupleInstances(select.exprs).foldLeft0(0)([t] =>
-      (count, expr) =>
-        expr match {
-          case CompiledExplodeExpr(_, _) => count + 1
-          case _ => count
-        }
-    )
-    explodes > 1
   }
 
   private def isSelfJoin(left: Dataset[?], right: Dataset[?]): Boolean = {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -114,7 +114,7 @@ private def exprToSqlExpr(expr: ExplodeExpr[?] | ExprNode[?], args: UnparserArgs
   expr match {
     case e: ExplodeExpr[?] => exprToSqlExpr(e.expr, args).map(arg =>
         args.dialect.explode match {
-          case SqlDialect.ExplodeSupport.Function(name, _) => SqlExpr.Function(name, Seq(arg))
+          case SqlDialect.ExplodeSupport.Function(name) => SqlExpr.Function(name, Seq(arg))
           case SqlDialect.ExplodeSupport.InnerJoin =>
             unreachable("Explodes using inner join should be handled in the SelectBuilder")
         }

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -310,7 +310,7 @@ private final case class SelectBuilder[T, R](
   private def selectExplode[R2](explode: CompiledExplodeExpr[R, R2]): Result[SelectBuilder[?, R2]] = {
     given Codec[R2] = explode.codec
     args.dialect.explode match {
-      case SqlDialect.ExplodeSupport.Function(_, _) => selectExplodeFunction(explode)
+      case SqlDialect.ExplodeSupport.Function(_) => selectExplodeFunction(explode)
       case SqlDialect.ExplodeSupport.InnerJoin => selectExplodeJoin(explode)
     }
   }
@@ -352,66 +352,24 @@ private final case class SelectBuilder[T, R](
       exprs: Tuple.Map[R2, [X] =>> CompiledExprOrExplode[R, X]]
   ): Result[SelectBuilder[?, R2]] =
     args.dialect.explode match {
-      case SqlDialect.ExplodeSupport.Function(_, supportMultiple) =>
-        selectNExplodeFunction(exprs, supportMultiple)
+      case SqlDialect.ExplodeSupport.Function(_) => selectNExplodeFunction(exprs)
       case SqlDialect.ExplodeSupport.InnerJoin => selectNExplodeJoin(exprs)
     }
 
   private def selectNExplodeFunction[R2 <: Tuple](
-      exprs: Tuple.Map[R2, [X] =>> CompiledExprOrExplode[R, X]],
-      supportMultipleExplodes: Boolean
+      exprs: Tuple.Map[R2, [X] =>> CompiledExprOrExplode[R, X]]
   ): Result[SelectBuilder[?, R2]] = {
-
-    val nbrExplodes = tupleInstances(exprs).foldLeft0(0)([t] =>
-      (acc, compiled) =>
-        compiled match {
-          case _: CompiledExplodeExpr[?, ?] => acc + 1
-          case compiled: CompiledExpr[?, ?] => acc
-        }
-    )
     val codec = Codec.tuple(tupleInstances(exprs).mapK([t] => _.codec))
-    // Workaround for old Spark versions not supporting multiple explodes
-    if nbrExplodes > 1 && !supportMultipleExplodes then {
-      val rowColumnName = "row"
-      val queryResult = buildWithSelect(NonEmpty[Seq]((RelaxedCompiledExpr(select), rowColumnName)))
-      tupleInstances(exprs)
-        .foldLeft0(queryResult.map((_, 0)))([t] =>
-          (result, selectExpr) =>
-            result.flatMap((query, resultCount) =>
-              val alias = args.aliasGen.table()
-              val from = From.Subquery(query, alias)
-              val rowExpr = SqlExpr.FieldAccess(SqlExpr.Ident(alias), rowColumnName)
-              def column(name: String) = SqlExpr.As(SqlExpr.FieldAccess(SqlExpr.Ident(alias), name), name)
-              val existingResultColumns = (1 to resultCount).map(i => column(s"_${i}"))
+    val newSelect = NonEmpty
+      .from(
+        tupleInstances(exprs)
+          .mapConst([t] => compiled => andThenRelaxed(select, compiled))
+          .zipWithIndex
+          .map { case (e, i) => (e, s"_${i + 1}") }
+      )
+      .getOrElse(unreachable("Selects contains at least one statement"))
 
-              val (arg, expr) = selectExpr match {
-                case explode: CompiledExplodeExpr[?, ?] => (explode.arg, ExplodeExpr(explode.expr))
-                case compiled: CompiledExpr[?, ?] => (compiled.arg, compiled.expr)
-              }
-              val newQuery = simplifyAndToSqlExpr(expr, Map(arg -> IdentifierOrSqlExpr.Expr(rowExpr)), args)
-                .map(SqlExpr.As(_, s"_${resultCount + 1}"))
-                .map(newResult =>
-                  NonEmpty[Seq](SqlExpr.As(rowExpr, rowColumnName)) ++ existingResultColumns ++ Seq(newResult)
-                )
-                .map(newSelect =>
-                  Query.Select(newSelect, Some(from), None, Seq.empty, None, distinct = false)
-                )
-              newQuery.map((_, resultCount + 1))
-            )
-        )
-        .map((query, _) => makeSubquery(query, codec))
-    } else {
-      val newSelect = NonEmpty
-        .from(
-          tupleInstances(exprs)
-            .mapConst([t] => compiled => andThenRelaxed(select, compiled))
-            .zipWithIndex
-            .map { case (e, i) => (e, s"_${i + 1}") }
-        )
-        .getOrElse(unreachable("Selects contains at least one statement"))
-
-      buildWithSelect(newSelect).map(makeSubquery(_, codec))
-    }
+    buildWithSelect(newSelect).map(makeSubquery(_, codec))
   }
 
   private def selectNExplodeJoin[R2 <: Tuple](

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -259,7 +259,7 @@ object SqlDialect {
       * explode(array_column)
       * ```
       */
-    case Function(name: String, supportMultipleExplodes: Boolean)
+    case Function(name: String)
 
     /** Explode is supported by doing a inner join with the array column. e.g.
       * ```
@@ -506,7 +506,7 @@ object SqlDialect {
     countIfFunction = "count_if",
     ddl = DdlDialect.Spark,
     errorFunction = "raise_error",
-    explode = ExplodeSupport.Function("explode", supportMultipleExplodes = false),
+    explode = ExplodeSupport.Function("explode"),
     extractDateDays = "unix_date",
     extractTimestampMicros = "unix_micros",
     floatingAggregate = FloatingAggregate.NaNIsLargest,

--- a/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
@@ -43,7 +43,7 @@ SELECT explode(t0.value) AS value FROM (SELECT explode(t1.value) AS value FROM t
 ------ end
 
 ------ Test: explode multiple nested Seq
-SELECT t1.row AS row, t1._1 AS _1, explode(t1.row._2) AS _2 FROM (SELECT t0.row AS row, explode(t0.row._1) AS _1 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2) AS row FROM t1) AS t0) AS t1
+SELECT explode(t1._1) AS _1, explode(t1._2) AS _2 FROM t1
 ------ end
 
 ------ Test: explode nested Seq
@@ -123,7 +123,7 @@ SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS
 ------ end
 
 ------ Test: select 7 explode
-SELECT t6.row AS row, t6._1 AS _1, t6._2 AS _2, t6._3 AS _3, t6._4 AS _4, t6._5 AS _5, t6._6 AS _6, explode(t6.row._7) AS _7 FROM (SELECT t5.row AS row, t5._1 AS _1, t5._2 AS _2, t5._3 AS _3, t5._4 AS _4, t5._5 AS _5, explode(t5.row._6) AS _6 FROM (SELECT t4.row AS row, t4._1 AS _1, t4._2 AS _2, t4._3 AS _3, t4._4 AS _4, explode(t4.row._5) AS _5 FROM (SELECT t3.row AS row, t3._1 AS _1, t3._2 AS _2, t3._3 AS _3, explode(t3.row._4) AS _4 FROM (SELECT t2.row AS row, t2._1 AS _1, t2._2 AS _2, explode(t2.row._3) AS _3 FROM (SELECT t1.row AS row, t1._1 AS _1, explode(t1.row._2) AS _2 FROM (SELECT t0.row AS row, explode(t0.row._1) AS _1 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2, '_3', t1._3, '_4', t1._4, '_5', t1._5, '_6', t1._6, '_7', t1._7) AS row FROM t1) AS t0) AS t1) AS t2) AS t3) AS t4) AS t5) AS t6
+SELECT explode(t1._1) AS _1, explode(t1._2) AS _2, explode(t1._3) AS _3, explode(t1._4) AS _4, explode(t1._5) AS _5, explode(t1._6) AS _6, explode(t1._7) AS _7 FROM t1
 ------ end
 
 ------ Test: select Product
@@ -143,7 +143,7 @@ SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 WHERE ((t1._1 IS NOT NULL) AND (t1._2 IS
 ------ end
 
 ------ Test: select multiple explode seq
-SELECT t1.row AS row, t1._1 AS _1, explode(t1.row._2) AS _2 FROM (SELECT t0.row AS row, explode(t0.row._1) AS _1 FROM (SELECT named_struct('_1', t1._1, '_2', t1._2) AS row FROM t1) AS t0) AS t1
+SELECT explode(t1._1) AS _1, explode(t1._2) AS _2 FROM t1
 ------ end
 
 ------ Test: select nested access

--- a/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
@@ -67,7 +67,7 @@ SELECT table1.a AS _1, table2.a AS _2 FROM table1 JOIN table2 ON (table1.a = tab
 ------ end
 
 ------ Test: join and then explode
-SELECT t1.row AS row, t1._1 AS _1, explode(t1.row._2.d) AS _2 FROM (SELECT t0.row AS row, explode(t0.row._1.d) AS _1 FROM (SELECT named_struct('_1', named_struct('a', table1.a, 'b', table1.b, 'c', table1.c, 'd', table1.d), '_2', named_struct('a', table2.a, 'b', table2.b, 'c', table2.c, 'd', table2.d)) AS row FROM table1 JOIN table2 ON (table1.a = table2.a)) AS t0) AS t1
+SELECT explode(table1.d) AS _1, explode(table2.d) AS _2 FROM table1 JOIN table2 ON (table1.a = table2.a)
 ------ end
 
 ------ Test: join+aggregate on lhs


### PR DESCRIPTION
After upgrading to Spark 3.5.3 we no longer need this workaround.
