### PR TITLE
Remove usages of AsExpr.Of[Boolean]

### DIFF
--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
@@ -5,6 +5,7 @@ import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.aggregates.sum
 import com.choreograph.tyda.functions.explode
+import com.choreograph.tyda.functions.lit
 
 object DatasetBasicSuite {
   type WideTuple = (Int, Int, Int, Int, Int, Int, Int)
@@ -19,7 +20,7 @@ trait DatasetBasicSuite extends DatasetSuite {
   test[Boolean, Boolean]("filter", _.filter(identity))
   test[Boolean, Boolean]("where", _.where(identity))
   test[Boolean, Boolean]("where not", _.where(!_))
-  test[Boolean, Boolean]("where literal", _.where(_ => true))
+  test[Boolean, Boolean]("where literal", _.where(_ => lit(true)))
   test[((Int, Int), Int), Int]("select nested access", _.select(_._1._1))
   test[Boolean, (Boolean, Int)]("select Product", _.select(v => (v, 1)))
   test[Boolean, Int]("select primitive", _.select(_ => 1))

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetJoinSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetJoinSuite.scala
@@ -5,6 +5,7 @@ import com.choreograph.tyda.Arbitrary
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.Expr.explode
+import com.choreograph.tyda.functions.lit
 import com.choreograph.tyda.testsuites.DatasetSuite.TinyByte
 
 object DatasetJoinSuite {
@@ -60,7 +61,7 @@ trait DatasetJoinSuite extends DatasetSuite {
   )
   test[TinyByte, EmptyTuple.type, (TinyByte, Option[EmptyTuple.type])](
     "leftOuterJoin singleton",
-    (ds1, ds2) => ds1.leftOuterJoin(ds2, (_, _) => true)
+    (ds1, ds2) => ds1.leftOuterJoin(ds2, (_, _) => lit(true))
   )
   test[Pair, Pair, (Pair, Option[Pair])](
     "leftOuterJoin product",

--- a/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/Dataset.scala
@@ -31,7 +31,7 @@ sealed trait Dataset[T: Codec] {
   def filter(p: T => Boolean): Dataset[T] = where(_.udf(p))
 
   /** Filter the Dataset based on a expression predicate. */
-  def where[R: AsExpr.Of[Boolean]](p: Expr[T] => R): Dataset[T] = Dataset.Filter(this, CompiledExpr(p))
+  def where[R](p: Expr[T] => Expr[Boolean]): Dataset[T] = Dataset.Filter(this, CompiledExpr(p))
 
   /** Select a single expression from the Dataset.
     *
@@ -488,10 +488,7 @@ sealed trait Dataset[T: Codec] {
   /** Perform a inner join with another [[Dataset]] using the given join
     * condition.
     */
-  def join[U, R: AsExpr.Of[Boolean]](
-      other: Dataset[U],
-      condition: (Expr[T], Expr[U]) => R
-  ): Dataset[(T, U)] = {
+  def join[U](other: Dataset[U], condition: (Expr[T], Expr[U]) => Expr[Boolean]): Dataset[(T, U)] = {
     given Codec[U] = other.codec
     Dataset.Join(this, other, CompiledExpr2(condition))
   }
@@ -499,10 +496,7 @@ sealed trait Dataset[T: Codec] {
   /** Perform a left outer join with another [[Dataset]] using the given join
     * condition.
     */
-  def leftOuterJoin[U, R: AsExpr.Of[Boolean]](
-      other: Dataset[U],
-      p: (Expr[T], Expr[U]) => R
-  ): Dataset[(T, Option[U])] = {
+  def leftOuterJoin[U](other: Dataset[U], p: (Expr[T], Expr[U]) => Expr[Boolean]): Dataset[(T, Option[U])] = {
     given Codec[U] = other.codec
     Dataset.LeftOuterJoin(this, other, CompiledExpr2(p))
   }
@@ -510,17 +504,15 @@ sealed trait Dataset[T: Codec] {
   /** Perform a right outer join with another [[Dataset]] using the given join
     * condition.
     */
-  def rightOuterJoin[U, R: AsExpr.Of[Boolean]](
-      other: Dataset[U],
-      p: (Expr[T], Expr[U]) => R
-  ): Dataset[(Option[T], U)] = other.leftOuterJoin(this, (l, r) => p(r, l)).select(_._2, _._1)
+  def rightOuterJoin[U](other: Dataset[U], p: (Expr[T], Expr[U]) => Expr[Boolean]): Dataset[(Option[T], U)] =
+    other.leftOuterJoin(this, (l, r) => p(r, l)).select(_._2, _._1)
 
   /** Perform a full outer join with another [[Dataset]] using the given join
     * condition.
     */
-  def fullOuterJoin[U, R: AsExpr.Of[Boolean]](
+  def fullOuterJoin[U](
       other: Dataset[U],
-      p: (Expr[T], Expr[U]) => R
+      p: (Expr[T], Expr[U]) => Expr[Boolean]
   ): Dataset[(Option[T], Option[U])] = {
     given Codec[U] = other.codec
     Dataset.FullOuterJoin(this, other, CompiledExpr2(p))
@@ -533,7 +525,7 @@ sealed trait Dataset[T: Codec] {
     * in the right side that match the join condition. In SQL left anti join are
     * usually created using a WHERE NOT EXISTS with a correlated subquery.
     */
-  def leftAntiJoin[U, R: AsExpr.Of[Boolean]](other: Dataset[U], p: (Expr[T], Expr[U]) => R): Dataset[T] = {
+  def leftAntiJoin[U](other: Dataset[U], p: (Expr[T], Expr[U]) => Expr[Boolean]): Dataset[T] = {
     given Codec[U] = other.codec
     Dataset.LeftAntiJoin(this, other, CompiledExpr2(p))
   }

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
@@ -111,15 +111,13 @@ trait ExprApi[Expr[T]] {
       * applied to the value.
       */
     @targetName("optionExists")
-    def exists[I: AsExpr.Of[Boolean]](p: Expr[T] => I): Expr[Boolean] =
-      ternary(isEmpty, ifTrue = false, p(get))
+    def exists(p: Expr[T] => Expr[Boolean]): Expr[Boolean] = ternary(isEmpty, ifTrue = false, p(get))
 
     /** Returns true if the option is None or the predicate returns true when
       * applied to the value.
       */
     @targetName("optionForall")
-    def forall[I: AsExpr.Of[Boolean]](p: Expr[T] => I): Expr[Boolean] =
-      ternary(isEmpty, ifTrue = true, p(get))
+    def forall(p: Expr[T] => Expr[Boolean]): Expr[Boolean] = ternary(isEmpty, ifTrue = true, p(get))
 
     /** Returns true if the option is Some and contains the value.
       */
@@ -707,12 +705,12 @@ trait ExprApi[Expr[T]] {
 
     /** Check if all elements in the sequence satisfy the given predicate.
       */
-    def forall[I: AsExpr.Of[Boolean]](p: Expr[T] => I): Expr[Boolean] =
+    def forall(p: Expr[T] => Expr[Boolean]): Expr[Boolean] =
       map(p).fold(PrimitiveAggregate.BoolAnd(), onEmpty = true)
 
     /** Check if any element in the sequence satisfy the given predicate.
       */
-    def exists[I: AsExpr.Of[Boolean]](p: Expr[T] => I): Expr[Boolean] =
+    def exists(p: Expr[T] => Expr[Boolean]): Expr[Boolean] =
       map(p).fold(PrimitiveAggregate.BoolOr(), onEmpty = false)
 
     /** Check if the sequence contains the given element.


### PR DESCRIPTION
Removes AsExpr conversions from functions expecting a boolean.

The AsExpr conversion was mainly added/implemented to make it more
convenient to work with tuples and literals in the Expr-api. But this
very rarely applies for places expecting a Boolean. Or I can not come up
with code where I would want to pass a literal Boolean to the functions
taking a AsExpr.Of[Boolean]. But due to things like universal equals it
quite easy to all such a function with a literal accidentally. So this
path suggest we remove the conversions for such a method and there
hopefully makes the api simpler and easier to use correctly.
