### PR TITLE
Add head, tail and *: for tuples in ExprApi

### DIFF
--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -1466,6 +1466,18 @@ SELECT CASE WHEN ((SAFE_CAST(t1.value AS SMALLINT) >= CAST(-32768 AS BIGINT)) AN
 SELECT CASE WHEN ((SAFE_CAST(t1.value AS TINYINT) >= CAST(-128 AS BIGINT)) AND (SAFE_CAST(t1.value AS TINYINT) <= CAST(127 AS BIGINT))) THEN SAFE_CAST(t1.value AS TINYINT) END AS value FROM t1
 ------ end
 
+------ Test: tuple *: construct
+SELECT CAST(1 AS INT) AS _1, t1._1 AS _2, t1._2 AS _3, t1._3 AS _4 FROM t1
+------ end
+
+------ Test: tuple head
+SELECT t1._1 AS value FROM t1
+------ end
+
+------ Test: tuple tail
+SELECT t1._2 AS _1, t1._3 AS _2 FROM t1
+------ end
+
 ------ Test: update adding new field
 SELECT t1.a AS a, t1.b AS b, t1.c AS c, TRUE AS d FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -1470,6 +1470,18 @@ SELECT TRY_CAST(t1.value AS SMALLINT) AS value FROM t1
 SELECT TRY_CAST(t1.value AS TINYINT) AS value FROM t1
 ------ end
 
+------ Test: tuple *: construct
+SELECT CAST(1 AS INT) AS _1, t1._1 AS _2, t1._2 AS _3, t1._3 AS _4 FROM t1
+------ end
+
+------ Test: tuple head
+SELECT t1._1 AS value FROM t1
+------ end
+
+------ Test: tuple tail
+SELECT t1._2 AS _1, t1._3 AS _2 FROM t1
+------ end
+
 ------ Test: update adding new field
 SELECT t1.a AS a, t1.b AS b, t1.c AS c, TRUE AS d FROM t1
 ------ end

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -587,6 +587,14 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
     t => Seq((t._1, t._2))
   )
 
+  testHasSameBehavior[(Int, Boolean, String), Int]("tuple head", _.head, _.head)
+  testHasSameBehavior[(Int, Boolean, String), (Boolean, String)]("tuple tail", _.tail, _.tail)
+  testHasSameBehavior[(Int, Boolean, String), (Int, Int, Boolean, String)](
+    "tuple *: construct",
+    t => lit(1) *: t.head *: t.tail,
+    t => 1 *: t.head *: t.tail
+  )
+
   testHasSameBehavior[(Int, Boolean), NamedTuple.Empty](
     "make empty namedTuple",
     _ => namedTuple(NamedTuple.Empty),

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
@@ -973,6 +973,53 @@ trait ExprApi[Expr[T]] {
       new CasesBuilder(head = ExprNode.WhenThen(unlift(cond), unlift(AsExpr(thenExpr))), tail = Seq.empty)
   }
 
+  // We need to eagerly simplify selects on products to avoid exponential growth when recursing over a tuple.
+  private def tupleSelect[T <: Tuple](node: ExprNode[T]): Int => ExprNode[?] =
+    node match {
+      case ExprNode.MakeProduct(elements, _) =>
+        // TYPE SAFETY: elements is Tuple.Map[?, ExprNode] so all elements are of type ExprNode[?]
+        i => elements.apply(i).asInstanceOf[ExprNode[?]]
+      case other => i => ExprNode.Select(other, s"_${i + 1}")
+    }
+
+  extension [T <: Tuple, H](e: Expr[H *: T]) {
+
+    /** Returns the head element of this non-empty tuple expression.
+      */
+    def head: Expr[H] =
+      // TYPE SAFETY: The types being H *: T proves that head is H
+      lift(tupleSelect(unlift(e))(0).asInstanceOf[ExprNode[H]])
+
+    /** Returns a tuple expression containing all elements after the first one
+      * of this non-empty tuple expression.
+      */
+    def tail: Expr[T] =
+      val node = unlift(e)
+      node.codec match {
+        case Codec.Product(_, fields, _) =>
+          val select = tupleSelect(node)
+          val elements = (1 until fields.arity).map(select)
+          lift(ExprNode.makeTupleUnsafe(elements))
+        case unsupported => unreachable(s"Tuple must be encoded using Product, but found ${unsupported}")
+      }
+  }
+
+  extension [H](head: Expr[H]) {
+
+    /** Prepend an element expression to this tuple expression.
+      */
+    infix def *:[T <: Tuple](tail: Expr[T]): Expr[H *: T] =
+      val tailNode = unlift(tail)
+      val select = tupleSelect(tailNode)
+      tailNode.codec match {
+        case Codec.Product(_, fields, _) =>
+          val tailNodes = (0 until fields.arity).map(select)
+          val elements = unlift(head) +: tailNodes
+          lift(ExprNode.makeTupleUnsafe(elements))
+        case unsupported => unreachable(s"Tuple must be encoded using Product, but found ${unsupported}")
+      }
+  }
+
   /** Construct an Expr[To] where To is a product with named fields or a named
     * tuple. Example:
     *

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprNode.scala
@@ -125,6 +125,10 @@ private object ExprNode extends ExprApi[ExprNode] {
   def makeTuple[T <: Tuple](values: Tuple.Map[T, ExprNode]): ExprNode[T] =
     new MakeProduct[T, T](values, Codec.tuple(tupleInstances(values).mapK([t] => _.codec)))
 
+  def makeTupleUnsafe[T <: Tuple](values: Seq[ExprNode[?]]): ExprNode[T] =
+    // TYPE SAFETY: All elements in values is of type ExprNode
+    makeTuple(Tuple.fromArray(values.toArray).asInstanceOf)
+
   def makeNamedTuple[NT <: AnyNamedTuple](values: NamedTuple.Map[NT, ExprNode])(using
       StringLiterals[NamedTuple.Names[NT]]
   ): ExprNode[NT] = new MakeProduct(values, Codec.namedTuple(tupleInstances(values).mapK([t] => _.codec)))


### PR DESCRIPTION
This extracts the basic methods head/tail and *: from https://github.com/unum-io/tyda/pull/122
so that we can add them more direcly without needing to wait for the
other changes there.
