### PR TITLE
Make joinExplode type safe

### DIFF
--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -1,7 +1,6 @@
 package com.choreograph.tyda.sql
 
 import scala.NamedTuple.AnyNamedTuple
-import scala.collection.mutable
 import scala.deriving.Mirror
 import scala.reflect.ClassTag
 
@@ -371,7 +370,7 @@ private final case class SelectBuilder[T, R](
   }
 
   private def selectNExplodeJoin[R2 <: Tuple](
-      exprs: Tuple.Map[R2, [X] =>> CompiledExprOrExplode[R, X]]
+      exprs: Tuple.Map[R2, [x] =>> CompiledExprOrExplode[R, x]]
   ): Result[SelectBuilder[?, R2]] = {
     val instances = tupleInstances(exprs)
     select match {
@@ -385,26 +384,35 @@ private final case class SelectBuilder[T, R](
             }
         )
         // TYPE SAFETY: Each value in (from.output.codec +: explodeCodecs) is a Codec
-        val newFromCodec: Codec.Product[Tuple] = Codec.tuple(tupleInstances(
-          Tuple.fromArray((from.output.codec +: explodeCodecs).toArray).asInstanceOf[Tuple.Map[Tuple, Codec]]
+        val newFromCodec: Codec.Product[T *: Tuple] = Codec.tuple(tupleInstances(
+          Tuple
+            .fromArray((from.output.codec +: explodeCodecs).toArray)
+            .asInstanceOf[Tuple.Map[T *: Tuple, Codec]]
         ))
         val newArg = ExprNode.Reference()(using newFromCodec)
-        val joinExprs = mutable.ArrayBuffer[CompiledExplodeExpr[T, ?]]()
+        var idx = 1
         val selectExprs = instances.mapK([t] =>
           _ match {
             case noExplode @ CompiledExpr(_, _) =>
               val composed = compiled.andThen(noExplode)
               composed.expr.replace(composed.arg, ExprNode.Select(newArg, "_1"))
-            case explode @ CompiledExplodeExpr(_, _) =>
-              joinExprs.addOne(explode.compose(compiled))
-              ExprNode.Select(newArg, s"_${joinExprs.size + 1}")
+            case _ @CompiledExplodeExpr(_, _) =>
+              idx += 1
+              (ExprNode.Select(newArg, s"_$idx"))
           }
         )
-        val newSelect = CompiledExpr(newArg, ExprNode.makeTuple[R2](selectExprs.toTuple))
+        val joinExprs = instances.mapConst([t] =>
+          _ match {
+            case _ @CompiledExpr(_, _) => None
+            case explode @ CompiledExplodeExpr(_, _) => Some(explode.compose(compiled))
+          }
+        )
+        val newSelect = CompiledExpr[T *: Tuple, R2](newArg, ExprNode.makeTuple(selectExprs.toTuple))
         val newWhere =
           where.map(cond => CompiledExpr(newArg, cond.expr.replace(cond.arg, ExprNode.Select(newArg, "_1"))))
+        // TYPE SAFETY: Each value in joinExprs.flatten is a CompiledExplodeExpr[T, ?]
         TypedFrom
-          .joinExplode(from, joinExprs.toSeq, newFromCodec, args)
+          .joinExplode[T, Tuple](from, Tuple.fromArray(joinExprs.flatten.toArray).asInstanceOf, args)
           .map(newFrom => SelectBuilder(args, from = newFrom, select = newSelect, where = newWhere))
       case _ => toSubquery.flatMap(_.selectN(exprs))
     }

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -396,14 +396,14 @@ private final case class SelectBuilder[T, R](
             case noExplode @ CompiledExpr(_, _) =>
               val composed = compiled.andThen(noExplode)
               composed.expr.replace(composed.arg, ExprNode.Select(newArg, "_1"))
-            case _ @CompiledExplodeExpr(_, _) =>
+            case CompiledExplodeExpr(_, _) =>
               idx += 1
               (ExprNode.Select(newArg, s"_$idx"))
           }
         )
         val joinExprs = instances.mapConst([t] =>
           _ match {
-            case _ @CompiledExpr(_, _) => None
+            case CompiledExpr(_, _) => None
             case explode @ CompiledExplodeExpr(_, _) => Some(explode.compose(compiled))
           }
         )

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -412,7 +412,7 @@ private final case class SelectBuilder[T, R](
           where.map(cond => CompiledExpr(newArg, cond.expr.replace(cond.arg, ExprNode.Select(newArg, "_1"))))
         // TYPE SAFETY: Each value in joinExprs.flatten is a CompiledExplodeExpr[T, ?]
         TypedFrom
-          .joinExplode[T, Tuple](from, Tuple.fromArray(joinExprs.flatten.toArray).asInstanceOf, args)
+          .joinExplode(from, Tuple.fromArray(joinExprs.flatten.toArray).asInstanceOf, args)
           .map(newFrom => SelectBuilder(args, from = newFrom, select = newSelect, where = newWhere))
       case _ => toSubquery.flatMap(_.selectN(exprs))
     }

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
@@ -15,6 +15,7 @@ import com.choreograph.tyda.sql.ast.From
 import com.choreograph.tyda.sql.ast.JoinType
 import com.choreograph.tyda.sql.ast.Query
 import com.choreograph.tyda.sql.ast.SqlExpr
+import com.choreograph.tyda.shapeless3extras.toTuple
 
 /** Typed version of [[ast.From]].
   *
@@ -45,10 +46,9 @@ private object TypedFrom {
     )
   }
 
-  private def joinExplodeReferenceAndOutput[U](
-      codec: Codec[U],
-      dialect: SqlDialect
-  ): (reference: ExprNode.Reference[?], output: ExprNode[U]) = {
+  type RefAndOutput[T] = (reference: ExprNode.Reference[?], output: ExprNode[T])
+
+  private def joinExplodeReferenceAndOutput[U](codec: Codec[U], dialect: SqlDialect): RefAndOutput[U] = {
     given Codec[U] = codec
     if shouldWrapArrayElement(codec, dialect.ddl) then {
       val ref = ExprNode.Reference[(value: U)]()
@@ -84,22 +84,17 @@ private object TypedFrom {
       rights: Tuple.Map[R, [r] =>> CompiledExplodeExpr[T, r]],
       args: UnparserArgs
   ): Result[TypedFrom[T *: R]] =
-    tupleInstances(rights)
+    val instances = tupleInstances(rights)
+    instances
       .mapConst([t] =>
-        f =>
-          val expr = ExplodeExpr(f.expr.replace(f.arg, left.output))
-          for {
-            sqlExpr <- simplifyAndToSqlExpr(expr, left.ids, args)
-            (ref, output) = joinExplodeReferenceAndOutput(f.codec, args.dialect)
-          } yield (ref, output, sqlExpr)
+        f => simplifyAndToSqlExpr(ExplodeExpr(f.expr.replace(f.arg, left.output)), left.ids, args)
       )
       .sequence
-      .map { refsAndSqlExprs =>
-        val (refs, outputs, exprs) = refsAndSqlExprs.unzip3
-        /* TYPE SAFETY: outputs has type Seq[ExprNode[?]] with components corresponding to the components of
-         * right */
-        val output =
-          ExprNode.makeTuple[T *: R](Tuple.fromArray((left.output +: outputs).toArray).asInstanceOf)
+      .map { exprs =>
+        val (refsAndOutputs) =
+          instances.mapK[RefAndOutput]([t] => f => joinExplodeReferenceAndOutput(f.codec, args.dialect))
+        val refs = refsAndOutputs.mapConst[ExprNode.Reference[?]]([t] => _.reference)
+        val output = ExprNode.makeTuple[T *: R](left.output *: refsAndOutputs.mapK([t] => _.output).toTuple)
         val aliases = refs.map(_ => args.aliasGen.table())
         val combinedIds = left.ids ++ refs.zip(aliases).map((r, a) => r -> IdentifierOrSqlExpr.Expr(a))
         val from = exprs

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
@@ -9,6 +9,7 @@ import com.choreograph.tyda.Forbidden
 import com.choreograph.tyda.NonEmpty
 import com.choreograph.tyda.rewrite.reduceBalanced
 import com.choreograph.tyda.shapeless3extras.mapConst
+import com.choreograph.tyda.shapeless3extras.tupleInstances
 import com.choreograph.tyda.sql.Result.sequence
 import com.choreograph.tyda.sql.ast.From
 import com.choreograph.tyda.sql.ast.JoinType
@@ -76,34 +77,29 @@ private object TypedFrom {
     )
   }
 
-  /** Explode multiple right column using INNER JOIN syntax
-    *
-    * The codec for R should be a flat tuple containing `T` as the first element
-    * and then all of the elements of right after that.
+  /** Explode multiple columns using INNER JOIN syntax
     */
   def joinExplode[T, R <: Tuple](
       left: TypedFrom[T],
-      rights: Seq[CompiledExplodeExpr[T, ?]],
-      codec: Codec.Product[R],
+      rights: Tuple.Map[R, [r] =>> CompiledExplodeExpr[T, r]],
       args: UnparserArgs
-  ): Result[TypedFrom[R]] = {
-    assert(codec.fields.arity == rights.length + 1, "Codec arity does not match number of right expressions")
-    rights
-      .map(f =>
-        val expr = ExplodeExpr(f.expr.replace(f.arg, left.output))
-        for {
-          sqlExpr <- simplifyAndToSqlExpr(expr, left.ids, args)
-          (ref, output) = joinExplodeReferenceAndOutput(f.codec, args.dialect)
-        } yield (ref, output, sqlExpr)
+  ): Result[TypedFrom[T *: R]] =
+    tupleInstances(rights)
+      .mapConst([t] =>
+        f =>
+          val expr = ExplodeExpr(f.expr.replace(f.arg, left.output))
+          for {
+            sqlExpr <- simplifyAndToSqlExpr(expr, left.ids, args)
+            (ref, output) = joinExplodeReferenceAndOutput(f.codec, args.dialect)
+          } yield (ref, output, sqlExpr)
       )
       .sequence
       .map { refsAndSqlExprs =>
         val (refs, outputs, exprs) = refsAndSqlExprs.unzip3
-        /* TYPE SAFETY: Each element of refs and output are of type ExprNode and that the types match the
-         * codec R is a precondition of this function */
-        val output = ExprNode.makeTuple(
-          Tuple.fromArray((left.output +: outputs).toArray).asInstanceOf[Tuple.Map[R, ExprNode]]
-        )
+        /* TYPE SAFETY: outputs has type Seq[ExprNode[?]] with components corresponding to the components of
+         * right */
+        val output =
+          ExprNode.makeTuple[T *: R](Tuple.fromArray((left.output +: outputs).toArray).asInstanceOf)
         val aliases = refs.map(_ => args.aliasGen.table())
         val combinedIds = left.ids ++ refs.zip(aliases).map((r, a) => r -> IdentifierOrSqlExpr.Expr(a))
         val from = exprs
@@ -113,7 +109,6 @@ private object TypedFrom {
           }
         TypedFrom(from, output, combinedIds)
       }
-  }
 
   /** The U being an Option is to make sure the right side output is nullable.
     * It up to the caller to ensure that the `Option` value is never `None`

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
@@ -9,13 +9,13 @@ import com.choreograph.tyda.Forbidden
 import com.choreograph.tyda.NonEmpty
 import com.choreograph.tyda.rewrite.reduceBalanced
 import com.choreograph.tyda.shapeless3extras.mapConst
+import com.choreograph.tyda.shapeless3extras.toTuple
 import com.choreograph.tyda.shapeless3extras.tupleInstances
 import com.choreograph.tyda.sql.Result.sequence
 import com.choreograph.tyda.sql.ast.From
 import com.choreograph.tyda.sql.ast.JoinType
 import com.choreograph.tyda.sql.ast.Query
 import com.choreograph.tyda.sql.ast.SqlExpr
-import com.choreograph.tyda.shapeless3extras.toTuple
 
 /** Typed version of [[ast.From]].
   *

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/TypedFrom.scala
@@ -91,7 +91,7 @@ private object TypedFrom {
       )
       .sequence
       .map { exprs =>
-        val (refsAndOutputs) =
+        val refsAndOutputs =
           instances.mapK[RefAndOutput]([t] => f => joinExplodeReferenceAndOutput(f.codec, args.dialect))
         val refs = refsAndOutputs.mapConst[ExprNode.Reference[?]]([t] => _.reference)
         val output = ExprNode.makeTuple[T *: R](left.output *: refsAndOutputs.mapK([t] => _.output).toTuple)


### PR DESCRIPTION
Instead of having a runtime assertion, we can bake the condition into the signature of joinExplode.