### PR TITLE
Simplify join explode logic for complex expressions

### DIFF
--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -115,8 +115,7 @@ private def exprToSqlExpr(expr: ExplodeExpr[?] | ExprNode[?], args: UnparserArgs
     case e: ExplodeExpr[?] => exprToSqlExpr(e.expr, args).map(arg =>
         args.dialect.explode match {
           case SqlDialect.ExplodeSupport.Function(name) => SqlExpr.Function(name, Seq(arg))
-          case SqlDialect.ExplodeSupport.InnerJoin =>
-            unreachable("Explodes using inner join should be handled in the SelectBuilder")
+          case SqlDialect.ExplodeSupport.InnerJoin(name) => SqlExpr.Function(name, Seq(arg))
         }
       )
     case e: ExprNode[?] => exprToSqlExpr(e, args)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -27,7 +27,6 @@ import com.choreograph.tyda.NonEmpty
 import com.choreograph.tyda.TreeApi.Continue
 import com.choreograph.tyda.TreeApi.Skip
 import com.choreograph.tyda.functions.lit
-import com.choreograph.tyda.rewrite.ArrayCodec
 import com.choreograph.tyda.rewrite.IsNone
 import com.choreograph.tyda.rewrite.Nullable
 import com.choreograph.tyda.rewrite.StructFields
@@ -311,7 +310,7 @@ private final case class SelectBuilder[T, R](
     given Codec[R2] = explode.codec
     args.dialect.explode match {
       case SqlDialect.ExplodeSupport.Function(_) => selectExplodeFunction(explode)
-      case SqlDialect.ExplodeSupport.InnerJoin => selectExplodeJoin(explode)
+      case SqlDialect.ExplodeSupport.InnerJoin(_) => selectExplodeJoin(explode)
     }
   }
 
@@ -333,13 +332,12 @@ private final case class SelectBuilder[T, R](
       explode: CompiledExplodeExpr[R, R2]
   ): Result[SelectBuilder[?, R2]] =
     select match {
-      case compiled: CompiledExpr[T, R]
-          if !distinct && onlySelects(compiled.andThen(explode.asCompiledExpr).expr) =>
+      case compiled: CompiledExpr[T, R] if !distinct =>
         given Codec[T] = from.output.codec
         val newSelect = CompiledExpr[(T, R2), R2](_._2)
         val newWhere = where.map(_.compose(CompiledExpr[(T, R2), T](_._1)))
         TypedFrom
-          .join(from, compiled.andThen(explode.asCompiledExpr), args)
+          .join(from, explode.compose(compiled), args)
           .map(newFrom => SelectBuilder(args, from = newFrom, select = newSelect, where = newWhere))
       case _ =>
         given Codec[Iterable[R2]] = explode.expr.codec
@@ -353,7 +351,7 @@ private final case class SelectBuilder[T, R](
   ): Result[SelectBuilder[?, R2]] =
     args.dialect.explode match {
       case SqlDialect.ExplodeSupport.Function(_) => selectNExplodeFunction(exprs)
-      case SqlDialect.ExplodeSupport.InnerJoin => selectNExplodeJoin(exprs)
+      case SqlDialect.ExplodeSupport.InnerJoin(_) => selectNExplodeJoin(exprs)
     }
 
   private def selectNExplodeFunction[R2 <: Tuple](
@@ -376,17 +374,8 @@ private final case class SelectBuilder[T, R](
       exprs: Tuple.Map[R2, [X] =>> CompiledExprOrExplode[R, X]]
   ): Result[SelectBuilder[?, R2]] = {
     val instances = tupleInstances(exprs)
-    def allOnlySelects(compiled: CompiledExpr[T, R]): Boolean =
-      instances.foldLeft0(true)([t] =>
-        (acc, select) =>
-          select match {
-            case CompiledExpr(_, _) => acc
-            case explode: CompiledExplodeExpr[?, ?] => acc &&
-              onlySelects(compiled.andThen(explode.asCompiledExpr).expr)
-          }
-      )
     select match {
-      case compiled: CompiledExpr[T, R] if !distinct && allOnlySelects(compiled) =>
+      case compiled: CompiledExpr[T, R] if !distinct =>
         // The explodes can be added as joins in the existing from without a subquery.
         val explodeCodecs = instances.foldLeft0(Vector.empty[Codec[?]])([t] =>
           (acc, select) =>
@@ -417,39 +406,7 @@ private final case class SelectBuilder[T, R](
         TypedFrom
           .joinExplode(from, joinExprs.toSeq, newFromCodec, args)
           .map(newFrom => SelectBuilder(args, from = newFrom, select = newSelect, where = newWhere))
-      case _ =>
-        /* The select can not be done as part of the current select, instead we apply the select without
-         * explodes create a subquery and then do the select with only the explode part */
-        val wasExplodeAndExpr = instances.mapConst[(Boolean, CompiledExpr[R, ?])]([t] =>
-          _ match {
-            case explode: CompiledExplodeExpr[R, ?] => (true, explode.asCompiledExpr)
-            case compiled: CompiledExpr[R, ?] => (false, compiled)
-          }
-        )
-        // TYPE SAFETY: Each value in wasExplodeAndExpr.map(_._2) is a CompiledExpr[R, ?]
-        val exprsWithoutExplodes = Tuple
-          .fromArray(wasExplodeAndExpr.map(_._2).toArray)
-          .asInstanceOf[Tuple.Map[Tuple, [X] =>> CompiledExprOrExplode[R, X]]]
-        selectN(exprsWithoutExplodes).flatMap(afterSelect =>
-          val codec = afterSelect.select.expr.codec
-          val arg = ExprNode.Reference()(using codec)
-          val explodesArray = wasExplodeAndExpr
-            .map(_._1)
-            .zipWithIndex
-            .map { (wasExplode, i) =>
-              val body = ExprNode.Select(arg, s"_${i + 1}")
-              // TYPE SAFETY: If wasExplode the body came from a CompiledExplodeExpr and must be Iterable
-              if wasExplode then CompiledExplodeExpr(arg, body.asInstanceOf[ExprNode[Iterable[?]]])
-              else CompiledExpr(arg, body)
-            }
-            .toArray
-          /* TYPE SAFETY: Each element is a CompiledExprOrExplode[Tuple, ?] where Tuple matches afterSelect
-           * output by contruction. */
-          val onlyExplodes = Tuple
-            .fromArray(explodesArray)
-            .asInstanceOf[Tuple.Map[R2, [X] =>> CompiledExprOrExplode[Tuple, X]]]
-          afterSelect.toSubquery.flatMap(_.selectN(onlyExplodes))
-        )
+      case _ => toSubquery.flatMap(_.selectN(exprs))
     }
   }
 
@@ -685,17 +642,6 @@ private object SelectBuilder {
   private def isJoin(from: TypedFrom[?]): Boolean =
     from match {
       case TypedFrom(From.Join(_, _, _, _), _, _) => true
-      case _ => false
-    }
-
-  private def onlySelects(expr: ExprNode[?]): Boolean =
-    simplifySelects(expr).forall {
-      case ExprNode.Reference(_, _) | ExprNode.Select(_, _) => true
-      // Upcasts of Map will need a CAST to the correct type
-      case ExprNode.UpcastToIterable(col) => col.codec match {
-          case ArrayCodec(_) => true
-          case _ => false
-        }
       case _ => false
     }
 

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -266,7 +266,7 @@ object SqlDialect {
       * FROM table JOIN table.array_column AS exploded_column
       * ```
       */
-    case InnerJoin
+    case InnerJoin(unnest: String)
   }
 
   enum FloatingCompare {
@@ -443,7 +443,7 @@ object SqlDialect {
       supportsArrayAsArrayElement = false
     ),
     errorFunction = "error",
-    explode = ExplodeSupport.InnerJoin,
+    explode = ExplodeSupport.InnerJoin("unnest"),
     extractDateDays = "unix_date",
     extractTimestampMicros = "unix_micros",
     floatingAggregate = FloatingAggregate.NaNIsSmallestAndLargest,

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
@@ -2,8 +2,8 @@ package com.choreograph.tyda.sql
 
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.CompiledExplodeExpr
-import com.choreograph.tyda.CompiledExpr
 import com.choreograph.tyda.CompiledExpr2
+import com.choreograph.tyda.ExplodeExpr
 import com.choreograph.tyda.ExprNode
 import com.choreograph.tyda.Forbidden
 import com.choreograph.tyda.NonEmpty
@@ -45,11 +45,11 @@ private object TypedFrom {
   }
 
   private def joinExplodeReferenceAndOutput[U](
-      codec: Codec[Iterable[U]],
+      codec: Codec[U],
       dialect: SqlDialect
   ): (reference: ExprNode.Reference[?], output: ExprNode[U]) = {
-    given elementCodec: Codec[U] = codec.element
-    if shouldWrapArrayElement(elementCodec, dialect.ddl) then {
+    given Codec[U] = codec
+    if shouldWrapArrayElement(codec, dialect.ddl) then {
       val ref = ExprNode.Reference[(value: U)]()
       (ref, ExprNode.Select(ref, "value"))
     } else {
@@ -61,10 +61,10 @@ private object TypedFrom {
   /** Explode right column using INNER JOIN syntax */
   def join[T, U](
       left: TypedFrom[T],
-      right: CompiledExpr[T, Iterable[U]],
+      right: CompiledExplodeExpr[T, U],
       args: UnparserArgs
   ): Result[TypedFrom[(T, U)]] = {
-    val exprReplaced = right.expr.replace(right.arg, left.output)
+    val exprReplaced = ExplodeExpr(right.expr.replace(right.arg, left.output))
     val alias = args.aliasGen.table()
     val (ref, output) = joinExplodeReferenceAndOutput(right.codec, args.dialect)
     simplifyAndToSqlExpr(exprReplaced, left.ids, args).map(rightSql =>
@@ -90,10 +90,10 @@ private object TypedFrom {
     assert(codec.fields.arity == rights.length + 1, "Codec arity does not match number of right expressions")
     rights
       .map(f =>
-        val expr = f.expr.replace(f.arg, left.output)
+        val expr = ExplodeExpr(f.expr.replace(f.arg, left.output))
         for {
           sqlExpr <- simplifyAndToSqlExpr(expr, left.ids, args)
-          (ref, output) = joinExplodeReferenceAndOutput(f.expr.codec, args.dialect)
+          (ref, output) = joinExplodeReferenceAndOutput(f.codec, args.dialect)
         } yield (ref, output, sqlExpr)
       )
       .sequence

--- a/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
@@ -27,7 +27,7 @@ SELECT DISTINCT t1.value AS value FROM t1
 ------ end
 
 ------ Test: explode Map
-SELECT t2._1 AS _1, t2._2 AS _2 FROM (SELECT CAST(t0.value AS ARRAY<STRUCT<_1 INT,_2 INT>>) AS value FROM (SELECT t1.value AS value FROM t1) AS t0) AS t1, t1.value AS t2
+SELECT t0._1 AS _1, t0._2 AS _2 FROM t1, unnest(CAST(t1.value AS ARRAY<STRUCT<_1 INT,_2 INT>>)) AS t0
 ------ end
 
 ------ Test: explode Option
@@ -35,19 +35,19 @@ SELECT t1.value AS value FROM t1 WHERE (t1.value IS NOT NULL)
 ------ end
 
 ------ Test: explode Seq
-SELECT t0 AS value FROM t1, t1.value AS t0
+SELECT t0 AS value FROM t1, unnest(t1.value) AS t0
 ------ end
 
 ------ Test: explode Seq Option Seq
-SELECT t2 AS value FROM (SELECT t0.value AS value FROM t1, t1.value AS t0 WHERE (t0.value IS NOT NULL)) AS t1, t1.value AS t2
+SELECT t1 AS value FROM t1, unnest(t1.value) AS t0, unnest(t0.value) AS t1 WHERE (t0.value IS NOT NULL)
 ------ end
 
 ------ Test: explode multiple nested Seq
-SELECT t0.value AS _1, t1.value AS _2 FROM t1, t1._1 AS t0, t1._2 AS t1
+SELECT t0.value AS _1, t1.value AS _2 FROM t1, unnest(t1._1) AS t0, unnest(t1._2) AS t1
 ------ end
 
 ------ Test: explode nested Seq
-SELECT t1 AS value FROM t1, t1.value AS t0, t0.value AS t1
+SELECT t1 AS value FROM t1, unnest(t1.value) AS t0, unnest(t0.value) AS t1
 ------ end
 
 ------ Test: limit after aggregate
@@ -55,7 +55,7 @@ SELECT t1._1 AS key, sum(t1._2) AS value FROM t1 GROUP BY t1._1 LIMIT 5
 ------ end
 
 ------ Test: limit after explode
-SELECT t0 AS value FROM t1, t1._2 AS t0 LIMIT 5
+SELECT t0 AS value FROM t1, unnest(t1._2) AS t0 LIMIT 5
 ------ end
 
 ------ Test: limit after filter
@@ -79,7 +79,7 @@ SELECT t0._1 AS key, sum(t0._2) AS value FROM (SELECT t1._1 AS _1, t1._2 AS _2 F
 ------ end
 
 ------ Test: limit before explode
-SELECT t1 AS value FROM (SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 LIMIT 5) AS t0, t0._2 AS t1
+SELECT t1 AS value FROM (SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 LIMIT 5) AS t0, unnest(t0._2) AS t1
 ------ end
 
 ------ Test: limit before filter
@@ -123,7 +123,7 @@ SELECT t1._1 AS _1, t1._2 AS _2, t1._3 AS _3, t1._4 AS _4, t1._5 AS _5, t1._6 AS
 ------ end
 
 ------ Test: select 7 explode
-SELECT t0 AS _1, t1 AS _2, t2 AS _3, t3 AS _4, t4 AS _5, t5 AS _6, t6 AS _7 FROM t1, t1._1 AS t0, t1._2 AS t1, t1._3 AS t2, t1._4 AS t3, t1._5 AS t4, t1._6 AS t5, t1._7 AS t6
+SELECT t0 AS _1, t1 AS _2, t2 AS _3, t3 AS _4, t4 AS _5, t5 AS _6, t6 AS _7 FROM t1, unnest(t1._1) AS t0, unnest(t1._2) AS t1, unnest(t1._3) AS t2, unnest(t1._4) AS t3, unnest(t1._5) AS t4, unnest(t1._6) AS t5, unnest(t1._7) AS t6
 ------ end
 
 ------ Test: select Product
@@ -143,7 +143,7 @@ SELECT t1._1 AS _1, t1._2 AS _2 FROM t1 WHERE ((t1._1 IS NOT NULL) AND (t1._2 IS
 ------ end
 
 ------ Test: select multiple explode seq
-SELECT t0 AS _1, t1 AS _2 FROM t1, t1._1 AS t0, t1._2 AS t1
+SELECT t0 AS _1, t1 AS _2 FROM t1, unnest(t1._1) AS t0, unnest(t1._2) AS t1
 ------ end
 
 ------ Test: select nested access

--- a/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
@@ -31,11 +31,11 @@ SELECT CAST(1 AS INT) AS `from`, CAST(2 AS BIGINT) AS `has space`
 ------ end
 
 ------ Test: explode after aggregate
-SELECT t1 AS _1, t0._2 AS _2 FROM (SELECT table1.d AS _1, min(table1.a) AS _2 FROM table1 GROUP BY table1.d) AS t0, t0._1 AS t1
+SELECT t1 AS _1, t0._2 AS _2 FROM (SELECT table1.d AS _1, min(table1.a) AS _2 FROM table1 GROUP BY table1.d) AS t0, unnest(t0._1) AS t1
 ------ end
 
 ------ Test: explode multiple expression
-SELECT table1.a AS _1, t0 AS _2 FROM table1, table1.d AS t0
+SELECT table1.a AS _1, t0 AS _2 FROM table1, unnest(table1.d) AS t0
 ------ end
 
 ------ Test: fromSeq
@@ -67,7 +67,7 @@ SELECT table1.a AS _1, table2.a AS _2 FROM table1 JOIN table2 ON (table1.a = tab
 ------ end
 
 ------ Test: join and then explode
-SELECT t0 AS _1, t1 AS _2 FROM table1 JOIN table2 ON (table1.a = table2.a), table1.d AS t0, table2.d AS t1
+SELECT t0 AS _1, t1 AS _2 FROM table1 JOIN table2 ON (table1.a = table2.a), unnest(table1.d) AS t0, unnest(table2.d) AS t1
 ------ end
 
 ------ Test: join+aggregate on lhs
@@ -111,7 +111,7 @@ SELECT struct(table1.a AS _1, table1.b AS _2, table1.c AS _3) AS value FROM tabl
 ------ end
 
 ------ Test: multiple explodes in separate selects
-SELECT t0 AS _1, t1 AS _2 FROM table1, table1.d AS t0, table1.d AS t1
+SELECT t0 AS _1, t1 AS _2 FROM table1, unnest(table1.d) AS t0, unnest(table1.d) AS t1
 ------ end
 
 ------ Test: multiple joins


### PR DESCRIPTION
Before this change we introduce a subquery to handle cases where the
expression did not contain only selects as might have been not been
parsed inside the FROM clause. But this patch instead always introduces
a unnest call which mean we can always put the full expressions directly
in the from clause.

This allows us to simplify the logic. This leads to slightly more
verbose sql in some cases, but one can argue that the unnest call makes
it more readable.
