### PR TITLE
Exclude generated file project/SparkDependencies.scala from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     interval: "daily"
   cooldown:
     default-days: 7
+  exclude-paths:
+    - "project/SparkDependencies.scala"
   ignore:
-  - dependency-name: "org.apache.spark:*"
-  - dependency-name: "org.scala-lang:*"
+    - dependency-name: "org.apache.spark:*"
+    - dependency-name: "org.scala-lang:*"


### PR DESCRIPTION
Otherwise we will get lots or PRs that we will never want to merge.
