### PR TITLE
Fix so lambda2 is "compiled" once

### DIFF
--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/ExprEvaluation.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/ExprEvaluation.scala
@@ -53,7 +53,8 @@ object ExprEvaluation {
     lambdaN(NonEmpty[Seq](compiled.arg), compiled.expr)
 
   private[tyda] def lambda2[T1, T2, R](compiled: CompiledExpr2[T1, T2, R]): (T1, T2) => R =
-    (t1, t2) => lambdaN[(T1, T2), R](NonEmpty[Seq](compiled.arg1, compiled.arg2), compiled.expr)((t1, t2))
+    val tupled = lambdaN[(T1, T2), R](NonEmpty[Seq](compiled.arg1, compiled.arg2), compiled.expr)
+    tupled(_, _)
 
   private def trimSpaces(str: String): String = {
     val first = str.indexWhere(_ != ' ')


### PR DESCRIPTION
Seems like this problem was here from the begining that the lambdaN call
was inside the returned tuple. This means that we converted the
expressions each invocation. This can be slow for expressions for doing
select on larger structs as we look up the field index each time.

Fixes: #151
