### PR TITLE
Do not expect ordered results in orderBy then join test

### DIFF
--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetOrderBySuite.scala
@@ -85,10 +85,7 @@ trait DatasetOrderBySuite extends DatasetSuite {
     "join then orderBy",
     (ds1, ds2) => ds1.join(ds2, _ == _).select(_._1).orderBy(identity)
   )
-  testOrdered[Int, Int, Int](
-    "orderBy then join",
-    (ds1, ds2) => ds1.orderBy(identity).join(ds2, _ == _).select(_._1)
-  )
+  test[Int, Int, Int]("orderBy then join", (ds1, ds2) => ds1.orderBy(identity).join(ds2, _ == _).select(_._1))
 
   testOrdered[Int, Int]("distinct then orderBy", _.distinct.orderBy(identity))
   test[Int, Int]("orderBy then distinct", _.orderBy(identity).distinct)


### PR DESCRIPTION
There is no promise on the order of the join output, so our tests should
not expect it either.

Failed in CI here: https://github.com/unum-io/tyda/actions/runs/29310881750/job/87014174623
