### PR TITLE
Support --help in TydaRepl

### DIFF
--- a/tyda-repl/src/main/scala/com/choreograph/tyda/repl/TydaRepl.scala
+++ b/tyda-repl/src/main/scala/com/choreograph/tyda/repl/TydaRepl.scala
@@ -60,6 +60,9 @@ object TydaRepl {
   }
 
   def main(args: Array[String]): Unit =
+    if args.contains("--help") then
+      Console.println(s"TydaRepl options:\n${ArgsParser.help[Args]}")
+      System.exit(0)
     ArgsParser.parse[Args](args.toSeq) match
       case Right(parsed) => run(parsed)
       case Left(error) =>


### PR DESCRIPTION
If any arg is `--help` we print the help info and exit.

Fixes: #146
