### PR TITLE
Googlesql testrunner

### DIFF
--- a/.github/workflows/googlesql.yml
+++ b/.github/workflows/googlesql.yml
@@ -1,0 +1,33 @@
+name: GoogleSQL Conformance
+
+on:
+  pull_request:
+    branches: ['**']
+  push:
+    branches: ['**']
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: sbt/setup-sbt@v1
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: sbt
+
+      - uses: actions/cache@v4
+        with:
+          path: target/execute_query_linux
+          key: googlesql-execute-query-2026.7.2-d362b2469f7077db5c8029f594dd4c435efb162fce0f50c51c9b85695fe98041
+
+      - name: Download pinned GoogleSQL executor
+        run: echo "TYDA_GOOGLESQL_EXECUTE_QUERY=$(dev/download-googlesql.sh)" >> "$GITHUB_ENV"
+
+      - name: Run BigQuery conformance tests
+        run: sbt 'project tydaBigQuery' test

--- a/README.md
+++ b/README.md
@@ -94,3 +94,19 @@ ds.explain()
 ## Documentation
 
 Full API documentation and guides are available at [unum-io.github.io/tyda](https://unum-io.github.io/tyda/docs/index.html)
+
+## Local BigQuery SQL tests
+
+The BigQuery query suites run against the GoogleSQL reference executor when no
+`TYDA_BIGQUERY_TEST_PROJECT_ID` is configured. Build its pinned executable and
+pass its path to the tests. The bootstrap downloads and verifies the pinned
+official Linux release binary.
+
+```sh
+export TYDA_GOOGLESQL_EXECUTE_QUERY="$(dev/download-googlesql.sh)"
+bloop test tydaBigQuery
+```
+
+When `TYDA_BIGQUERY_TEST_PROJECT_ID` is set, the credential-backed BigQuery
+tests run instead. GCS read/write tests additionally require
+`TYDA_BIGQUERY_TEST_TMP_LOCATION` and remain real-service integration tests.

--- a/build.sbt
+++ b/build.sbt
@@ -404,6 +404,7 @@ lazy val tydaBigQuery = (project in file("tyda-big-query"))
   .settings(Dependencies.tydaBigQuery)
   .dependsOn(scalafixRules % ScalafixConfig)
   .dependsOn(tydaSql)
+  .dependsOn(tydaJson % "test->compile")
   .dependsOn(tydaIterator % "test->compile")
   .dependsOn(tydaTestSuites % "test->compile")
 

--- a/dev/download-googlesql.sh
+++ b/dev/download-googlesql.sh
@@ -17,7 +17,8 @@ if [[ -x "$executable" ]] && echo "$sha256  $executable" | sha256sum --check --s
 fi
 
 mkdir -p "$(dirname "$executable")"
-readonly temporary_executable="$(mktemp "${executable}.download.XXXXXX")"
+temporary_executable="$(mktemp "${executable}.download.XXXXXX")"
+readonly temporary_executable
 trap 'rm -f "$temporary_executable"' EXIT
 
 curl --fail --location --retry 3 --output "$temporary_executable" "$download_url"

--- a/dev/download-googlesql.sh
+++ b/dev/download-googlesql.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly release='2026.7.2'
+readonly sha256='d362b2469f7077db5c8029f594dd4c435efb162fce0f50c51c9b85695fe98041'
+readonly executable="${TYDA_GOOGLESQL_EXECUTABLE_PATH:-$PWD/target/execute_query_linux}"
+readonly download_url="https://github.com/google/googlesql/releases/download/$release/execute_query_linux"
+
+if ! command -v curl >/dev/null; then
+  echo 'curl is required to download the GoogleSQL executable.' >&2
+  exit 1
+fi
+
+if [[ -x "$executable" ]] && echo "$sha256  $executable" | sha256sum --check --status; then
+  printf '%s\n' "$executable"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$executable")"
+readonly temporary_executable="$(mktemp "${executable}.download.XXXXXX")"
+trap 'rm -f "$temporary_executable"' EXIT
+
+curl --fail --location --retry 3 --output "$temporary_executable" "$download_url"
+echo "$sha256  $temporary_executable" | sha256sum --check --status
+chmod +x "$temporary_executable"
+mv "$temporary_executable" "$executable"
+
+printf '%s\n' "$executable"

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteGoogleSql.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/DatasetSuiteGoogleSql.scala
@@ -1,0 +1,40 @@
+package com.choreograph.tyda.bigquery
+
+import org.scalatest.ParallelTestExecution
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Dataset
+import com.choreograph.tyda.Expr
+import com.choreograph.tyda.Runner
+import com.choreograph.tyda.iterator.IteratorRunner
+import com.choreograph.tyda.testsuites.DatasetAggregatesSuite
+import com.choreograph.tyda.testsuites.DatasetBasicSuite
+import com.choreograph.tyda.testsuites.DatasetJoinSuite
+import com.choreograph.tyda.testsuites.DatasetOrderBySuite
+import com.choreograph.tyda.testsuites.DatasetSubquerySuite
+import com.choreograph.tyda.testsuites.DatasetSuite
+import com.choreograph.tyda.testsuites.ExprEvaluationSuite
+
+private trait WithGoogleSqlTestRunner {
+  def runner: GoogleSqlTestRunner = GoogleSqlTestRunner.configuredOrSkip
+}
+
+private trait GoogleSqlSuiteRunner extends DatasetSuite, WithGoogleSqlTestRunner, ParallelTestExecution {
+  def reference: Runner = IteratorRunner
+  def implementation: Runner = runner
+}
+
+class DatasetBasicSuiteGoogleSql extends DatasetBasicSuite, GoogleSqlSuiteRunner
+class DatasetJoinSuiteGoogleSql extends DatasetJoinSuite, GoogleSqlSuiteRunner
+class DatasetAggregatesSuiteGoogleSql extends DatasetAggregatesSuite, GoogleSqlSuiteRunner
+class DatasetSubquerySuiteGoogleSql extends DatasetSubquerySuite, GoogleSqlSuiteRunner
+class DatasetOrderBySuiteGoogleSql extends DatasetOrderBySuite, GoogleSqlSuiteRunner
+
+class ExprEvaluationSuiteGoogleSql
+    extends ExprEvaluationSuite, WithGoogleSqlTestRunner, ParallelTestExecution {
+  override def evaluate[From: Codec, To](expr: Expr[From] => Expr[To], values: Seq[From]): Seq[To] =
+    runner.collect(Dataset.from(values).select(expr))
+
+  override def explain[From: Codec, To](expr: Expr[From] => Expr[To], values: Seq[From]): String =
+    runner.sql(Dataset.from(values).select(expr)).single
+}

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunner.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunner.scala
@@ -1,0 +1,370 @@
+package com.choreograph.tyda.bigquery
+
+import java.math.MathContext
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.sys.process.Process
+import scala.sys.process.ProcessLogger
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import org.scalatest.Assertions.assume
+import org.scalatest.Assertions.pending
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Dataset
+import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.Field
+import com.choreograph.tyda.NumericLimits
+import com.choreograph.tyda.Runner
+import com.choreograph.tyda.json.CodecToJsoniter
+import com.choreograph.tyda.rewrite.CollectionOrNullableCollectionCodec
+import com.choreograph.tyda.shapeless3extras.mapConst
+import com.choreograph.tyda.sql.DatasetToSqlError
+import com.choreograph.tyda.sql.RenderedMultiStatement
+import com.choreograph.tyda.sql.SqlDialect
+import com.choreograph.tyda.sql.toSql
+import com.choreograph.tyda.testsuites.BigQueryIntegrationTestEnvVariables
+import com.choreograph.tyda.unreachable
+
+object GoogleSqlTestRunner {
+  private val ExecutableEnv = "TYDA_GOOGLESQL_EXECUTE_QUERY"
+
+  def configuredOrSkip: GoogleSqlTestRunner = {
+    BigQueryIntegrationTestEnvVariables.skipIfProjectIsSet()
+    sys.env.get(ExecutableEnv).map(Path.of(_)) match {
+      case Some(executable) if Files.isExecutable(executable) => new GoogleSqlTestRunner(executable)
+      case _ =>
+        assume(
+          condition = false,
+          s"Set $ExecutableEnv to the executable provided by dev/download-googlesql.sh to run local GoogleSQL tests"
+        )
+        unreachable("Test skipped by assume")
+    }
+  }
+
+  private[bigquery] def errorMessageFromBoxOutput(output: String): Option[String] =
+    output
+      .linesIterator
+      .collectFirst { case line if line.startsWith("ERROR: ") => line.stripPrefix("ERROR: ") }
+
+  private[bigquery] def escapeMacrosInStringLiterals(sql: String): String = {
+    val result = StringBuilder()
+    var inString = false
+    var index = 0
+    while index < sql.length do
+      sql(index) match {
+        case '\'' =>
+          inString = !inString
+          result.append('\'')
+          index += 1
+        case '\\' if inString && index + 1 < sql.length =>
+          result.append(sql(index)).append(sql(index + 1)): Unit
+          index += 2
+        case '$' if inString =>
+          result.append("$' '")
+          index += 1
+        case character =>
+          result.append(character)
+          index += 1
+      }
+    result.result()
+  }
+}
+
+final class GoogleSqlTestRunner private (executable: Path) extends Runner {
+  def sql(ds: Dataset[?] | Dataset.Action): RenderedMultiStatement =
+    toSql(ds, SqlDialect.GoogleSql) match {
+      case Left(DatasetToSqlError.RequiresUdfCapability(_)) =>
+        pending
+        unreachable("Test should be skipped by pending")
+      case Left(DatasetToSqlError.NotImplemented(msg)) =>
+        pending
+        unreachable(s"Unimplemented feature: $msg")
+      case Right(plan) => plan
+    }
+
+  def collect[T](ds: Dataset[T]): Seq[T] = {
+    val rendered = sql(ds).single
+    val query = GoogleSqlTestRunner.escapeMacrosInStringLiterals(
+      s"SELECT TO_JSON_STRING(result) AS value FROM ($rendered) AS result"
+    )
+    val encodedRows = run(query)
+    val jsonCodec = GoogleSqlJsonDecoder.create(using ds.codec)
+    encodedRows.map(encoded => readFromString(encoded)(using jsonCodec))
+  }
+
+  def execute(ds: Dataset.Action): Unit =
+    throw UnsupportedOperationException("GoogleSQL reference execution does not support BigQuery actions")
+
+  def explain[T](ds: Dataset[T]): String = sql(ds).single
+  def explain(action: Dataset.Action): String = sql(action).single
+
+  private def run(query: String): Seq[String] = {
+    val (exitCode, stdout, stderr) = runQuery(query, "json")
+    if exitCode != 0 then
+      throw RuntimeException(
+        s"GoogleSQL exited with status $exitCode. SQL:\n$query\nStandard output:\n$stdout\nStandard error:\n$stderr"
+      )
+    val output = stdout.trim
+    if output.isEmpty then {
+      val (boxExitCode, boxOutput, boxError) = runQuery(query, "box")
+      if boxExitCode != 0 then
+        throw RuntimeException(
+          s"GoogleSQL exited with status $boxExitCode. SQL:\n$query\nStandard output:\n$boxOutput\nStandard error:\n$boxError"
+        )
+      GoogleSqlTestRunner
+        .errorMessageFromBoxOutput(boxOutput)
+        .foreach(message => throw RuntimeException(message))
+      return Seq.empty
+    }
+    try readFromString(output)(using GoogleSqlResultCodec)
+    catch {
+      case error: Throwable =>
+        throw RuntimeException(s"Unable to decode GoogleSQL result. SQL:\n$query\nOutput:\n$output", error)
+    }
+  }
+
+  private def runQuery(query: String, outputMode: String): (Int, String, String) = {
+    val command = Seq(executable.toString, "--catalog=none", s"--output_mode=$outputMode", query)
+    val stdout = StringBuilder()
+    val stderr = StringBuilder()
+    val logger = ProcessLogger(
+      line => { stdout.append(line).append('\n'): Unit },
+      line => { stderr.append(line).append('\n'): Unit }
+    )
+    val exitCode = Process(command).!(logger)
+    (exitCode, stdout.result(), stderr.result())
+  }
+}
+
+private[bigquery] object GoogleSqlJsonDecoder {
+  def create[T: Codec]: JsonValueCodec[T] =
+    Codec[T] match {
+      case Codec.Product(_, _, _) => fromReaderWriter[T]
+      case Codec.FromInjection(injection, inner) =>
+        xmap(create(using inner), injection.apply, injection.invert)
+      case _ => xmap(create[(value: T)], (value = _), _.value)
+    }
+
+  private def fromReaderWriter[T: Codec]: JsonValueCodec[T] = {
+    val jsonCodec = CodecToJsoniter.create[T]
+    val read = reader(summon[Codec[T]])
+    new JsonValueCodec[T] {
+      def decodeValue(in: JsonReader, default: T): T = read(in)
+
+      def encodeValue(value: T, out: JsonWriter): Unit = jsonCodec.encodeValue(value, out)
+
+      def nullValue: T = jsonCodec.nullValue
+    }
+  }
+
+  private def xmap[T: Codec, A](inner: JsonValueCodec[A], to: T => A, from: A => T): JsonValueCodec[T] =
+    new JsonValueCodec[T] {
+      def decodeValue(in: JsonReader, default: T): T = from(inner.decodeValue(in, inner.nullValue))
+
+      def encodeValue(value: T, out: JsonWriter): Unit = inner.encodeValue(to(value), out)
+
+      def nullValue: T = CodecToJsoniter.create[T].nullValue
+    }
+
+  private type Reader[T] = JsonReader => T
+
+  private def reader[T](codec: Codec[T]): Reader[T] =
+    codec match {
+      case Codec.Boolean => standardReader(Codec.Boolean)
+      case Codec.Byte => checkedIntegralReader[Byte]
+      case Codec.Short => checkedIntegralReader[Short]
+      case Codec.Int => checkedIntegralReader[Int]
+      case Codec.Long => standardReader(Codec.Long)
+      case Codec.Float => standardReader(Codec.Float)
+      case Codec.Double => standardReader(Codec.Double)
+      case Codec.String => standardReader(Codec.String)
+      case Codec.Bytes => standardReader(Codec.Bytes)
+      case decimal @ Codec.Decimal(precision, scale) => in => {
+          val value =
+            if in.nextValueIsString() then BigDecimal(in.readString(null))
+            else in.readBigDecimal(null, MathContext.UNLIMITED, 1000, 1000)
+          Decimal(using decimal.valid)(value).getOrElse(
+            throw RuntimeException(s"Value $value cannot be represented as Decimal($precision, $scale)")
+          )
+        }
+      case Codec.Date => standardReader(Codec.Date)
+      case Codec.TimestampMicros => standardReader(Codec.TimestampMicros)
+      case Codec.DurationMicros => standardReader(Codec.DurationMicros)
+      case Codec.Option(element @ Codec.Option(_)) => nestedOptionReader(element)
+      case Codec.Option(element) =>
+        val elementReader = reader(element)
+        in =>
+          if in.isNextToken('n') then in.readNullOrError(None, "expected null or value")
+          else {
+            in.rollbackToken()
+            Some(elementReader(in))
+          }
+      case Codec.Seq(element) =>
+        val elementReader = reader(element)
+        val wrapped = CollectionOrNullableCollectionCodec.unapply(element).isDefined
+        in => seqReader(in, if wrapped then wrappedReader(elementReader) else elementReader)
+      case Codec.Map(given Codec[k], given Codec[v]) =>
+        val pairReader = reader[Seq[(key: k, value: v)]](summon)
+        in => pairReader(in).map { case (key, value) => key -> value }.toMap
+      case product @ Codec.Product(_, _, _) => productReader(product)
+      case Codec.FromInjection(injection, inner) => reader(inner).andThen(injection.invert)
+    }
+
+  private def standardReader[T](codec: Codec[T]): Reader[T] = {
+    given Codec[T] = codec
+    val jsonCodec = CodecToJsoniter.unwrapped[T]
+    in => jsonCodec.decodeValue(in, jsonCodec.nullValue)
+  }
+
+  private def checkedIntegralReader[A: {NumericLimits as limits, Numeric as numeric}]: Reader[A] =
+    in => {
+      import numeric.mkNumericOps
+      val value = if in.nextValueIsString() then in.readStringAsLong() else in.readLong()
+      if value < limits.min.toLong || value > limits.max.toLong then
+        throw RuntimeException(s"Value $value is out of range for target type")
+      numeric.fromInt(value.toInt)
+    }
+
+  private def nestedOptionReader[T](element: Codec.Option[T]): Reader[Option[Option[T]]] = {
+    given Codec[T] = element.element
+    val structReader = reader[Option[(value: Option[T])]](summon)
+    in => structReader(in).map(_.value)
+  }
+
+  private def seqReader[T](in: JsonReader, elementReader: Reader[T]): Seq[T] =
+    if !in.isNextToken('[') then in.decodeError("Expected GoogleSQL array")
+    else if in.isNextToken(']') then Seq.empty
+    else {
+      in.rollbackToken()
+      val values = Vector.newBuilder[T]
+      while {
+        values += elementReader(in)
+        in.isNextToken(',')
+      } do ()
+      if !in.isCurrentToken(']') then in.arrayEndOrCommaError()
+      values.result()
+    }
+
+  private def wrappedReader[T](read: Reader[T]): Reader[T] =
+    in => {
+      if !in.isNextToken('{') then in.decodeError("Expected GoogleSQL array element wrapper")
+      var value: Option[T] = None
+      if !in.isNextToken('}') then {
+        in.rollbackToken()
+        while {
+          in.readKeyAsString() match {
+            case "value" => value = Some(read(in))
+            case _ => in.skip()
+          }
+          in.isNextToken(',')
+        } do ()
+        if !in.isCurrentToken('}') then in.objectEndOrCommaError()
+      }
+      value.getOrElse(in.decodeError("GoogleSQL array element wrapper has no value field"))
+    }
+
+  private def productReader[T](codec: Codec.Product[T]): Reader[T] = {
+    val fields = codec.fields.mapConst[Field[?]]([t] => identity(_)).toArray
+    val readers = fields.map(_.codec).map(reader)
+    val required = fields.map(!_.codec.isInstanceOf[Codec.Option[?]])
+    val nameToIndex = fields.map(_.name).zipWithIndex.toMap
+    in =>
+      def fromValues(values: Array[Any]): T = {
+        required.foldLeft(0) { (index, isRequired) =>
+          if values(index) == null then
+            if isRequired then in.decodeError("missing required field " + fields(index).name)
+            else values(index) = None
+          index + 1
+        }: Unit
+        codec.fromProduct(Tuple.fromArray(values))
+      }
+      if !in.isNextToken('{') then in.decodeError("Expected GoogleSQL struct")
+      else if in.isNextToken('}') then fromValues(new Array[Any](fields.size))
+      else {
+        in.rollbackToken()
+        val values = new Array[Any](fields.size)
+        while {
+          val fieldName = in.readKeyAsString()
+          nameToIndex.get(fieldName) match {
+            case Some(index) =>
+              if values(index) != null then in.decodeError("duplicate key " + fieldName)
+              values(index) = readers(index)(in)
+            case _ => in.skip()
+          }
+          in.isNextToken(',')
+        } do ()
+        if !in.isCurrentToken('}') then in.objectEndOrCommaError()
+        fromValues(values)
+      }
+  }
+
+  extension (in: JsonReader)
+    private def nextValueIsString(): Boolean = {
+      val result = in.isNextToken('"')
+      in.rollbackToken()
+      result
+    }
+}
+
+private[bigquery] object GoogleSqlResultCodec extends JsonValueCodec[Seq[String]] {
+  def decodeValue(in: JsonReader, default: Seq[String]): Seq[String] = {
+    if !in.isNextToken('{') then in.decodeError("Expected GoogleSQL JSON result object")
+    val rows = Vector.newBuilder[String]
+    if !in.isNextToken('}') then {
+      in.rollbackToken()
+      while {
+        in.readKeyAsString() match {
+          case "row" => readRows(in, rows)
+          case _ => in.skip()
+        }
+        in.isNextToken(',')
+      } do ()
+      if !in.isCurrentToken('}') then in.objectEndOrCommaError()
+    }
+    rows.result()
+  }
+
+  def encodeValue(x: Seq[String], out: com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter): Unit =
+    out.writeArrayStart()
+    x.foreach(out.writeVal)
+    out.writeArrayEnd()
+
+  def nullValue: Seq[String] = Seq.empty
+
+  private def readRows(
+      in: JsonReader,
+      rows: scala.collection.mutable.Builder[String, Vector[String]]
+  ): Unit = {
+    if !in.isNextToken('[') then in.decodeError("Expected GoogleSQL result rows")
+    else if !in.isNextToken(']') then {
+      in.rollbackToken()
+      while {
+        rows += readRow(in)
+        in.isNextToken(',')
+      } do ()
+      if !in.isCurrentToken(']') then in.arrayEndOrCommaError()
+    }
+  }
+
+  private def readRow(in: JsonReader): String = {
+    if !in.isNextToken('{') then in.decodeError("Expected GoogleSQL result row")
+    var value: Option[String] = None
+    if !in.isNextToken('}') then {
+      in.rollbackToken()
+      while {
+        in.readKeyAsString() match {
+          case "value" => value = Some(in.readString(null))
+          case _ => in.skip()
+        }
+        in.isNextToken(',')
+      } do ()
+      if !in.isCurrentToken('}') then in.objectEndOrCommaError()
+    }
+    value.getOrElse(in.decodeError("GoogleSQL result row has no value column"))
+  }
+}

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunner.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunner.scala
@@ -46,10 +46,13 @@ object GoogleSqlTestRunner {
     }
   }
 
-  private[bigquery] def errorMessageFromBoxOutput(output: String): Option[String] =
+  private[bigquery] def errorMessageFromBoxOutput(output: String, query: String, stderr: String): String =
     output
       .linesIterator
       .collectFirst { case line if line.startsWith("ERROR: ") => line.stripPrefix("ERROR: ") }
+      .getOrElse(
+        s"GoogleSQL returned no JSON output and no recognized error. SQL:\n$query\nStandard output:\n$output\nStandard error:\n$stderr"
+      )
 
   private[bigquery] def escapeMacrosInStringLiterals(sql: String): String = {
     val result = StringBuilder()
@@ -119,10 +122,7 @@ final class GoogleSqlTestRunner private (executable: Path) extends Runner {
           throw RuntimeException(
             s"GoogleSQL exited with status $boxExitCode. SQL:\n$query\nStandard output:\n$boxOutput\nStandard error:\n$boxError"
           )
-        GoogleSqlTestRunner
-          .errorMessageFromBoxOutput(boxOutput)
-          .foreach(message => throw RuntimeException(message))
-        Seq.empty
+        throw RuntimeException(GoogleSqlTestRunner.errorMessageFromBoxOutput(boxOutput, query, boxError))
       } else
         try readFromString(output)(using GoogleSqlResultCodec)
         catch {

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunner.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunner.scala
@@ -1,6 +1,5 @@
 package com.choreograph.tyda.bigquery
 
-import java.math.MathContext
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -10,15 +9,15 @@ import scala.sys.process.ProcessLogger
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromArrayReentrant
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToArrayReentrant
 import org.scalatest.Assertions.assume
 import org.scalatest.Assertions.pending
 
 import com.choreograph.tyda.Codec
 import com.choreograph.tyda.Dataset
-import com.choreograph.tyda.Decimal
 import com.choreograph.tyda.Field
-import com.choreograph.tyda.NumericLimits
 import com.choreograph.tyda.Runner
 import com.choreograph.tyda.json.CodecToJsoniter
 import com.choreograph.tyda.rewrite.CollectionOrNullableCollectionCodec
@@ -96,7 +95,7 @@ final class GoogleSqlTestRunner private (executable: Path) extends Runner {
       s"SELECT TO_JSON_STRING(result) AS value FROM ($rendered) AS result"
     )
     val encodedRows = run(query)
-    val jsonCodec = GoogleSqlJsonDecoder.create(using ds.codec)
+    val jsonCodec = GoogleSqlJsonCodec.create(using ds.codec)
     encodedRows.map(encoded => readFromString(encoded)(using jsonCodec))
   }
 
@@ -148,20 +147,15 @@ final class GoogleSqlTestRunner private (executable: Path) extends Runner {
   }
 }
 
-private[bigquery] object GoogleSqlJsonDecoder {
-  def create[T: Codec]: JsonValueCodec[T] =
-    Codec[T] match {
-      case Codec.Product(_, _, _) => fromReaderWriter[T]
-      case Codec.FromInjection(injection, inner) =>
-        xmap(create(using inner), injection.apply, injection.invert)
-      case _ => xmap(create[(value: T)], (value = _), _.value)
-    }
-
-  private def fromReaderWriter[T: Codec]: JsonValueCodec[T] = {
+private[bigquery] object GoogleSqlJsonCodec {
+  def create[T: Codec]: JsonValueCodec[T] = {
+    val codec = summon[Codec[T]]
     val jsonCodec = CodecToJsoniter.create[T]
-    val read = reader(summon[Codec[T]])
     new JsonValueCodec[T] {
-      def decodeValue(in: JsonReader, default: T): T = read(in)
+      def decodeValue(in: JsonReader, default: T): T = {
+        val tydaJson = GoogleSqlJsonNormalizer.normalize(in.readRawValAsBytes(), codec)
+        readFromArrayReentrant(tydaJson)(using jsonCodec)
+      }
 
       def encodeValue(value: T, out: JsonWriter): Unit = jsonCodec.encodeValue(value, out)
 
@@ -169,153 +163,134 @@ private[bigquery] object GoogleSqlJsonDecoder {
     }
   }
 
-  private def xmap[T: Codec, A](inner: JsonValueCodec[A], to: T => A, from: A => T): JsonValueCodec[T] =
-    new JsonValueCodec[T] {
-      def decodeValue(in: JsonReader, default: T): T = from(inner.decodeValue(in, inner.nullValue))
+}
 
-      def encodeValue(value: T, out: JsonWriter): Unit = inner.encodeValue(to(value), out)
+private object GoogleSqlJsonNormalizer {
+  private enum Json {
+    case Raw(value: scala.Array[Byte])
+    case JsonArray(values: Seq[Json])
+    case Object(fields: Seq[(String, Json)])
+  }
 
-      def nullValue: T = CodecToJsoniter.create[T].nullValue
-    }
+  private object JsonCodec extends JsonValueCodec[Json] {
+    def decodeValue(in: JsonReader, default: Json): Json = read(in)
 
-  private type Reader[T] = JsonReader => T
-
-  private def reader[T](codec: Codec[T]): Reader[T] =
-    codec match {
-      case Codec.Boolean => standardReader(Codec.Boolean)
-      case Codec.Byte => checkedIntegralReader[Byte]
-      case Codec.Short => checkedIntegralReader[Short]
-      case Codec.Int => checkedIntegralReader[Int]
-      case Codec.Long => standardReader(Codec.Long)
-      case Codec.Float => standardReader(Codec.Float)
-      case Codec.Double => standardReader(Codec.Double)
-      case Codec.String => standardReader(Codec.String)
-      case Codec.Bytes => standardReader(Codec.Bytes)
-      case decimal @ Codec.Decimal(precision, scale) => in => {
-          val value =
-            if in.nextValueIsString() then BigDecimal(in.readString(null))
-            else in.readBigDecimal(null, MathContext.UNLIMITED, 1000, 1000)
-          Decimal(using decimal.valid)(value).getOrElse(
-            throw RuntimeException(s"Value $value cannot be represented as Decimal($precision, $scale)")
-          )
-        }
-      case Codec.Date => standardReader(Codec.Date)
-      case Codec.TimestampMicros => standardReader(Codec.TimestampMicros)
-      case Codec.DurationMicros => standardReader(Codec.DurationMicros)
-      case Codec.Option(element @ Codec.Option(_)) => nestedOptionReader(element)
-      case Codec.Option(element) =>
-        val elementReader = reader(element)
-        in =>
-          if in.isNextToken('n') then in.readNullOrError(None, "expected null or value")
-          else {
-            in.rollbackToken()
-            Some(elementReader(in))
+    def encodeValue(value: Json, out: JsonWriter): Unit =
+      value match {
+        case Json.Raw(value) => out.writeRawVal(value)
+        case Json.JsonArray(values) =>
+          out.writeArrayStart()
+          values.foreach(encodeValue(_, out))
+          out.writeArrayEnd()
+        case Json.Object(fields) =>
+          out.writeObjectStart()
+          fields.foreach { case (name, value) =>
+            out.writeKey(name)
+            encodeValue(value, out)
           }
-      case Codec.Seq(element) =>
-        val elementReader = reader(element)
-        val wrapped = CollectionOrNullableCollectionCodec.unapply(element).isDefined
-        in => seqReader(in, if wrapped then wrappedReader(elementReader) else elementReader)
-      case Codec.Map(given Codec[k], given Codec[v]) =>
-        val pairReader = reader[Seq[(key: k, value: v)]](summon)
-        in => pairReader(in).map { case (key, value) => key -> value }.toMap
-      case product @ Codec.Product(_, _, _) => productReader(product)
-      case Codec.FromInjection(injection, inner) => reader(inner).andThen(injection.invert)
-    }
+          out.writeObjectEnd()
+      }
 
-  private def standardReader[T](codec: Codec[T]): Reader[T] = {
-    given Codec[T] = codec
-    val jsonCodec = CodecToJsoniter.unwrapped[T]
-    in => jsonCodec.decodeValue(in, jsonCodec.nullValue)
+    def nullValue: Json = Json.Raw("null".getBytes(java.nio.charset.StandardCharsets.UTF_8))
   }
 
-  private def checkedIntegralReader[A: {NumericLimits as limits, Numeric as numeric}]: Reader[A] =
-    in => {
-      import numeric.mkNumericOps
-      val value = if in.nextValueIsString() then in.readStringAsLong() else in.readLong()
-      if value < limits.min.toLong || value > limits.max.toLong then
-        throw RuntimeException(s"Value $value is out of range for target type")
-      numeric.fromInt(value.toInt)
-    }
-
-  private def nestedOptionReader[T](element: Codec.Option[T]): Reader[Option[Option[T]]] = {
-    given Codec[T] = element.element
-    val structReader = reader[Option[(value: Option[T])]](summon)
-    in => structReader(in).map(_.value)
+  def normalize(encoded: Array[Byte], codec: Codec[?]): Array[Byte] = {
+    val googleSqlJson = readFromArrayReentrant(encoded)(using JsonCodec)
+    val tydaJson = normalizeTopLevel(googleSqlJson, codec)
+    writeToArrayReentrant(tydaJson)(using JsonCodec)
   }
 
-  private def seqReader[T](in: JsonReader, elementReader: Reader[T]): Seq[T] =
-    if !in.isNextToken('[') then in.decodeError("Expected GoogleSQL array")
-    else if in.isNextToken(']') then Seq.empty
+  private def normalizeTopLevel(value: Json, codec: Codec[?]): Json =
+    codec match {
+      case Codec.Product(_, _, _) => normalize(value, codec)
+      case Codec.FromInjection(_, inner) => normalizeTopLevel(value, inner)
+      case _ => normalizeObject(value, Map("value" -> codec))
+    }
+
+  private def normalize(value: Json, codec: Codec[?]): Json =
+    codec match {
+      case Codec.Option(element @ Codec.Option(_)) => normalizeObject(value, Map("value" -> element))
+      case Codec.Option(element) => normalize(value, element)
+      case Codec.Seq(element) => normalizeArray(value, element)
+      case Codec.Map(keyCodec, valueCodec) => normalizeMap(value, keyCodec, valueCodec)
+      case Codec.Product(_, fields, _) =>
+        val fieldCodecs = fields
+          .mapConst[Field[?]]([t] => identity(_))
+          .map(field => field.name -> field.codec)
+          .toMap
+        normalizeObject(value, fieldCodecs)
+      case Codec.FromInjection(_, inner) => normalize(value, inner)
+      case _ => value
+    }
+
+  private def normalizeArray(value: Json, elementCodec: Codec[?]): Json =
+    value match {
+      case Json.JsonArray(values) =>
+        val wrapped = CollectionOrNullableCollectionCodec.unapply(elementCodec).isDefined
+        Json.JsonArray(values.map { value =>
+          val element = if wrapped then unwrapCollectionElement(value) else value
+          normalize(element, elementCodec)
+        })
+      case _ => value
+    }
+
+  private def normalizeMap(value: Json, keyCodec: Codec[?], valueCodec: Codec[?]): Json =
+    value match {
+      case Json.JsonArray(values) =>
+        Json.JsonArray(values.map(normalizeObject(_, Map("key" -> keyCodec, "value" -> valueCodec))))
+      case _ => value
+    }
+
+  private def unwrapCollectionElement(value: Json): Json =
+    value match {
+      case Json.Object(fields) => fields.collectFirst { case ("value", value) => value }.getOrElse(value)
+      case _ => value
+    }
+
+  private def normalizeObject(value: Json, fieldCodecs: Map[String, Codec[?]]): Json =
+    value match {
+      case Json.Object(fields) => Json.Object(fields.map { case (name, value) =>
+          name -> fieldCodecs.get(name).fold(value)(normalize(value, _))
+        })
+      case _ => value
+    }
+
+  private def read(in: JsonReader): Json =
+    if in.isNextToken('{') then readObject(in)
     else {
       in.rollbackToken()
-      val values = Vector.newBuilder[T]
+      if in.isNextToken('[') then readArray(in)
+      else {
+        in.rollbackToken()
+        Json.Raw(in.readRawValAsBytes())
+      }
+    }
+
+  private def readObject(in: JsonReader): Json = {
+    val fields = Vector.newBuilder[(String, Json)]
+    if !in.isNextToken('}') then {
+      in.rollbackToken()
       while {
-        values += elementReader(in)
+        fields += in.readKeyAsString() -> read(in)
+        in.isNextToken(',')
+      } do ()
+      if !in.isCurrentToken('}') then in.objectEndOrCommaError()
+    }
+    Json.Object(fields.result())
+  }
+
+  private def readArray(in: JsonReader): Json = {
+    val values = Vector.newBuilder[Json]
+    if !in.isNextToken(']') then {
+      in.rollbackToken()
+      while {
+        values += read(in)
         in.isNextToken(',')
       } do ()
       if !in.isCurrentToken(']') then in.arrayEndOrCommaError()
-      values.result()
     }
-
-  private def wrappedReader[T](read: Reader[T]): Reader[T] =
-    in => {
-      if !in.isNextToken('{') then in.decodeError("Expected GoogleSQL array element wrapper")
-      var value: Option[T] = None
-      if !in.isNextToken('}') then {
-        in.rollbackToken()
-        while {
-          in.readKeyAsString() match {
-            case "value" => value = Some(read(in))
-            case _ => in.skip()
-          }
-          in.isNextToken(',')
-        } do ()
-        if !in.isCurrentToken('}') then in.objectEndOrCommaError()
-      }
-      value.getOrElse(in.decodeError("GoogleSQL array element wrapper has no value field"))
-    }
-
-  private def productReader[T](codec: Codec.Product[T]): Reader[T] = {
-    val fields = codec.fields.mapConst[Field[?]]([t] => identity(_)).toArray
-    val readers = fields.map(_.codec).map(reader)
-    val required = fields.map(!_.codec.isInstanceOf[Codec.Option[?]])
-    val nameToIndex = fields.map(_.name).zipWithIndex.toMap
-    in =>
-      def fromValues(values: Array[Any]): T = {
-        required.foldLeft(0) { (index, isRequired) =>
-          if values(index) == null then
-            if isRequired then in.decodeError("missing required field " + fields(index).name)
-            else values(index) = None
-          index + 1
-        }: Unit
-        codec.fromProduct(Tuple.fromArray(values))
-      }
-      if !in.isNextToken('{') then in.decodeError("Expected GoogleSQL struct")
-      else if in.isNextToken('}') then fromValues(new Array[Any](fields.size))
-      else {
-        in.rollbackToken()
-        val values = new Array[Any](fields.size)
-        while {
-          val fieldName = in.readKeyAsString()
-          nameToIndex.get(fieldName) match {
-            case Some(index) =>
-              if values(index) != null then in.decodeError("duplicate key " + fieldName)
-              values(index) = readers(index)(in)
-            case _ => in.skip()
-          }
-          in.isNextToken(',')
-        } do ()
-        if !in.isCurrentToken('}') then in.objectEndOrCommaError()
-        fromValues(values)
-      }
+    Json.JsonArray(values.result())
   }
-
-  extension (in: JsonReader)
-    private def nextValueIsString(): Boolean = {
-      val result = in.isNextToken('"')
-      in.rollbackToken()
-      result
-    }
 }
 
 private[bigquery] object GoogleSqlResultCodec extends JsonValueCodec[Seq[String]] {

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunner.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunner.scala
@@ -104,32 +104,39 @@ final class GoogleSqlTestRunner private (executable: Path) extends Runner {
   def explain(action: Dataset.Action): String = sql(action).single
 
   private def run(query: String): Seq[String] = {
-    val (exitCode, stdout, stderr) = runQuery(query, "json")
-    if exitCode != 0 then
-      throw RuntimeException(
-        s"GoogleSQL exited with status $exitCode. SQL:\n$query\nStandard output:\n$stdout\nStandard error:\n$stderr"
-      )
-    val output = stdout.trim
-    if output.isEmpty then {
-      val (boxExitCode, boxOutput, boxError) = runQuery(query, "box")
-      if boxExitCode != 0 then
+    val queryFile = Files.createTempFile("tyda-googlesql-", ".sql")
+    try {
+      Files.writeString(queryFile, query)
+      val (exitCode, stdout, stderr) = runQuery(queryFile, "json")
+      if exitCode != 0 then
         throw RuntimeException(
-          s"GoogleSQL exited with status $boxExitCode. SQL:\n$query\nStandard output:\n$boxOutput\nStandard error:\n$boxError"
+          s"GoogleSQL exited with status $exitCode. SQL:\n$query\nStandard output:\n$stdout\nStandard error:\n$stderr"
         )
-      GoogleSqlTestRunner
-        .errorMessageFromBoxOutput(boxOutput)
-        .foreach(message => throw RuntimeException(message))
-      return Seq.empty
-    }
-    try readFromString(output)(using GoogleSqlResultCodec)
-    catch {
-      case error: Throwable =>
-        throw RuntimeException(s"Unable to decode GoogleSQL result. SQL:\n$query\nOutput:\n$output", error)
-    }
+      val output = stdout.trim
+      if output.isEmpty then {
+        val (boxExitCode, boxOutput, boxError) = runQuery(queryFile, "box")
+        if boxExitCode != 0 then
+          throw RuntimeException(
+            s"GoogleSQL exited with status $boxExitCode. SQL:\n$query\nStandard output:\n$boxOutput\nStandard error:\n$boxError"
+          )
+        GoogleSqlTestRunner
+          .errorMessageFromBoxOutput(boxOutput)
+          .foreach(message => throw RuntimeException(message))
+        Seq.empty
+      } else
+        try readFromString(output)(using GoogleSqlResultCodec)
+        catch {
+          case error: Throwable => throw RuntimeException(
+              s"Unable to decode GoogleSQL result. SQL:\n$query\nOutput:\n$output",
+              error
+            )
+        }
+    } finally Files.deleteIfExists(queryFile): Unit
   }
 
-  private def runQuery(query: String, outputMode: String): (Int, String, String) = {
-    val command = Seq(executable.toString, "--catalog=none", s"--output_mode=$outputMode", query)
+  private def runQuery(queryFile: Path, outputMode: String): (Int, String, String) = {
+    val command =
+      Seq(executable.toString, "--catalog=none", s"--output_mode=$outputMode", s"--sql_file=$queryFile")
     val stdout = StringBuilder()
     val stderr = StringBuilder()
     val logger = ProcessLogger(

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
@@ -49,29 +49,44 @@ class GoogleSqlTestRunnerSpec extends AnyFunSuite {
   test("decode nested arrays wrapped for GoogleSQL") {
     given Codec[Seq[Seq[Int]]] = summon
     val encoded = """{"value":[{"value":[1,2]},{"value":[]}]}"""
-    assert(readFromString(encoded)(using GoogleSqlJsonDecoder.create) == Seq(Seq(1, 2), Seq.empty))
+    assert(readFromString(encoded)(using GoogleSqlJsonCodec.create) == Seq(Seq(1, 2), Seq.empty))
   }
 
   test("decode nullable arrays wrapped for GoogleSQL") {
     given Codec[Seq[Option[Seq[Int]]]] = summon
     val encoded = """{"value":[{"value":[1,2]},{"value":null},{"value":[]}]}"""
     assert(
-      readFromString(encoded)(using GoogleSqlJsonDecoder.create) ==
-        Seq(Some(Seq(1, 2)), None, Some(Seq.empty))
+      readFromString(encoded)(using GoogleSqlJsonCodec.create) == Seq(Some(Seq(1, 2)), None, Some(Seq.empty))
     )
   }
 
+  test("decode nested arrays wrapped inside maps for GoogleSQL") {
+    given Codec[Map[String, Seq[Seq[Int]]]] = summon
+    val encoded = """{"value":[{"key":"a","value":[{"value":[1,2]}]}]}"""
+    assert(readFromString(encoded)(using GoogleSqlJsonCodec.create) == Map("a" -> Seq(Seq(1, 2))))
+  }
+
+  test("decode nested arrays wrapped inside products for GoogleSQL") {
+    given Codec[(items: Seq[Seq[Int]])] = summon
+    val encoded = """{"items":[{"value":[1,2]},{"value":[]}]}"""
+    assert(readFromString(encoded)(using GoogleSqlJsonCodec.create) == (items = Seq(Seq(1, 2), Seq.empty)))
+  }
+
+  test("decode nested options containing arrays for GoogleSQL") {
+    given Codec[Option[Option[Seq[Seq[Int]]]]] = summon
+    val encoded = """{"value":{"value":[{"value":[1,2]}]}}"""
+    assert(readFromString(encoded)(using GoogleSqlJsonCodec.create) == Some(Some(Seq(Seq(1, 2)))))
+  }
+
   test("reject integral values outside the target type's range") {
-    val error = intercept[RuntimeException](readFromString("""{"value":2147483648}""")(using
-      GoogleSqlJsonDecoder.create[Int]
+    intercept[RuntimeException](readFromString("""{"value":2147483648}""")(using
+      GoogleSqlJsonCodec.create[Int]
     ))
-    assert(error.getMessage.contains("out of range"))
   }
 
   test("reject decimal values outside the target type's range") {
-    val error = intercept[RuntimeException](readFromString("""{"value":"100"}""")(using
-      GoogleSqlJsonDecoder.create[Decimal[2, 0]]
+    intercept[RuntimeException](readFromString("""{"value":"100"}""")(using
+      GoogleSqlJsonCodec.create[Decimal[2, 0]]
     ))
-    assert(error.getMessage.contains("cannot be represented as Decimal(2, 0)"))
   }
 }

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
@@ -46,6 +46,13 @@ class GoogleSqlTestRunnerSpec extends AnyFunSuite {
     assert(result == Seq(Some(Binary.fromArray(Array(-5))), None, None))
   }
 
+  test("preserve first-occurrence order when distincting sequences") {
+    val result = GoogleSqlTestRunner
+      .configuredOrSkip
+      .collect(Dataset.from(Seq(Seq(3, 1, 3, 2, 1))).select(_.distinct))
+    assert(result == Seq(Seq(3, 1, 2)))
+  }
+
   test("decode nested arrays wrapped for GoogleSQL") {
     given Codec[Seq[Seq[Int]]] = summon
     val encoded = """{"value":[{"value":[1,2]},{"value":[]}]}"""

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
@@ -21,8 +21,15 @@ class GoogleSqlTestRunnerSpec extends AnyFunSuite {
 
   test("extract execution errors from GoogleSQL box output") {
     assert(
-      GoogleSqlTestRunner.errorMessageFromBoxOutput("ERROR: OUT_OF_RANGE: value is out of range\n") ==
-        Some("OUT_OF_RANGE: value is out of range")
+      GoogleSqlTestRunner.errorMessageFromBoxOutput("ERROR: OUT_OF_RANGE: value is out of range\n", "", "") ==
+        "OUT_OF_RANGE: value is out of range"
+    )
+  }
+
+  test("report unexpected GoogleSQL box output") {
+    assert(
+      GoogleSqlTestRunner.errorMessageFromBoxOutput("", "SELECT 1", "unexpected output") ==
+        "GoogleSQL returned no JSON output and no recognized error. SQL:\nSELECT 1\nStandard output:\n\nStandard error:\nunexpected output"
     )
   }
 

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
@@ -1,0 +1,61 @@
+package com.choreograph.tyda.bigquery
+
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Decimal
+
+class GoogleSqlTestRunnerSpec extends AnyFunSuite {
+  test("decode GoogleSQL JSON result rows") {
+    val output = """{"row":[{"value":"{\"value\":1}"},{"value":"{\"value\":2}"}]}"""
+    assert(readFromString(output)(using GoogleSqlResultCodec) == Seq("{\"value\":1}", "{\"value\":2}"))
+  }
+
+  test("decode GoogleSQL JSON result with no rows") {
+    assert(readFromString("{} ")(using GoogleSqlResultCodec) == Seq.empty)
+  }
+
+  test("extract execution errors from GoogleSQL box output") {
+    assert(
+      GoogleSqlTestRunner.errorMessageFromBoxOutput("ERROR: OUT_OF_RANGE: boom\n") ==
+        Some("OUT_OF_RANGE: boom")
+    )
+  }
+
+  test("escape GoogleSQL macros inside string literals") {
+    assert(
+      GoogleSqlTestRunner.escapeMacrosInStringLiterals("SELECT '$A(', '\\$B(', $parameter") ==
+        "SELECT '$' 'A(', '\\$B(', $parameter"
+    )
+  }
+
+  test("decode nested arrays wrapped for GoogleSQL") {
+    given Codec[Seq[Seq[Int]]] = summon
+    val encoded = """{"value":[{"value":[1,2]},{"value":[]}]}"""
+    assert(readFromString(encoded)(using GoogleSqlJsonDecoder.create) == Seq(Seq(1, 2), Seq.empty))
+  }
+
+  test("decode nullable arrays wrapped for GoogleSQL") {
+    given Codec[Seq[Option[Seq[Int]]]] = summon
+    val encoded = """{"value":[{"value":[1,2]},{"value":null},{"value":[]}]}"""
+    assert(
+      readFromString(encoded)(using GoogleSqlJsonDecoder.create) ==
+        Seq(Some(Seq(1, 2)), None, Some(Seq.empty))
+    )
+  }
+
+  test("reject integral values outside the target type's range") {
+    val error = intercept[RuntimeException](readFromString("""{"value":2147483648}""")(using
+      GoogleSqlJsonDecoder.create[Int]
+    ))
+    assert(error.getMessage.contains("out of range"))
+  }
+
+  test("reject decimal values outside the target type's range") {
+    val error = intercept[RuntimeException](readFromString("""{"value":"100"}""")(using
+      GoogleSqlJsonDecoder.create[Decimal[2, 0]]
+    ))
+    assert(error.getMessage.contains("cannot be represented as Decimal(2, 0)"))
+  }
+}

--- a/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
+++ b/tyda-big-query/src/test/scala/com/choreograph/tyda/bigquery/GoogleSqlTestRunnerSpec.scala
@@ -3,8 +3,11 @@ package com.choreograph.tyda.bigquery
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import org.scalatest.funsuite.AnyFunSuite
 
+import com.choreograph.tyda.Binary
 import com.choreograph.tyda.Codec
+import com.choreograph.tyda.Dataset
 import com.choreograph.tyda.Decimal
+import com.choreograph.tyda.functions.fromBase64
 
 class GoogleSqlTestRunnerSpec extends AnyFunSuite {
   test("decode GoogleSQL JSON result rows") {
@@ -18,8 +21,8 @@ class GoogleSqlTestRunnerSpec extends AnyFunSuite {
 
   test("extract execution errors from GoogleSQL box output") {
     assert(
-      GoogleSqlTestRunner.errorMessageFromBoxOutput("ERROR: OUT_OF_RANGE: boom\n") ==
-        Some("OUT_OF_RANGE: boom")
+      GoogleSqlTestRunner.errorMessageFromBoxOutput("ERROR: OUT_OF_RANGE: value is out of range\n") ==
+        Some("OUT_OF_RANGE: value is out of range")
     )
   }
 
@@ -28,6 +31,12 @@ class GoogleSqlTestRunnerSpec extends AnyFunSuite {
       GoogleSqlTestRunner.escapeMacrosInStringLiterals("SELECT '$A(', '\\$B(', $parameter") ==
         "SELECT '$' 'A(', '\\$B(', $parameter"
     )
+  }
+
+  test("match BigQuery Base64 whitespace handling") {
+    val values = Seq("++ \t\r\n", "++\u001C", "++\u1680")
+    val result = GoogleSqlTestRunner.configuredOrSkip.collect(Dataset.from(values).select(fromBase64))
+    assert(result == Seq(Some(Binary.fromArray(Array(-5))), None, None))
   }
 
   test("decode nested arrays wrapped for GoogleSQL") {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/DdlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/DdlDialect.scala
@@ -17,7 +17,11 @@ final case class DdlDialect(
     supportsArrayAsArrayElement: Boolean = true,
     floatType: String = "FLOAT",
     doubleType: String = "DOUBLE",
-    bytesType: String = "BINARY"
+    bytesType: String = "BINARY",
+    byteType: String = "TINYINT",
+    shortType: String = "SMALLINT",
+    intType: String = "INT",
+    longType: String = "BIGINT"
 )
 
 object DdlDialect {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -490,13 +490,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
             case SqlDialect.FromBase64Support.StrictFunction(name, replace, matches) =>
               val withoutWhitespace = SqlExpr.Function(
                 replace,
-                Seq(
-                  str,
-                  SqlExpr.LiteralRawString(
-                    "[\\x20\\t-\\r\\x1C-\\x1F\\x{1680}\\x{2000}-\\x{2006}\\x{2008}-\\x{200A}\\x{2028}\\x{2029}\\x{205F}\\x{3000}]"
-                  ),
-                  SqlExpr.LiteralString("")
-                )
+                Seq(str, SqlExpr.LiteralRawString("[\\x20\\t-\\r]"), SqlExpr.LiteralString(""))
               )
               val isValid = SqlExpr.Function(
                 matches,

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -454,6 +454,17 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
             case SqlDialect.ArrayDistinct.Function(name) => SqlExpr.Function(name, Seq(arr))
             case SqlDialect.ArrayDistinct.Subquery(makeArray, unnest) =>
               val element = args.aliasGen.column()
+              val selectQuery = Query.Select(
+                select = NonEmpty(SqlExpr.Ident(element)),
+                from = Some(From.Expr(SqlExpr.Function(unnest, Seq(arr)), element)),
+                where = None,
+                groupBy = Seq.empty,
+                having = None,
+                distinct = true
+              )
+              SqlExpr.Function(makeArray, Seq(SqlExpr.Subquery(selectQuery)))
+            case SqlDialect.ArrayDistinct.OrderedSubquery(makeArray, unnest) =>
+              val element = args.aliasGen.column()
               val offset = args.aliasGen.column()
               val firstOffset = args.aliasGen.column()
               val subqueryAlias = args.aliasGen.column()

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -220,7 +220,23 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
             }
         }
       case ExprNode.LessThanOrEqual(_, lhs, rhs) => binaryOp("<=", lhs, rhs)
+      case ExprNode.And(lhs, rhs) if dialect.shortCircuitBooleanOperators =>
+        for {
+          lhsSql <- inner(lhs)
+          rhsSql <- inner(rhs)
+        } yield SqlExpr.Case(
+          Seq((condition = lhsSql, result = rhsSql)),
+          elseExpr = Some(SqlExpr.LiteralBool(false))
+        )
       case ExprNode.And(lhs, rhs) => binaryOp("AND", lhs, rhs)
+      case ExprNode.Or(lhs, rhs) if dialect.shortCircuitBooleanOperators =>
+        for {
+          lhsSql <- inner(lhs)
+          rhsSql <- inner(rhs)
+        } yield SqlExpr.Case(
+          Seq((condition = lhsSql, result = SqlExpr.LiteralBool(true))),
+          elseExpr = Some(rhsSql)
+        )
       case ExprNode.Or(lhs, rhs) => binaryOp("OR", lhs, rhs)
       case ExprNode.Not(operand) => inner(operand).map(SqlExpr.not)
       case ExprNode.MakeProduct(values, codec) =>
@@ -438,15 +454,30 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
             case SqlDialect.ArrayDistinct.Function(name) => SqlExpr.Function(name, Seq(arr))
             case SqlDialect.ArrayDistinct.Subquery(makeArray, unnest) =>
               val element = args.aliasGen.column()
+              val offset = args.aliasGen.column()
+              val firstOffset = args.aliasGen.column()
+              val subqueryAlias = args.aliasGen.column()
               val elementIdent = SqlExpr.Ident(element)
-              val unnestFrom = From.Expr(SqlExpr.Function(unnest, Seq(arr)), element)
-              val selectQuery = Query.Select(
-                select = NonEmpty(elementIdent),
+              val unnestFrom = From.ExprWithOffset(SqlExpr.Function(unnest, Seq(arr)), element, offset)
+              val distinctQuery = Query.Select(
+                select = NonEmpty[Seq](
+                  SqlExpr.As(elementIdent, "value"),
+                  SqlExpr.As(SqlExpr.Function("min", Seq(SqlExpr.Ident(offset))), firstOffset)
+                ),
                 from = Some(unnestFrom),
+                where = None,
+                groupBy = Seq(elementIdent),
+                having = None,
+                distinct = false
+              )
+              val selectQuery = Query.Select(
+                select = NonEmpty(SqlExpr.FieldAccess(SqlExpr.Ident(subqueryAlias), "value")),
+                from = Some(From.Subquery(distinctQuery, subqueryAlias)),
                 where = None,
                 groupBy = Seq.empty,
                 having = None,
-                distinct = true
+                distinct = false,
+                orderBy = Seq(SqlExpr.FieldAccess(SqlExpr.Ident(subqueryAlias), firstOffset))
               )
               SqlExpr.Function(makeArray, Seq(SqlExpr.Subquery(selectQuery)))
           }
@@ -908,6 +939,12 @@ private def primitiveAggregate[T: Codec](
   def simple(name: String): Result[SqlExpr] = simpleAggregate(name, arg)
   def binaryAgg(name: String): Result[SqlExpr] =
     Right(SqlExpr.Function(name, Seq(SqlExpr.FieldAccess(arg, "_1"), SqlExpr.FieldAccess(arg, "_2"))))
+  def orderedArrayAgg(descending: Boolean, name: String): Result[SqlExpr] = {
+    val value = SqlExpr.FieldAccess(arg, "_1")
+    val key = SqlExpr.FieldAccess(arg, "_2")
+    val aggregate = SqlExpr.OrderedAggregate(name, value, key, descending, limit = 1)
+    Right(SqlExpr.Index(aggregate, SqlExpr.Function("OFFSET", Seq(SqlExpr.LiteralNumeric("0")))))
+  }
   agg match {
     case PrimitiveAggregate.Count() => simple("count")
     case PrimitiveAggregate.BoolAnd() => simple(dialect.boolAndFunction)
@@ -924,8 +961,14 @@ private def primitiveAggregate[T: Codec](
       }
     case PrimitiveAggregate.Max(_) => simple("max")
     case PrimitiveAggregate.Min(_) => simple("min")
-    case PrimitiveAggregate.MaxBy(_) => binaryAgg("max_by")
-    case PrimitiveAggregate.MinBy(_) => binaryAgg("min_by")
+    case PrimitiveAggregate.MaxBy(_) => dialect.minMaxBy match {
+        case SqlDialect.MinMaxBy.Function(_, max) => binaryAgg(max)
+        case SqlDialect.MinMaxBy.OrderedArrayAgg(name) => orderedArrayAgg(descending = true, name)
+      }
+    case PrimitiveAggregate.MinBy(_) => dialect.minMaxBy match {
+        case SqlDialect.MinMaxBy.Function(min, _) => binaryAgg(min)
+        case SqlDialect.MinMaxBy.OrderedArrayAgg(name) => orderedArrayAgg(descending = false, name)
+      }
     case PrimitiveAggregate.Sum(CompatibleSum()) => simple("sum")
     case PrimitiveAggregate.Sum(magnet) =>
       Left(DatasetToSqlError.RequiresUdfCapability(s"Sum uses custom $magnet"))

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -220,7 +220,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
             }
         }
       case ExprNode.LessThanOrEqual(_, lhs, rhs) => binaryOp("<=", lhs, rhs)
-      case ExprNode.And(lhs, rhs) if isGoogleSql(dialect) =>
+      case ExprNode.And(lhs, rhs) if dialect.useCaseForShortCircuitBooleanOperators =>
         for {
           lhsSql <- inner(lhs)
           rhsSql <- inner(rhs)
@@ -229,7 +229,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
           elseExpr = Some(SqlExpr.LiteralBool(false))
         )
       case ExprNode.And(lhs, rhs) => binaryOp("AND", lhs, rhs)
-      case ExprNode.Or(lhs, rhs) if isGoogleSql(dialect) =>
+      case ExprNode.Or(lhs, rhs) if dialect.useCaseForShortCircuitBooleanOperators =>
         for {
           lhsSql <- inner(lhs)
           rhsSql <- inner(rhs)
@@ -948,8 +948,6 @@ object CompatibleFractional {
 private def simpleAggregate(name: String, arg: SqlExpr): Result[SqlExpr] =
   Right(SqlExpr.Function(name, Seq(arg)))
 
-private def isGoogleSql(dialect: SqlDialect): Boolean = dialect == SqlDialect.GoogleSql
-
 private def primitiveAggregate[T: Codec](
     arg: SqlExpr,
     agg: PrimitiveAggregate[T, ?],
@@ -980,12 +978,14 @@ private def primitiveAggregate[T: Codec](
       }
     case PrimitiveAggregate.Max(_) => simple("max")
     case PrimitiveAggregate.Min(_) => simple("min")
-    case PrimitiveAggregate.MaxBy(_) if isGoogleSql(dialect) =>
-      orderedArrayAgg(descending = true, "array_agg")
-    case PrimitiveAggregate.MaxBy(_) => binaryAgg("max_by")
-    case PrimitiveAggregate.MinBy(_) if isGoogleSql(dialect) =>
-      orderedArrayAgg(descending = false, "array_agg")
-    case PrimitiveAggregate.MinBy(_) => binaryAgg("min_by")
+    case PrimitiveAggregate.MaxBy(_) => dialect.minMaxBy match {
+        case SqlDialect.MinMaxBy.Function(_, max) => binaryAgg(max)
+        case SqlDialect.MinMaxBy.OrderedArrayAgg(name) => orderedArrayAgg(descending = true, name)
+      }
+    case PrimitiveAggregate.MinBy(_) => dialect.minMaxBy match {
+        case SqlDialect.MinMaxBy.Function(min, _) => binaryAgg(min)
+        case SqlDialect.MinMaxBy.OrderedArrayAgg(name) => orderedArrayAgg(descending = false, name)
+      }
     case PrimitiveAggregate.Sum(CompatibleSum()) => simple("sum")
     case PrimitiveAggregate.Sum(magnet) =>
       Left(DatasetToSqlError.RequiresUdfCapability(s"Sum uses custom $magnet"))

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -493,7 +493,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
                 Seq(
                   str,
                   SqlExpr.LiteralRawString(
-                    "[\\t-\\r\\x1C-\\x1F\\x{1680}\\x{2000}-\\x{2006}\\x{2008}-\\x{200A}\\x{2028}\\x{2029}\\x{205F}\\x{3000}]"
+                    "[\\x20\\t-\\r\\x1C-\\x1F\\x{1680}\\x{2000}-\\x{2006}\\x{2008}-\\x{200A}\\x{2028}\\x{2029}\\x{205F}\\x{3000}]"
                   ),
                   SqlExpr.LiteralString("")
                 )

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -487,6 +487,29 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
             case SqlDialect.FromBase64Support.TryFunction(name, format) =>
               SqlExpr.Function(name, Seq(str, SqlExpr.LiteralString(format)))
             case SqlDialect.FromBase64Support.Function(name) => SqlExpr.Function(name, Seq(str))
+            case SqlDialect.FromBase64Support.StrictFunction(name, replace, matches) =>
+              val withoutWhitespace = SqlExpr.Function(
+                replace,
+                Seq(
+                  str,
+                  SqlExpr.LiteralRawString(
+                    "[\\t-\\r\\x1C-\\x1F\\x{1680}\\x{2000}-\\x{2006}\\x{2008}-\\x{200A}\\x{2028}\\x{2029}\\x{205F}\\x{3000}]"
+                  ),
+                  SqlExpr.LiteralString("")
+                )
+              )
+              val isValid = SqlExpr.Function(
+                matches,
+                Seq(
+                  withoutWhitespace,
+                  SqlExpr.LiteralRawString(
+                    "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=?)?$"
+                  )
+                )
+              )
+              SqlExpr.Case(Seq(
+                (condition = isValid, result = SqlExpr.Function(name, Seq(withoutWhitespace)))
+              ))
           }
         )
       case ExprNode.ToBase64(binary) => inner(binary).map(bin =>

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -220,7 +220,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
             }
         }
       case ExprNode.LessThanOrEqual(_, lhs, rhs) => binaryOp("<=", lhs, rhs)
-      case ExprNode.And(lhs, rhs) if dialect.shortCircuitBooleanOperators =>
+      case ExprNode.And(lhs, rhs) if isGoogleSql(dialect) =>
         for {
           lhsSql <- inner(lhs)
           rhsSql <- inner(rhs)
@@ -229,7 +229,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
           elseExpr = Some(SqlExpr.LiteralBool(false))
         )
       case ExprNode.And(lhs, rhs) => binaryOp("AND", lhs, rhs)
-      case ExprNode.Or(lhs, rhs) if dialect.shortCircuitBooleanOperators =>
+      case ExprNode.Or(lhs, rhs) if isGoogleSql(dialect) =>
         for {
           lhsSql <- inner(lhs)
           rhsSql <- inner(rhs)
@@ -954,6 +954,8 @@ object CompatibleFractional {
 private def simpleAggregate(name: String, arg: SqlExpr): Result[SqlExpr] =
   Right(SqlExpr.Function(name, Seq(arg)))
 
+private def isGoogleSql(dialect: SqlDialect): Boolean = dialect == SqlDialect.GoogleSql
+
 private def primitiveAggregate[T: Codec](
     arg: SqlExpr,
     agg: PrimitiveAggregate[T, ?],
@@ -984,14 +986,12 @@ private def primitiveAggregate[T: Codec](
       }
     case PrimitiveAggregate.Max(_) => simple("max")
     case PrimitiveAggregate.Min(_) => simple("min")
-    case PrimitiveAggregate.MaxBy(_) => dialect.minMaxBy match {
-        case SqlDialect.MinMaxBy.Function(_, max) => binaryAgg(max)
-        case SqlDialect.MinMaxBy.OrderedArrayAgg(name) => orderedArrayAgg(descending = true, name)
-      }
-    case PrimitiveAggregate.MinBy(_) => dialect.minMaxBy match {
-        case SqlDialect.MinMaxBy.Function(min, _) => binaryAgg(min)
-        case SqlDialect.MinMaxBy.OrderedArrayAgg(name) => orderedArrayAgg(descending = false, name)
-      }
+    case PrimitiveAggregate.MaxBy(_) if isGoogleSql(dialect) =>
+      orderedArrayAgg(descending = true, "array_agg")
+    case PrimitiveAggregate.MaxBy(_) => binaryAgg("max_by")
+    case PrimitiveAggregate.MinBy(_) if isGoogleSql(dialect) =>
+      orderedArrayAgg(descending = false, "array_agg")
+    case PrimitiveAggregate.MinBy(_) => binaryAgg("min_by")
     case PrimitiveAggregate.Sum(CompatibleSum()) => simple("sum")
     case PrimitiveAggregate.Sum(magnet) =>
       Left(DatasetToSqlError.RequiresUdfCapability(s"Sum uses custom $magnet"))

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -31,7 +31,6 @@ final case class SqlDialect(
     binaryLiteral: SqlDialect.BinaryLiteral,
     boolAndFunction: String,
     boolOrFunction: String,
-    shortCircuitBooleanOperators: Boolean = false,
     bytesLength: String,
     fromBase64: SqlDialect.FromBase64Support,
     toBase64: SqlDialect.ToBase64Support.Function,
@@ -54,7 +53,6 @@ final case class SqlDialect(
     makeStruct: SqlDialect.MakeStruct,
     makeTimestamp: SqlDialect.MakeTimestamp,
     mapSupport: SqlDialect.MapSupport,
-    minMaxBy: SqlDialect.MinMaxBy = SqlDialect.MinMaxBy.Function("min_by", "max_by"),
     range: SqlDialect.Range,
     regexp: String,
     endsWithFunction: String,
@@ -221,11 +219,6 @@ object SqlDialect {
   enum MapSupport {
     case Array
     case Native(makeMap: String, mapEntries: String, mapGet: String, mapContains: String)
-  }
-
-  enum MinMaxBy {
-    case Function(min: String, max: String)
-    case OrderedArrayAgg(name: String)
   }
 
   enum IntegerSupport {
@@ -475,7 +468,6 @@ object SqlDialect {
     makeStruct = MakeStruct.FunctionAndAlias("struct"),
     makeTimestamp = MakeTimestamp.Function("timestamp_micros"),
     mapSupport = MapSupport.Array,
-    minMaxBy = MinMaxBy.Function("min_by", "max_by"),
     range = Range.Inclusive("generate_array", errorOnEmpty = false),
     regexp = "regexp_contains",
     endsWithFunction = "ends_with",
@@ -498,10 +490,8 @@ object SqlDialect {
     )
   )
 
-  val GoogleSql: SqlDialect = BigQuery.copy(
-    fromBase64 = FromBase64Support.StrictFunction("SAFE.FROM_BASE64", "regexp_replace", "regexp_contains"),
-    minMaxBy = MinMaxBy.OrderedArrayAgg("array_agg"),
-    shortCircuitBooleanOperators = true
+  val GoogleSql: SqlDialect = BigQuery.copy(fromBase64 =
+    FromBase64Support.StrictFunction("SAFE.FROM_BASE64", "regexp_replace", "regexp_contains")
   )
 
   private val sparkJsonOptions =

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -31,6 +31,7 @@ final case class SqlDialect(
     binaryLiteral: SqlDialect.BinaryLiteral,
     boolAndFunction: String,
     boolOrFunction: String,
+    shortCircuitBooleanOperators: Boolean = false,
     bytesLength: String,
     fromBase64: SqlDialect.FromBase64Support,
     toBase64: SqlDialect.ToBase64Support.Function,
@@ -53,6 +54,7 @@ final case class SqlDialect(
     makeStruct: SqlDialect.MakeStruct,
     makeTimestamp: SqlDialect.MakeTimestamp,
     mapSupport: SqlDialect.MapSupport,
+    minMaxBy: SqlDialect.MinMaxBy = SqlDialect.MinMaxBy.Function("min_by", "max_by"),
     range: SqlDialect.Range,
     regexp: String,
     endsWithFunction: String,
@@ -217,6 +219,11 @@ object SqlDialect {
   enum MapSupport {
     case Array
     case Native(makeMap: String, mapEntries: String, mapGet: String, mapContains: String)
+  }
+
+  enum MinMaxBy {
+    case Function(min: String, max: String)
+    case OrderedArrayAgg(name: String)
   }
 
   enum IntegerSupport {
@@ -440,6 +447,10 @@ object SqlDialect {
       floatType = "FLOAT64",
       doubleType = "FLOAT64",
       bytesType = "BYTES",
+      byteType = "INT64",
+      shortType = "INT64",
+      intType = "INT64",
+      longType = "INT64",
       supportsArrayAsArrayElement = false
     ),
     errorFunction = "error",
@@ -462,6 +473,7 @@ object SqlDialect {
     makeStruct = MakeStruct.FunctionAndAlias("struct"),
     makeTimestamp = MakeTimestamp.Function("timestamp_micros"),
     mapSupport = MapSupport.Array,
+    minMaxBy = MinMaxBy.Function("min_by", "max_by"),
     range = Range.Inclusive("generate_array", errorOnEmpty = false),
     regexp = "regexp_contains",
     endsWithFunction = "ends_with",
@@ -483,6 +495,9 @@ object SqlDialect {
       RemoveNullSafeEqualsInJoinCondition
     )
   )
+
+  val GoogleSql: SqlDialect =
+    BigQuery.copy(minMaxBy = MinMaxBy.OrderedArrayAgg("array_agg"), shortCircuitBooleanOperators = true)
 
   private val sparkJsonOptions =
     Map("timeZone" -> "UTC", "timestampFormat" -> "yyyy-MM-dd'T'HH:mm[:ss][.SSSSSS][XXX]")

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -31,6 +31,7 @@ final case class SqlDialect(
     binaryLiteral: SqlDialect.BinaryLiteral,
     boolAndFunction: String,
     boolOrFunction: String,
+    useCaseForShortCircuitBooleanOperators: Boolean = false,
     bytesLength: String,
     fromBase64: SqlDialect.FromBase64Support,
     toBase64: SqlDialect.ToBase64Support.Function,
@@ -53,6 +54,7 @@ final case class SqlDialect(
     makeStruct: SqlDialect.MakeStruct,
     makeTimestamp: SqlDialect.MakeTimestamp,
     mapSupport: SqlDialect.MapSupport,
+    minMaxBy: SqlDialect.MinMaxBy = SqlDialect.MinMaxBy.Function("min_by", "max_by"),
     range: SqlDialect.Range,
     regexp: String,
     endsWithFunction: String,
@@ -219,6 +221,11 @@ object SqlDialect {
   enum MapSupport {
     case Array
     case Native(makeMap: String, mapEntries: String, mapGet: String, mapContains: String)
+  }
+
+  enum MinMaxBy {
+    case Function(min: String, max: String)
+    case OrderedArrayAgg(name: String)
   }
 
   enum IntegerSupport {
@@ -427,6 +434,7 @@ object SqlDialect {
     binaryLiteral = BinaryLiteral.ByteEscapeString,
     boolAndFunction = "logical_and",
     boolOrFunction = "logical_or",
+    useCaseForShortCircuitBooleanOperators = false,
     bytesLength = "byte_length",
     fromBase64 = FromBase64Support.Function("SAFE.FROM_BASE64"),
     toBase64 = ToBase64Support.Function("TO_BASE64", false),
@@ -468,6 +476,7 @@ object SqlDialect {
     makeStruct = MakeStruct.FunctionAndAlias("struct"),
     makeTimestamp = MakeTimestamp.Function("timestamp_micros"),
     mapSupport = MapSupport.Array,
+    minMaxBy = MinMaxBy.Function("min_by", "max_by"),
     range = Range.Inclusive("generate_array", errorOnEmpty = false),
     regexp = "regexp_contains",
     endsWithFunction = "ends_with",
@@ -490,8 +499,10 @@ object SqlDialect {
     )
   )
 
-  val GoogleSql: SqlDialect = BigQuery.copy(fromBase64 =
-    FromBase64Support.StrictFunction("SAFE.FROM_BASE64", "regexp_replace", "regexp_contains")
+  val GoogleSql: SqlDialect = BigQuery.copy(
+    fromBase64 = FromBase64Support.StrictFunction("SAFE.FROM_BASE64", "regexp_replace", "regexp_contains"),
+    minMaxBy = MinMaxBy.OrderedArrayAgg("array_agg"),
+    useCaseForShortCircuitBooleanOperators = true
   )
 
   private val sparkJsonOptions =
@@ -509,6 +520,7 @@ object SqlDialect {
     binaryLiteral = BinaryLiteral.HexString,
     boolAndFunction = "bool_and",
     boolOrFunction = "bool_or",
+    useCaseForShortCircuitBooleanOperators = false,
     bytesLength = "length",
     fromBase64 = FromBase64Support.TryFunction("try_to_binary", "base64"),
     toBase64 = ToBase64Support.Function("base64", true),
@@ -536,6 +548,7 @@ object SqlDialect {
       mapGet = "element_at",
       mapContains = "map_contains_key"
     ),
+    minMaxBy = MinMaxBy.Function("min_by", "max_by"),
     range = Range.Inclusive("sequence", errorOnEmpty = true),
     regexp = "regexp",
     endsWithFunction = "endswith",

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -100,6 +100,8 @@ object SqlDialect {
       * `SAFE.FROM_BASE64(str)`.
       */
     case Function(name: String)
+
+    case StrictFunction(name: String, replace: String, matches: String)
   }
 
   /** How to encode binary to a Base64 string. */
@@ -496,8 +498,11 @@ object SqlDialect {
     )
   )
 
-  val GoogleSql: SqlDialect =
-    BigQuery.copy(minMaxBy = MinMaxBy.OrderedArrayAgg("array_agg"), shortCircuitBooleanOperators = true)
+  val GoogleSql: SqlDialect = BigQuery.copy(
+    fromBase64 = FromBase64Support.StrictFunction("SAFE.FROM_BASE64", "regexp_replace", "regexp_contains"),
+    minMaxBy = MinMaxBy.OrderedArrayAgg("array_agg"),
+    shortCircuitBooleanOperators = true
+  )
 
   private val sparkJsonOptions =
     Map("timeZone" -> "UTC", "timestampFormat" -> "yyyy-MM-dd'T'HH:mm[:ss][.SSSSSS][XXX]")

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -217,7 +217,9 @@ object SqlDialect {
       */
     case Subquery(makeArray: String, unnest: String)
 
-    /** Array distinct needs to preserve the first occurrence of each element using a subquery. */
+    /** Array distinct needs to preserve the first occurrence of each element
+      * using a subquery.
+      */
     case OrderedSubquery(makeArray: String, unnest: String)
   }
 

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -216,6 +216,9 @@ object SqlDialect {
       * ```
       */
     case Subquery(makeArray: String, unnest: String)
+
+    /** Array distinct needs to preserve the first occurrence of each element using a subquery. */
+    case OrderedSubquery(makeArray: String, unnest: String)
   }
 
   enum MapSupport {
@@ -500,6 +503,7 @@ object SqlDialect {
   )
 
   val GoogleSql: SqlDialect = BigQuery.copy(
+    arrayDistinct = ArrayDistinct.OrderedSubquery("array", "unnest"),
     fromBase64 = FromBase64Support.StrictFunction("SAFE.FROM_BASE64", "regexp_replace", "regexp_contains"),
     minMaxBy = MinMaxBy.OrderedArrayAgg("array_agg"),
     useCaseForShortCircuitBooleanOperators = true

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ToDdl.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ToDdl.scala
@@ -99,10 +99,10 @@ object ToDdl {
   private[tyda] def toNullableDdlType[T](codec: Codec[T], dialect: DdlDialect): DdlType =
     codec match {
       case Codec.Boolean => DdlType.Primitive("BOOLEAN")
-      case Codec.Byte => DdlType.Primitive("TINYINT")
-      case Codec.Short => DdlType.Primitive("SMALLINT")
-      case Codec.Int => DdlType.Primitive("INT")
-      case Codec.Long => DdlType.Primitive("BIGINT")
+      case Codec.Byte => DdlType.Primitive(dialect.byteType)
+      case Codec.Short => DdlType.Primitive(dialect.shortType)
+      case Codec.Int => DdlType.Primitive(dialect.intType)
+      case Codec.Long => DdlType.Primitive(dialect.longType)
       case Codec.Float => DdlType.Primitive(dialect.floatType)
       case Codec.Double => DdlType.Primitive(dialect.doubleType)
       case Codec.String => DdlType.Primitive("STRING")

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/From.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/From.scala
@@ -5,6 +5,7 @@ import com.choreograph.tyda.NonEmpty
 private[sql] enum From {
   case Table(name: Identifier)
   case Expr(name: SqlExpr, alias: Identifier)
+  case ExprWithOffset(name: SqlExpr, alias: Identifier, offset: Identifier)
   case Subquery(query: Query, alias: Identifier)
   case Join(left: From, right: From, joinType: JoinType, on: Option[SqlExpr])
   case Values(values: Seq[NonEmpty[Seq[SqlExpr]]], columns: NonEmpty[Seq[Identifier]], alias: Identifier)
@@ -13,6 +14,11 @@ private[sql] enum From {
 private[sql] object From {
   object Expr {
     def apply(expr: SqlExpr, alias: String): From = Expr(expr, Identifier(alias))
+  }
+
+  object ExprWithOffset {
+    def apply(expr: SqlExpr, alias: String, offset: String): From =
+      ExprWithOffset(expr, Identifier(alias), Identifier(offset))
   }
 
   object Table {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
@@ -10,6 +10,7 @@ private[sql] enum SqlExpr {
   case Index(array: SqlExpr, index: SqlExpr)
   case Ident(name: Identifier)
   case LiteralString(value: String)
+  case LiteralRawString(value: String)
   case LiteralHexString(value: Array[Byte])
   case LiteralByteEscapeString(value: Array[Byte])
   case LiteralNumeric(value: String)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
@@ -6,6 +6,7 @@ private[sql] enum SqlExpr {
   case BinaryOp(op: String, lhs: SqlExpr, rhs: SqlExpr)
   case FieldAccess(struct: SqlExpr, field: Identifier)
   case Function(name: String, args: Seq[SqlExpr])
+  case OrderedAggregate(name: String, arg: SqlExpr, orderBy: SqlExpr, descending: Boolean, limit: Int)
   case Index(array: SqlExpr, index: SqlExpr)
   case Ident(name: Identifier)
   case LiteralString(value: String)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
@@ -33,6 +33,11 @@ private[tyda] final case class SqlWriter(writer: Writer) {
       case SqlExpr.Brackets(exprs) => writeSql1"[$exprs]"
       case SqlExpr.FieldAccess(struct, field) => writeSql"$struct.$field"
       case SqlExpr.Function(name, args) => writeSql"$name($args)"
+      case SqlExpr.OrderedAggregate(name, arg, orderBy, descending, limit) =>
+        writeSql"$name($arg ORDER BY $orderBy"
+        write(if descending then " DESC LIMIT " else " ASC LIMIT ")
+        write(limit.toString)
+        write(")")
       case SqlExpr.Index(arr, idx) => writeSql"$arr[$idx]"
       case SqlExpr.Ident(name) => write(name)
       case SqlExpr.UnaryOp(op, e, true) => writeSql"($op $e)"
@@ -117,6 +122,7 @@ private[tyda] final case class SqlWriter(writer: Writer) {
     from match {
       case From.Table(name) => write(name)
       case From.Expr(expr, alias) => writeSql"$expr AS $alias"
+      case From.ExprWithOffset(expr, alias, offset) => writeSql"$expr AS $alias WITH OFFSET AS $offset"
       case From.Subquery(query, alias) => writeSql"($query) AS $alias"
       case From.Join(left, right, JoinType.Inner, None) => writeSql"$left, $right"
       case From.Join(left, right, tpe, on) =>

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
@@ -55,6 +55,10 @@ private[tyda] final case class SqlWriter(writer: Writer) {
           case c => writer.write(c)
         }
         writer.write('\'')
+      case SqlExpr.LiteralRawString(value) =>
+        writer.write("r'")
+        writer.write(value)
+        writer.write('\'')
       case SqlExpr.LiteralHexString(value) =>
         write("X'")
         value.foreach(b => write(f"$b%02x"))

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
@@ -1,29 +1,29 @@
 ------ Test: aggregate 2 whole dataset
-SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT)) AS _1, array_agg(table1.value) AS _2) END AS value FROM table1
+SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT64)) AS _1, array_agg(table1.value) AS _2) END AS value FROM table1
 ------ end
 
 ------ Test: aggregate 3 whole dataset
-SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT)) AS _1, array_agg(table1.value) AS _2, min(table1.value) AS _3) END AS value FROM table1
+SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT64)) AS _1, array_agg(table1.value) AS _2, min(table1.value) AS _3) END AS value FROM table1
 ------ end
 
 ------ Test: aggregate 4 whole dataset
-SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT)) AS _1, array_agg(table1.value) AS _2, min(table1.value) AS _3, max(table1.value) AS _4) END AS value FROM table1
+SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT64)) AS _1, array_agg(table1.value) AS _2, min(table1.value) AS _3, max(table1.value) AS _4) END AS value FROM table1
 ------ end
 
 ------ Test: aggregate 5 whole dataset
-SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT)) AS _1, array_agg(struct(table1._1 AS _1, table1._2 AS _2)) AS _2, min(table1._1) AS _3, max(table1._1) AS _4, min(table1._2) AS _5) END AS value FROM table1
+SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT64)) AS _1, array_agg(struct(table1._1 AS _1, table1._2 AS _2)) AS _2, min(table1._1) AS _3, max(table1._1) AS _4, min(table1._2) AS _5) END AS value FROM table1
 ------ end
 
 ------ Test: aggregate 6 whole dataset
-SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT)) AS _1, array_agg(struct(table1._1 AS _1, table1._2 AS _2)) AS _2, min(table1._1) AS _3, max(table1._1) AS _4, min(table1._2) AS _5, max(table1._2) AS _6) END AS value FROM table1
+SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT64)) AS _1, array_agg(struct(table1._1 AS _1, table1._2 AS _2)) AS _2, min(table1._1) AS _3, max(table1._1) AS _4, min(table1._2) AS _5, max(table1._2) AS _6) END AS value FROM table1
 ------ end
 
 ------ Test: aggregate 7 whole dataset
-SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT)) AS _1, array_agg(struct(table1._1 AS _1, table1._2 AS _2)) AS _2, min(table1._1) AS _3, max(table1._1) AS _4, min(table1._2) AS _5, max(table1._2) AS _6, array_agg(table1._2) AS _7) END AS value FROM table1
+SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT64)) AS _1, array_agg(struct(table1._1 AS _1, table1._2 AS _2)) AS _2, min(table1._1) AS _3, max(table1._1) AS _4, min(table1._2) AS _5, max(table1._2) AS _6, array_agg(table1._2) AS _7) END AS value FROM table1
 ------ end
 
 ------ Test: aggregate 8 whole dataset
-SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT)) AS _1, array_agg(struct(table1._1 AS _1, table1._2 AS _2)) AS _2, min(table1._1) AS _3, max(table1._1) AS _4, min(table1._2) AS _5, max(table1._2) AS _6, array_agg(table1._2) AS _7, sum(table1._1) AS _8) END AS value FROM table1
+SELECT CASE WHEN (count(1) <> 0) THEN struct(count(CAST(1 AS INT64)) AS _1, array_agg(struct(table1._1 AS _1, table1._2 AS _2)) AS _2, min(table1._1) AS _3, max(table1._1) AS _4, min(table1._2) AS _5, max(table1._2) AS _6, array_agg(table1._2) AS _7, sum(table1._1) AS _8) END AS value FROM table1
 ------ end
 
 ------ Test: aggregate collect whole dataset
@@ -31,7 +31,7 @@ SELECT CASE WHEN (count(1) <> 0) THEN array_agg(table1.value) END AS value FROM 
 ------ end
 
 ------ Test: aggregate count whole dataset
-SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM table1
+SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT64)) END AS value FROM table1
 ------ end
 
 ------ Test: aggregate max whole dataset
@@ -47,7 +47,7 @@ SELECT CASE WHEN (count(1) <> 0) THEN struct(sum(table1.value) AS value) END AS 
 ------ end
 
 ------ Test: boolAnd expr
-SELECT logical_and((NOT (table1._2 <= CAST(0 AS INT)))) AS value FROM table1 GROUP BY table1._1
+SELECT logical_and((NOT (table1._2 <= CAST(0 AS INT64)))) AS value FROM table1 GROUP BY table1._1
 ------ end
 
 ------ Test: boolAnd whole row
@@ -55,7 +55,7 @@ SELECT CASE WHEN (count(1) <> 0) THEN logical_and(table1.value) END AS value FRO
 ------ end
 
 ------ Test: boolOr expr
-SELECT logical_or((NOT (table1._2 <= CAST(0 AS INT)))) AS value FROM table1 GROUP BY table1._1
+SELECT logical_or((NOT (table1._2 <= CAST(0 AS INT64)))) AS value FROM table1 GROUP BY table1._1
 ------ end
 
 ------ Test: boolOr whole row
@@ -63,23 +63,23 @@ SELECT CASE WHEN (count(1) <> 0) THEN logical_or(table1.value) END AS value FROM
 ------ end
 
 ------ Test: collect Option
-SELECT array_agg(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT array_agg(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: collect Option Seq
-SELECT array_agg(struct(table1.value AS value)) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT array_agg(struct(table1.value AS value)) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: collect Seq
-SELECT array_agg(struct(table1.value AS value)) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT array_agg(struct(table1.value AS value)) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: collect and map
-SELECT array((SELECT (CAST(c0 AS INT) + CAST(1 AS INT)) FROM unnest(t0.value) AS c0)) AS value FROM (SELECT array_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
+SELECT array((SELECT (CAST(c0 AS INT64) + CAST(1 AS INT64)) FROM unnest(t0.value) AS c0)) AS value FROM (SELECT array_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
 ------ end
 
 ------ Test: collect and map pairs
-SELECT t0._1 AS _1, array((SELECT (CAST(c0 AS INT) + CAST(1 AS INT)) FROM unnest(t0._2) AS c0)) AS _2 FROM (SELECT table1._1 AS _1, array_agg(table1._2) AS _2 FROM table1 GROUP BY table1._1) AS t0
+SELECT t0._1 AS _1, array((SELECT (CAST(c0 AS INT64) + CAST(1 AS INT64)) FROM unnest(t0._2) AS c0)) AS _2 FROM (SELECT table1._1 AS _1, array_agg(table1._2) AS _2 FROM table1 GROUP BY table1._1) AS t0
 ------ end
 
 ------ Test: collect column
@@ -87,11 +87,11 @@ SELECT array_agg(table1._2) AS value FROM table1 GROUP BY table1._1
 ------ end
 
 ------ Test: collect whole row
-SELECT array_agg(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT array_agg(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: concat and map
-SELECT array((SELECT (CAST(c0 AS INT) + CAST(1 AS INT)) FROM unnest(t0.value) AS c0)) AS value FROM (SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
+SELECT array((SELECT (CAST(c0 AS INT64) + CAST(1 AS INT64)) FROM unnest(t0.value) AS c0)) AS value FROM (SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
 ------ end
 
 ------ Test: concat column
@@ -99,7 +99,7 @@ SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1
 ------ end
 
 ------ Test: concat seq
-SELECT array_concat_agg(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT array_concat_agg(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: concat seq by group
@@ -107,23 +107,23 @@ SELECT table1._1 AS _1, array_concat_agg(table1._2) AS _2 FROM table1 GROUP BY t
 ------ end
 
 ------ Test: count group by
-SELECT table1._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM table1 GROUP BY table1._1
+SELECT table1._1 AS _1, count(CAST(1 AS INT64)) AS _2 FROM table1 GROUP BY table1._1
 ------ end
 
 ------ Test: count whole row
-SELECT count(CAST(1 AS INT)) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT count(CAST(1 AS INT64)) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: countIf expr
-SELECT count(CASE WHEN (NOT (table1.value <= CAST(0 AS INT))) THEN CAST(1 AS INT) END) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT count(CASE WHEN (NOT (table1.value <= CAST(0 AS INT64))) THEN CAST(1 AS INT64) END) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: countIf group by
-SELECT table1._1 AS _1, count(CASE WHEN (NOT (table1._2 <= CAST(0 AS INT))) THEN CAST(1 AS INT) END) AS _2 FROM table1 GROUP BY table1._1
+SELECT table1._1 AS _1, count(CASE WHEN (NOT (table1._2 <= CAST(0 AS INT64))) THEN CAST(1 AS INT64) END) AS _2 FROM table1 GROUP BY table1._1
 ------ end
 
 ------ Test: countIf whole row
-SELECT count(CASE WHEN table1.value THEN CAST(1 AS INT) END) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT count(CASE WHEN table1.value THEN CAST(1 AS INT64) END) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: countSome expr
@@ -131,7 +131,7 @@ SELECT count(table1._2) AS value FROM table1 GROUP BY table1._1
 ------ end
 
 ------ Test: countSome whole row
-SELECT count(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT count(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: explode after aggregate
@@ -151,11 +151,11 @@ SELECT struct(table1._1 AS _1, table1._2 AS _2) AS _1, min(table1._1) AS _2 FROM
 ------ end
 
 ------ Test: groupBy transform
-SELECT (NOT (table1._1 <= CAST(2 AS INT))) AS _1, min(table1._2) AS _2 FROM table1 GROUP BY (NOT (table1._1 <= CAST(2 AS INT)))
+SELECT (NOT (table1._1 <= CAST(2 AS INT64))) AS _1, min(table1._2) AS _2 FROM table1 GROUP BY (NOT (table1._1 <= CAST(2 AS INT64)))
 ------ end
 
 ------ Test: max Double
-SELECT max(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT max(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: maxBy
@@ -163,31 +163,31 @@ SELECT table1._1 AS _1, max_by(struct(table1._1 AS _1, table1._2 AS _2)._1, stru
 ------ end
 
 ------ Test: min Boolean
-SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: min Byte
-SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: min Double
-SELECT coalesce(min(CASE WHEN (NOT is_nan(table1.value)) THEN table1.value END), CAST('NaN' AS FLOAT64)) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT coalesce(min(CASE WHEN (NOT is_nan(table1.value)) THEN table1.value END), CAST('NaN' AS FLOAT64)) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: min Float
-SELECT coalesce(min(CASE WHEN (NOT is_nan(table1.value)) THEN table1.value END), CAST('NaN' AS FLOAT64)) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT coalesce(min(CASE WHEN (NOT is_nan(table1.value)) THEN table1.value END), CAST('NaN' AS FLOAT64)) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: min Int
-SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: min Short
-SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: min String
-SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: min expr
@@ -195,7 +195,7 @@ SELECT table1._1 AS _1, min(table1._2) AS _2 FROM table1 GROUP BY table1._1
 ------ end
 
 ------ Test: min whole row
-SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT min(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: minBy
@@ -203,19 +203,19 @@ SELECT table1._1 AS _1, min_by(struct(table1._1 AS _1, table1._2 AS _2)._1, stru
 ------ end
 
 ------ Test: reduce group by nested option
-SELECT count(CAST(1 AS INT)) AS value FROM (SELECT table1.value AS _1, struct(CASE WHEN CASE WHEN (table1.value IS NULL) THEN TRUE ELSE (NOT (table1.value <= CAST(0 AS INT))) END THEN struct(table1.value AS value) END AS key) AS _2 FROM table1) AS t0 GROUP BY t0._2
+SELECT count(CAST(1 AS INT64)) AS value FROM (SELECT table1.value AS _1, struct(CASE WHEN CASE WHEN (table1.value IS NULL) THEN TRUE ELSE (NOT (table1.value <= CAST(0 AS INT64))) END THEN struct(table1.value AS value) END AS key) AS _2 FROM table1) AS t0 GROUP BY t0._2
 ------ end
 
 ------ Test: reduce group by option.map with struct
-SELECT count(CAST(1 AS INT)) AS value FROM (SELECT table1.value AS _1, struct(CASE WHEN (table1.value IS NOT NULL) THEN struct(table1.value._1 AS _1, CAST(1 AS INT) AS _2) END AS key) AS _2 FROM table1) AS t0 GROUP BY t0._2
+SELECT count(CAST(1 AS INT64)) AS value FROM (SELECT table1.value AS _1, struct(CASE WHEN (table1.value IS NOT NULL) THEN struct(table1.value._1 AS _1, CAST(1 AS INT64) AS _2) END AS key) AS _2 FROM table1) AS t0 GROUP BY t0._2
 ------ end
 
 ------ Test: reduce group by option.orElse with struct
-SELECT count(CAST(1 AS INT)) AS value FROM (SELECT table1.value AS _1, struct(coalesce(table1.value, struct(CAST(0 AS INT) AS _1, CAST(0 AS INT) AS _2)) AS key) AS _2 FROM table1) AS t0 GROUP BY t0._2
+SELECT count(CAST(1 AS INT64)) AS value FROM (SELECT table1.value AS _1, struct(coalesce(table1.value, struct(CAST(0 AS INT64) AS _1, CAST(0 AS INT64) AS _2)) AS key) AS _2 FROM table1) AS t0 GROUP BY t0._2
 ------ end
 
 ------ Test: sum Byte
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: sum Decimal overflow should error
@@ -223,27 +223,27 @@ SELECT CASE WHEN (count(1) <> 0) THEN sum(table1.value) END AS value FROM table1
 ------ end
 
 ------ Test: sum Decimal(MaxPrecision, 2)
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: sum Decimal(MaxPrecision, 9)
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: sum Double
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: sum Float
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: sum Int
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: sum Long
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: sum Long overflow should error
@@ -251,25 +251,25 @@ SELECT CASE WHEN (count(1) <> 0) THEN sum(table1.value) END AS value FROM table1
 ------ end
 
 ------ Test: sum Option[Int]
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: sum Short
-SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT sum(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: support group by with enum
-SELECT struct('a' AS discriminant, struct(table1.value AS a) AS a, CAST(NULL AS STRUCT<b INT>) AS b, CAST(NULL AS STRUCT<c INT>) AS c) AS _1, count(CAST(1 AS INT)) AS _2 FROM table1 GROUP BY table1.value
+SELECT struct('a' AS discriminant, struct(table1.value AS a) AS a, CAST(NULL AS STRUCT<b INT64>) AS b, CAST(NULL AS STRUCT<c INT64>) AS c) AS _1, count(CAST(1 AS INT64)) AS _2 FROM table1 GROUP BY table1.value
 ------ end
 
 ------ Test: support group by with nested option
-SELECT struct(table1.value AS value) AS _1, count(CAST(1 AS INT)) AS _2 FROM table1 GROUP BY table1.value
+SELECT struct(table1.value AS value) AS _1, count(CAST(1 AS INT64)) AS _2 FROM table1 GROUP BY table1.value
 ------ end
 
 ------ Test: support group by with select from literal
-SELECT CAST(1 AS INT) AS _1, count(CAST(1 AS INT)) AS _2 FROM table1 GROUP BY CAST(NULL AS INT)
+SELECT CAST(1 AS INT64) AS _1, count(CAST(1 AS INT64)) AS _2 FROM table1 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: support group with complex literals
-SELECT struct(struct(table1.value AS i, CAST(NULL AS STRING) AS a) AS i, CAST(NULL AS STRUCT<i INT,a STRING>) AS a) AS _1, count(CAST(1 AS INT)) AS _2 FROM table1 GROUP BY table1.value
+SELECT struct(struct(table1.value AS i, CAST(NULL AS STRING) AS a) AS i, CAST(NULL AS STRUCT<i INT64,a STRING>) AS a) AS _1, count(CAST(1 AS INT64)) AS _2 FROM table1 GROUP BY table1.value
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
@@ -27,11 +27,11 @@ SELECT DISTINCT table1.value AS value FROM table1
 ------ end
 
 ------ Test: explode Map
-SELECT t0._1 AS _1, t0._2 AS _2 FROM table1, unnest(CAST(table1.value AS ARRAY<STRUCT<_1 INT,_2 INT>>)) AS t0
+SELECT t0._1 AS _1, t0._2 AS _2 FROM table1, unnest(CAST(table1.value AS ARRAY<STRUCT<_1 INT64,_2 INT64>>)) AS t0
 ------ end
 
 ------ Test: explode Map and select Int
-SELECT t0 AS _1, table1._2 AS _2 FROM table1, unnest(CAST(table1._1 AS ARRAY<STRUCT<_1 INT,_2 INT>>)) AS t0
+SELECT t0 AS _1, table1._2 AS _2 FROM table1, unnest(CAST(table1._1 AS ARRAY<STRUCT<_1 INT64,_2 INT64>>)) AS t0
 ------ end
 
 ------ Test: explode Option
@@ -75,7 +75,7 @@ SELECT t0 AS value FROM table1, unnest(table1._2) AS t0 LIMIT 5
 ------ end
 
 ------ Test: limit after filter
-SELECT table1.value AS value FROM table1 WHERE (NOT (table1.value <= CAST(5 AS INT))) LIMIT 3
+SELECT table1.value AS value FROM table1 WHERE (NOT (table1.value <= CAST(5 AS INT64))) LIMIT 3
 ------ end
 
 ------ Test: limit after join
@@ -99,7 +99,7 @@ SELECT t1 AS value FROM (SELECT table1._1 AS _1, table1._2 AS _2 FROM table1 LIM
 ------ end
 
 ------ Test: limit before filter
-SELECT t0.value AS value FROM (SELECT table1.value AS value FROM table1 LIMIT 5) AS t0 WHERE (NOT (t0.value <= CAST(2 AS INT)))
+SELECT t0.value AS value FROM (SELECT table1.value AS value FROM table1 LIMIT 5) AS t0 WHERE (NOT (t0.value <= CAST(2 AS INT64)))
 ------ end
 
 ------ Test: limit before join
@@ -115,7 +115,7 @@ SELECT t0 AS _1, t1 AS _2 FROM table1, unnest(table1.d) AS t0, unnest(table1.d) 
 ------ end
 
 ------ Test: nested option upcast
-SELECT CASE WHEN (table1.value IS NOT NULL) THEN [table1.value.value] ELSE CAST([] AS ARRAY<INT>) END AS value FROM table1
+SELECT CASE WHEN (table1.value IS NOT NULL) THEN [table1.value.value] ELSE CAST([] AS ARRAY<INT64>) END AS value FROM table1
 ------ end
 
 ------ Test: select 2
@@ -147,11 +147,11 @@ SELECT t0 AS _1, t1 AS _2, t2 AS _3, t3 AS _4, t4 AS _5, t5 AS _6, t6 AS _7 FROM
 ------ end
 
 ------ Test: select Product
-SELECT table1.value AS _1, CAST(1 AS INT) AS _2 FROM table1
+SELECT table1.value AS _1, CAST(1 AS INT64) AS _2 FROM table1
 ------ end
 
 ------ Test: select complex
-SELECT CAST(CAST([] AS ARRAY<STRUCT<_1 INT,_2 INT>>) AS ARRAY<STRUCT<key INT,value INT>>) AS value FROM table1
+SELECT CAST(CAST([] AS ARRAY<STRUCT<_1 INT64,_2 INT64>>) AS ARRAY<STRUCT<key INT64,value INT64>>) AS value FROM table1
 ------ end
 
 ------ Test: select enum
@@ -171,7 +171,7 @@ SELECT table1._1._1 AS value FROM table1
 ------ end
 
 ------ Test: select primitive
-SELECT CAST(1 AS INT) AS value FROM table1
+SELECT CAST(1 AS INT64) AS value FROM table1
 ------ end
 
 ------ Test: union

--- a/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
@@ -191,11 +191,11 @@ SELECT table1.value AS value FROM table1 WHERE table1.value
 ------ end
 
 ------ Test: where after explode
-SELECT t0 AS _1, t1 AS _2, table1._1 AS _3 FROM table1, unnest(table1._2) AS t0, unnest(table1._2) AS t1 WHERE (t0 < CAST(0 AS INT))
+SELECT t0 AS _1, t1 AS _2, table1._1 AS _3 FROM table1, unnest(table1._2) AS t0, unnest(table1._2) AS t1 WHERE (t0 < CAST(0 AS INT64))
 ------ end
 
 ------ Test: where before explode
-SELECT t0 AS _1, t1 AS _2, table1._1 AS _3 FROM table1, unnest(table1._2) AS t0, unnest(table1._2) AS t1 WHERE (array_length(table1._2) < CAST(2 AS INT))
+SELECT t0 AS _1, t1 AS _2, table1._1 AS _3 FROM table1, unnest(table1._2) AS t0, unnest(table1._2) AS t1 WHERE (array_length(table1._2) < CAST(2 AS INT64))
 ------ end
 
 ------ Test: where literal

--- a/tyda-sql/src/test/resources/golden/DatasetJoinBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetJoinBigQueryGoldenSuite.golden
@@ -1,5 +1,5 @@
 ------ Test: fullJoinFlat
-SELECT CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END IS NULL) THEN struct(CAST(NULL AS TINYINT) AS key, CAST(NULL AS INT) AS b) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.key AS key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.b AS b) END.key AS key, CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END IS NULL) THEN struct(CAST(NULL AS TINYINT) AS key, CAST(NULL AS INT) AS b) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.key AS key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.b AS b) END.b AS b, CASE WHEN (CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END IS NULL) THEN struct(CAST(NULL AS TINYINT) AS m1Key, CAST(NULL AS INT) AS c) ELSE struct(CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END.m1Key AS m1Key, CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END.c AS c) END.m1Key AS m1Key, CASE WHEN (CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END IS NULL) THEN struct(CAST(NULL AS TINYINT) AS m1Key, CAST(NULL AS INT) AS c) ELSE struct(CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END.m1Key AS m1Key, CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END.c AS c) END.c AS c FROM (SELECT struct(table1.key AS key, table1.b AS b) AS value FROM table1) AS t0 FULL JOIN (SELECT struct(table2.m1Key AS m1Key, table2.c AS c) AS value FROM table2) AS t1 ON (t0.value.key = t1.value.m1Key)
+SELECT CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END IS NULL) THEN struct(CAST(NULL AS INT64) AS key, CAST(NULL AS INT64) AS b) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.key AS key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.b AS b) END.key AS key, CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END IS NULL) THEN struct(CAST(NULL AS INT64) AS key, CAST(NULL AS INT64) AS b) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.key AS key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.b AS b) END.b AS b, CASE WHEN (CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END IS NULL) THEN struct(CAST(NULL AS INT64) AS m1Key, CAST(NULL AS INT64) AS c) ELSE struct(CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END.m1Key AS m1Key, CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END.c AS c) END.m1Key AS m1Key, CASE WHEN (CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END IS NULL) THEN struct(CAST(NULL AS INT64) AS m1Key, CAST(NULL AS INT64) AS c) ELSE struct(CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END.m1Key AS m1Key, CASE WHEN (t1.value IS NOT NULL) THEN struct(t1.value.m1Key AS m1Key, t1.value.c AS c) END.c AS c) END.c AS c FROM (SELECT struct(table1.key AS key, table1.b AS b) AS value FROM table1) AS t0 FULL JOIN (SELECT struct(table2.m1Key AS m1Key, table2.c AS c) AS value FROM table2) AS t1 ON (t0.value.key = t1.value.m1Key)
 ------ end
 
 ------ Test: fullOuterJoin
@@ -7,7 +7,7 @@ SELECT t0.value AS _1, t1.value AS _2 FROM (SELECT table1.value AS value FROM ta
 ------ end
 
 ------ Test: fullOuterJoin nested Option
-SELECT t0.value AS _1, t1.value AS _2 FROM (SELECT struct(table1.value AS value) AS value FROM table1) AS t0 FULL JOIN (SELECT struct(table2.value AS value) AS value FROM table2) AS t1 ON ((coalesce(t0.value.value, CAST(0 AS TINYINT)) = coalesce(t1.value.value, CAST(0 AS TINYINT))) AND ((t0.value.value IS NULL) = (t1.value.value IS NULL)))
+SELECT t0.value AS _1, t1.value AS _2 FROM (SELECT struct(table1.value AS value) AS value FROM table1) AS t0 FULL JOIN (SELECT struct(table2.value AS value) AS value FROM table2) AS t1 ON ((coalesce(t0.value.value, CAST(0 AS INT64)) = coalesce(t1.value.value, CAST(0 AS INT64))) AND ((t0.value.value IS NULL) = (t1.value.value IS NULL)))
 ------ end
 
 ------ Test: fullOuterJoin nested Option one side
@@ -31,11 +31,11 @@ SELECT t0 AS _1, t1 AS _2 FROM table1 JOIN table2 ON (table1.a = table2.a), unne
 ------ end
 
 ------ Test: join complex condition
-SELECT struct(table1._1 AS _1, table1._2 AS _2) AS _1, struct(table2._1 AS _1, table2._2 AS _2) AS _2 FROM table1 JOIN table2 ON ((table1._1 = table2._1) AND ((table2._2 = table1._2) OR (table1._2 = CAST(0 AS TINYINT))))
+SELECT struct(table1._1 AS _1, table1._2 AS _2) AS _1, struct(table2._1 AS _1, table2._2 AS _2) AS _2 FROM table1 JOIN table2 ON ((table1._1 = table2._1) AND ((table2._2 = table1._2) OR (table1._2 = CAST(0 AS INT64))))
 ------ end
 
 ------ Test: join complex not equi condition
-SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON ((table1.value = table2.value) OR (table1.value = CAST(0 AS TINYINT)))
+SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON ((table1.value = table2.value) OR (table1.value = CAST(0 AS INT64)))
 ------ end
 
 ------ Test: join condition reverse order of exprs
@@ -43,15 +43,15 @@ SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON (table2
 ------ end
 
 ------ Test: join filter on both sides
-SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON (table1.value = table2.value) WHERE ((table1.value < CAST(0 AS TINYINT)) AND (table2.value < CAST(5 AS TINYINT)))
+SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON (table1.value = table2.value) WHERE ((table1.value < CAST(0 AS INT64)) AND (table2.value < CAST(5 AS INT64)))
 ------ end
 
 ------ Test: join filter on lhs
-SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON (table1.value = table2.value) WHERE (table1.value < CAST(0 AS TINYINT))
+SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON (table1.value = table2.value) WHERE (table1.value < CAST(0 AS INT64))
 ------ end
 
 ------ Test: join filter on rhs
-SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON (table1.value = table2.value) WHERE (table2.value < CAST(0 AS TINYINT))
+SELECT table1.value AS _1, table2.value AS _2 FROM table1 JOIN table2 ON (table1.value = table2.value) WHERE (table2.value < CAST(0 AS INT64))
 ------ end
 
 ------ Test: join multiple keys
@@ -71,7 +71,7 @@ SELECT table1._1 AS _1, table1._2 AS _2 FROM table1 WHERE (NOT EXISTS (SELECT ta
 ------ end
 
 ------ Test: leftJoinFlat
-SELECT table1.key AS key, table1.b AS b, CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END IS NULL) THEN struct(CAST(NULL AS TINYINT) AS m1Key, CAST(NULL AS INT) AS c) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END.m1Key AS m1Key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END.c AS c) END.m1Key AS m1Key, CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END IS NULL) THEN struct(CAST(NULL AS TINYINT) AS m1Key, CAST(NULL AS INT) AS c) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END.m1Key AS m1Key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END.c AS c) END.c AS c FROM table1 LEFT JOIN (SELECT struct(table2.m1Key AS m1Key, table2.c AS c) AS value FROM table2) AS t0 ON (table1.key = t0.value.m1Key)
+SELECT table1.key AS key, table1.b AS b, CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END IS NULL) THEN struct(CAST(NULL AS INT64) AS m1Key, CAST(NULL AS INT64) AS c) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END.m1Key AS m1Key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END.c AS c) END.m1Key AS m1Key, CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END IS NULL) THEN struct(CAST(NULL AS INT64) AS m1Key, CAST(NULL AS INT64) AS c) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END.m1Key AS m1Key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.m1Key AS m1Key, t0.value.c AS c) END.c AS c) END.c AS c FROM table1 LEFT JOIN (SELECT struct(table2.m1Key AS m1Key, table2.c AS c) AS value FROM table2) AS t0 ON (table1.key = t0.value.m1Key)
 ------ end
 
 ------ Test: leftOuterJoin
@@ -107,7 +107,7 @@ SELECT CASE WHEN (t0.value IS NOT NULL) THEN t0.value._2 END AS _1, table2.value
 ------ end
 
 ------ Test: rightJoinFlat
-SELECT CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END IS NULL) THEN struct(CAST(NULL AS TINYINT) AS key, CAST(NULL AS INT) AS b) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.key AS key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.b AS b) END.key AS key, CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END IS NULL) THEN struct(CAST(NULL AS TINYINT) AS key, CAST(NULL AS INT) AS b) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.key AS key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.b AS b) END.b AS b, table2.m1Key AS m1Key, table2.c AS c FROM table2 LEFT JOIN (SELECT struct(table1.key AS key, table1.b AS b) AS value FROM table1) AS t0 ON (t0.value.key = table2.m1Key)
+SELECT CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END IS NULL) THEN struct(CAST(NULL AS INT64) AS key, CAST(NULL AS INT64) AS b) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.key AS key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.b AS b) END.key AS key, CASE WHEN (CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END IS NULL) THEN struct(CAST(NULL AS INT64) AS key, CAST(NULL AS INT64) AS b) ELSE struct(CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.key AS key, CASE WHEN (t0.value IS NOT NULL) THEN struct(t0.value.key AS key, t0.value.b AS b) END.b AS b) END.b AS b, table2.m1Key AS m1Key, table2.c AS c FROM table2 LEFT JOIN (SELECT struct(table1.key AS key, table1.b AS b) AS value FROM table1) AS t0 ON (t0.value.key = table2.m1Key)
 ------ end
 
 ------ Test: rightOuterJoin

--- a/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
@@ -3,11 +3,11 @@ SELECT t0.value AS value FROM (SELECT DISTINCT table1.value AS value FROM table1
 ------ end
 
 ------ Test: filter then orderBy
-SELECT table1.value AS value FROM table1 WHERE (NOT (table1.value <= CAST(0 AS INT))) ORDER BY table1.value
+SELECT table1.value AS value FROM table1 WHERE (NOT (table1.value <= CAST(0 AS INT64))) ORDER BY table1.value
 ------ end
 
 ------ Test: groupBy aggregate then orderBy
-SELECT table1._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM table1 GROUP BY table1._1 ORDER BY table1._1
+SELECT table1._1 AS _1, count(CAST(1 AS INT64)) AS _2 FROM table1 GROUP BY table1._1 ORDER BY table1._1
 ------ end
 
 ------ Test: join then orderBy
@@ -119,11 +119,11 @@ SELECT DISTINCT t0.value AS value FROM (SELECT table1.value AS value FROM table1
 ------ end
 
 ------ Test: orderBy then filter
-SELECT t0.value AS value FROM (SELECT table1.value AS value FROM table1 ORDER BY table1.value) AS t0 WHERE (NOT (t0.value <= CAST(0 AS INT)))
+SELECT t0.value AS value FROM (SELECT table1.value AS value FROM table1 ORDER BY table1.value) AS t0 WHERE (NOT (t0.value <= CAST(0 AS INT64)))
 ------ end
 
 ------ Test: orderBy then groupBy aggregate
-SELECT t0._1 AS _1, count(CAST(1 AS INT)) AS _2 FROM (SELECT table1._1 AS _1, table1._2 AS _2 FROM table1 ORDER BY table1._1) AS t0 GROUP BY t0._1
+SELECT t0._1 AS _1, count(CAST(1 AS INT64)) AS _2 FROM (SELECT table1._1 AS _1, table1._2 AS _2 FROM table1 ORDER BY table1._1) AS t0 GROUP BY t0._1
 ------ end
 
 ------ Test: orderBy then join

--- a/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
@@ -1,17 +1,17 @@
 ------ Test: collect subquery
-SELECT table1.value AS value FROM table1 WHERE (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = table1.value) FROM unnest(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(table2.value) END AS value FROM table2), CAST([] AS ARRAY<TINYINT>))) AS c0))) AS c1)
+SELECT table1.value AS value FROM table1 WHERE (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = table1.value) FROM unnest(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(table2.value) END AS value FROM table2), CAST([] AS ARRAY<INT64>))) AS c0))) AS c1)
 ------ end
 
 ------ Test: count subquery
-SELECT table1.value AS value FROM table1 WHERE (NOT (table1.value <= coalesce((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM table2), CAST(0 AS BIGINT))))
+SELECT table1.value AS value FROM table1 WHERE (NOT (table1.value <= coalesce((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT64)) END AS value FROM table2), CAST(0 AS INT64))))
 ------ end
 
 ------ Test: exists subquery
-SELECT EXISTS (SELECT CAST(1 AS INT) AS value FROM table1 WHERE (NOT (table1.value <= CAST(0 AS BIGINT)))) AS value FROM table1
+SELECT EXISTS (SELECT CAST(1 AS INT64) AS value FROM table1 WHERE (NOT (table1.value <= CAST(0 AS INT64)))) AS value FROM table1
 ------ end
 
 ------ Test: exists subquery in where
-SELECT table1.value AS value FROM table1 WHERE EXISTS (SELECT CAST(1 AS INT) AS value FROM table1 WHERE (NOT (table1.value <= CAST(0 AS BIGINT))))
+SELECT table1.value AS value FROM table1 WHERE EXISTS (SELECT CAST(1 AS INT64) AS value FROM table1 WHERE (NOT (table1.value <= CAST(0 AS INT64))))
 ------ end
 
 ------ Test: explode subquery

--- a/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
@@ -15,7 +15,7 @@ SELECT table1.value AS value FROM table1 WHERE EXISTS (SELECT CAST(1 AS INT64) A
 ------ end
 
 ------ Test: explode subquery
-SELECT t0 AS _1, coalesce((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM table2, unnest(table2.value) AS t1), CAST(0 AS BIGINT)) AS _2 FROM table1, unnest(table1.value) AS t0
+SELECT t0 AS _1, coalesce((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT64)) END AS value FROM table2, unnest(table2.value) AS t1), CAST(0 AS INT64)) AS _2 FROM table1, unnest(table1.value) AS t0
 ------ end
 
 ------ Test: scalar subquery

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -939,19 +939,19 @@ SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: make map
-SELECT CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
+SELECT CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
 ------ end
 
 ------ Test: make map fails on duplicate keys
-SELECT CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
+SELECT CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
 ------ end
 
 ------ Test: make map fails on literal duplicate keys
-SELECT CASE WHEN (array_length([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
+SELECT CASE WHEN (array_length([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
 ------ end
 
 ------ Test: make map with a mix of literal and non-literal entries
-SELECT CASE WHEN (array_length([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
+SELECT CASE WHEN (array_length([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
 ------ end
 
 ------ Test: make map with multiple entries
@@ -1043,7 +1043,7 @@ SELECT (SELECT c0.value FROM unnest(CAST([struct(CAST(1 AS INT64) AS _1, 'x' AS 
 ------ end
 
 ------ Test: mapGet with literal key
-SELECT (SELECT c5.value FROM unnest(CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END) AS c5 WHERE (c5.key = t1._1)) AS value FROM t1
+SELECT (SELECT c2.value FROM unnest(CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END) AS c2 WHERE (c2.key = t1._1)) AS value FROM t1
 ------ end
 
 ------ Test: match-case all cases sealed trait
@@ -1399,7 +1399,7 @@ SELECT CAST([struct(CAST(1 AS INT64) AS _1, t1._1 AS _2), struct(CAST(2 AS INT64
 ------ end
 
 ------ Test: toMap with many
-SELECT CASE WHEN (array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT struct(c0 AS _1, c0 AS _2) FROM unnest(t1.value) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3))) = array_length(array((SELECT c14.value FROM (SELECT c11 AS value, min(c12) AS c13 FROM unnest(array((SELECT c10._1 FROM unnest(array((SELECT c9.value FROM (SELECT c6 AS value, min(c7) AS c8 FROM unnest(array((SELECT struct(c5 AS _1, c5 AS _2) FROM unnest(t1.value) AS c5))) AS c6 WITH OFFSET AS c7 GROUP BY c6) AS c9 ORDER BY c9.c8))) AS c10))) AS c11 WITH OFFSET AS c12 GROUP BY c11) AS c14 ORDER BY c14.c13)))) THEN CAST(array((SELECT c19.value FROM (SELECT c16 AS value, min(c17) AS c18 FROM unnest(array((SELECT struct(c15 AS _1, c15 AS _2) FROM unnest(t1.value) AS c15))) AS c16 WITH OFFSET AS c17 GROUP BY c16) AS c19 ORDER BY c19.c18)) AS ARRAY<STRUCT<key INT64,value INT64>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value INT64>>) END AS value FROM t1
+SELECT CASE WHEN (array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT struct(c0 AS _1, c0 AS _2) FROM unnest(t1.value) AS c0))) AS c1))) = array_length(array((SELECT DISTINCT c5 FROM unnest(array((SELECT c4._1 FROM unnest(array((SELECT DISTINCT c3 FROM unnest(array((SELECT struct(c2 AS _1, c2 AS _2) FROM unnest(t1.value) AS c2))) AS c3))) AS c4))) AS c5)))) THEN CAST(array((SELECT DISTINCT c7 FROM unnest(array((SELECT struct(c6 AS _1, c6 AS _2) FROM unnest(t1.value) AS c6))) AS c7)) AS ARRAY<STRUCT<key INT64,value INT64>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value INT64>>) END AS value FROM t1
 ------ end
 
 ------ Test: trim string

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -43,15 +43,15 @@ SELECT CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1
 ------ end
 
 ------ Test: Option.contains
-SELECT ((t1.value IS NOT NULL) AND (t1.value = CAST(0 AS TINYINT))) AS value FROM t1
+SELECT ((t1.value IS NOT NULL) AND (t1.value = CAST(0 AS INT64))) AS value FROM t1
 ------ end
 
 ------ Test: Option.exists
-SELECT CASE WHEN (t1.value IS NULL) THEN FALSE ELSE (t1.value = CAST(0 AS TINYINT)) END AS value FROM t1
+SELECT CASE WHEN (t1.value IS NULL) THEN FALSE ELSE (t1.value = CAST(0 AS INT64)) END AS value FROM t1
 ------ end
 
 ------ Test: Option.forall
-SELECT CASE WHEN (t1.value IS NULL) THEN TRUE ELSE (t1.value = CAST(0 AS TINYINT)) END AS value FROM t1
+SELECT CASE WHEN (t1.value IS NULL) THEN TRUE ELSE (t1.value = CAST(0 AS INT64)) END AS value FROM t1
 ------ end
 
 ------ Test: Option.getOrElse
@@ -63,7 +63,7 @@ SELECT (t1.value IS NULL) AS value FROM t1
 ------ end
 
 ------ Test: Option.map
-SELECT CASE WHEN (t1.value IS NOT NULL) THEN (t1.value = CAST(0 AS INT)) END AS value FROM t1
+SELECT CASE WHEN (t1.value IS NOT NULL) THEN (t1.value = CAST(0 AS INT64)) END AS value FROM t1
 ------ end
 
 ------ Test: Option.orElse
@@ -119,11 +119,11 @@ SELECT t1.a AS a, t1.b AS b, t1.c AS c FROM t1
 ------ end
 
 ------ Test: array element access fails on index too large
-SELECT [CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)][CAST(100 AS INT)] AS value FROM t1
+SELECT [CAST(1 AS INT64), CAST(2 AS INT64), CAST(3 AS INT64)][CAST(100 AS INT64)] AS value FROM t1
 ------ end
 
 ------ Test: array element access fails on negative index
-SELECT [CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)][CAST(-1 AS INT)] AS value FROM t1
+SELECT [CAST(1 AS INT64), CAST(2 AS INT64), CAST(3 AS INT64)][CAST(-1 AS INT64)] AS value FROM t1
 ------ end
 
 ------ Test: array element access with Expr index
@@ -131,31 +131,31 @@ SELECT t1._1[t1._2] AS value FROM t1
 ------ end
 
 ------ Test: array element access with literal index
-SELECT t1.value[CAST(0 AS INT)] AS value FROM t1
+SELECT t1.value[CAST(0 AS INT64)] AS value FROM t1
 ------ end
 
 ------ Test: array element access with literal index and array element
-SELECT t1.value[CAST(0 AS INT)].value AS value FROM t1
+SELECT t1.value[CAST(0 AS INT64)].value AS value FROM t1
 ------ end
 
 ------ Test: asBase complex
-SELECT 'c' AS discriminant, t1._1 AS c, CAST(NULL AS STRUCT<i INT>) AS d FROM t1
+SELECT 'c' AS discriminant, t1._1 AS c, CAST(NULL AS STRUCT<i INT64>) AS d FROM t1
 ------ end
 
 ------ Test: asBase from enum case class C to enum
-SELECT 'c' AS discriminant, struct(t1.i AS i) AS c, CAST(NULL AS STRUCT<i INT>) AS d FROM t1
+SELECT 'c' AS discriminant, struct(t1.i AS i) AS c, CAST(NULL AS STRUCT<i INT64>) AS d FROM t1
 ------ end
 
 ------ Test: asBase from enum case class D to enum
-SELECT 'd' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, struct(t1.i AS i) AS d FROM t1
+SELECT 'd' AS discriminant, CAST(NULL AS STRUCT<i INT64>) AS c, struct(t1.i AS i) AS d FROM t1
 ------ end
 
 ------ Test: asBase from enum case object A to enum
-SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d FROM t1
+SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT64>) AS c, CAST(NULL AS STRUCT<i INT64>) AS d FROM t1
 ------ end
 
 ------ Test: asBase from enum case object B to enum
-SELECT 'b' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d FROM t1
+SELECT 'b' AS discriminant, CAST(NULL AS STRUCT<i INT64>) AS c, CAST(NULL AS STRUCT<i INT64>) AS d FROM t1
 ------ end
 
 ------ Test: asBase from string complex
@@ -171,7 +171,7 @@ SELECT 'a' AS value FROM t1
 ------ end
 
 ------ Test: asBase inverts asCase for enum product case
-SELECT coalesce(struct(t1.i AS i), CAST(error('Failed to invert asBase') AS STRUCT<i INT>)).i AS i FROM t1
+SELECT coalesce(struct(t1.i AS i), CAST(error('Failed to invert asBase') AS STRUCT<i INT64>)).i AS i FROM t1
 ------ end
 
 ------ Test: asBase inverts asCase for enum singleton case
@@ -179,7 +179,7 @@ SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: asBase inverts asCase for sealed trait product case
-SELECT coalesce(struct(t1.i AS i), CAST(error('Failed to invert asBase') AS STRUCT<i INT>)).i AS i FROM t1
+SELECT coalesce(struct(t1.i AS i), CAST(error('Failed to invert asBase') AS STRUCT<i INT64>)).i AS i FROM t1
 ------ end
 
 ------ Test: asBase inverts asCase for sealed trait singleton case
@@ -211,11 +211,11 @@ SELECT CASE WHEN (t1.value = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is
 ------ end
 
 ------ Test: asCase inverts asBase for enum product case
-SELECT CASE WHEN (t1.c IS NOT NULL) THEN struct('c' AS discriminant, t1.c AS c, CAST(NULL AS STRUCT<i INT>) AS d) END AS value FROM t1
+SELECT CASE WHEN (t1.c IS NOT NULL) THEN struct('c' AS discriminant, t1.c AS c, CAST(NULL AS STRUCT<i INT64>) AS d) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for enum singleton case
-SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN struct('a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d) END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN struct('a' AS discriminant, CAST(NULL AS STRUCT<i INT64>) AS c, CAST(NULL AS STRUCT<i INT64>) AS d) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for sealed trait product case
@@ -223,7 +223,7 @@ SELECT CASE WHEN (t1.b IS NOT NULL) THEN struct('b' AS discriminant, t1.b AS b) 
 ------ end
 
 ------ Test: asCase inverts asBase for sealed trait singleton case
-SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN struct('a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS b) END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN struct('a' AS discriminant, CAST(NULL AS STRUCT<i INT64>) AS b) END AS value FROM t1
 ------ end
 
 ------ Test: asCase inverts asBase for string enum singleton case
@@ -255,11 +255,11 @@ SELECT byte_length(t1.value) AS value FROM t1
 ------ end
 
 ------ Test: cases.when first matching branch is used
-SELECT CASE WHEN (NOT (t1.value <= CAST(0 AS INT))) THEN CAST(1 AS INT) WHEN (NOT (t1.value <= CAST(-5 AS INT))) THEN CAST(2 AS INT) ELSE CAST(3 AS INT) END AS value FROM t1
+SELECT CASE WHEN (NOT (t1.value <= CAST(0 AS INT64))) THEN CAST(1 AS INT64) WHEN (NOT (t1.value <= CAST(-5 AS INT64))) THEN CAST(2 AS INT64) ELSE CAST(3 AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: cases.when with Option result and otherwise
-SELECT CASE WHEN (NOT (t1.value <= CAST(0 AS INT))) THEN t1.value END AS value FROM t1
+SELECT CASE WHEN (NOT (t1.value <= CAST(0 AS INT64))) THEN t1.value END AS value FROM t1
 ------ end
 
 ------ Test: cases.when with literal then-expressions
@@ -267,11 +267,11 @@ SELECT CASE WHEN t1._1 THEN t1._2 ELSE t1._3 END AS value FROM t1
 ------ end
 
 ------ Test: cases.when with many branches and literal otherwise
-SELECT CASE WHEN (t1.value < CAST(0 AS INT)) THEN 'negative' WHEN (t1.value = CAST(0 AS INT)) THEN 'zero' ELSE 'positive' END AS value FROM t1
+SELECT CASE WHEN (t1.value < CAST(0 AS INT64)) THEN 'negative' WHEN (t1.value = CAST(0 AS INT64)) THEN 'zero' ELSE 'positive' END AS value FROM t1
 ------ end
 
 ------ Test: cases.when with multiple branches and otherwise
-SELECT CASE WHEN (NOT (t1._1 <= CAST(0 AS INT))) THEN t1._1 WHEN (NOT (t1._2 <= CAST(0 AS INT))) THEN t1._2 ELSE CAST(0 AS INT) END AS value FROM t1
+SELECT CASE WHEN (NOT (t1._1 <= CAST(0 AS INT64))) THEN t1._1 WHEN (NOT (t1._2 <= CAST(0 AS INT64))) THEN t1._2 ELSE CAST(0 AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: cases.when with single branch and otherwise
@@ -323,27 +323,27 @@ SELECT CAST(t1.value AS FLOAT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Byte to scala.Int
-SELECT CAST(t1.value AS INT) AS value FROM t1
+SELECT CAST(t1.value AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Byte to scala.Long
-SELECT CAST(t1.value AS BIGINT) AS value FROM t1
+SELECT CAST(t1.value AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Byte to scala.Short
-SELECT CAST(t1.value AS SMALLINT) AS value FROM t1
+SELECT CAST(t1.value AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Double to com.choreograph.tyda.Decimal$package.Decimal[3, 1] and back
-SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(1 AS INT)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(1 AS INT)) AS FLOAT64) END AS value FROM t1
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(1 AS INT64)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(1 AS INT64)) AS FLOAT64) END AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Double to com.choreograph.tyda.Decimal$package.Decimal[38, 18] and back
-SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(18 AS INT)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(18 AS INT)) AS FLOAT64) END AS value FROM t1
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(18 AS INT64)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(18 AS INT64)) AS FLOAT64) END AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Double to com.choreograph.tyda.Decimal$package.Decimal[38, 9] and back
-SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT)) AS FLOAT64) END AS value FROM t1
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT64)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT64)) AS FLOAT64) END AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Double to scala.Float
@@ -351,15 +351,15 @@ SELECT CAST(t1.value AS FLOAT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Float to com.choreograph.tyda.Decimal$package.Decimal[2, 0] and back
-SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) AS FLOAT64) END AS value FROM t1
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT64)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT64)) AS FLOAT64) END AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Float to com.choreograph.tyda.Decimal$package.Decimal[38, 18] and back
-SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(18 AS INT)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(18 AS INT)) AS FLOAT64) END AS value FROM t1
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(18 AS INT64)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(18 AS INT64)) AS FLOAT64) END AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Float to com.choreograph.tyda.Decimal$package.Decimal[38, 9] and back
-SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT)) AS FLOAT64) END AS value FROM t1
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT64)) IS NOT NULL) THEN CAST(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT64)) AS FLOAT64) END AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Float to scala.Double
@@ -383,7 +383,7 @@ SELECT CAST(t1.value AS FLOAT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Int to scala.Long
-SELECT CAST(t1.value AS BIGINT) AS value FROM t1
+SELECT CAST(t1.value AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Long to com.choreograph.tyda.Decimal$package.Decimal[22, 2]
@@ -419,11 +419,11 @@ SELECT CAST(t1.value AS FLOAT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Short to scala.Int
-SELECT CAST(t1.value AS INT) AS value FROM t1
+SELECT CAST(t1.value AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.Short to scala.Long
-SELECT CAST(t1.value AS BIGINT) AS value FROM t1
+SELECT CAST(t1.value AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.collection.immutable.Seq[scala.Byte] to scala.collection.immutable.Seq[scala.Double]
@@ -435,11 +435,11 @@ SELECT array((SELECT CAST(c0 AS FLOAT64) FROM unnest(t1.value) AS c0)) AS value 
 ------ end
 
 ------ Test: cast scala.collection.immutable.Seq[scala.Int] to scala.collection.immutable.Seq[scala.Long]
-SELECT array((SELECT CAST(c0 AS BIGINT) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT CAST(c0 AS INT64) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: cast scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Int]] to scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Long]]
-SELECT array((SELECT struct(CAST(c0.value AS ARRAY<BIGINT>) AS value) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT struct(CAST(c0.value AS ARRAY<INT64>) AS value) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: coalesce
@@ -475,27 +475,27 @@ SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: create literal (a,1) scala.NamedTuple.NamedTuple[scala.Tuple2["a", "b"], scala.Tuple2[scala.Predef.String, scala.Int]]
-SELECT 'a' AS a, CAST(1 AS INT) AS b FROM t1
+SELECT 'a' AS a, CAST(1 AS INT64) AS b FROM t1
 ------ end
 
 ------ Test: create literal (a,2) scala.NamedTuple.NamedTuple[scala.Tuple2["c", "d"], scala.Tuple2[scala.Predef.String, scala.Long]]
-SELECT 'a' AS c, CAST(2 AS BIGINT) AS d FROM t1
+SELECT 'a' AS c, CAST(2 AS INT64) AS d FROM t1
 ------ end
 
 ------ Test: create literal 0 scala.Byte
-SELECT CAST(0 AS TINYINT) AS value FROM t1
+SELECT CAST(0 AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: create literal 0 scala.Int
-SELECT CAST(0 AS INT) AS value FROM t1
+SELECT CAST(0 AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: create literal 0 scala.Long
-SELECT CAST(0 AS BIGINT) AS value FROM t1
+SELECT CAST(0 AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: create literal 0 scala.Short
-SELECT CAST(0 AS SMALLINT) AS value FROM t1
+SELECT CAST(0 AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: create literal 0.0 scala.Double
@@ -507,19 +507,19 @@ SELECT CAST(0.0 AS FLOAT64) AS value FROM t1
 ------ end
 
 ------ Test: create literal 1 com.choreograph.tyda.Date$package.Date
-SELECT date_from_unix_date(CAST(1 AS INT)) AS value FROM t1
+SELECT date_from_unix_date(CAST(1 AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: create literal 1 com.choreograph.tyda.Duration$package.Duration
-SELECT (CAST(1 AS BIGINT) - CAST(0 AS BIGINT)) AS value FROM t1
+SELECT (CAST(1 AS INT64) - CAST(0 AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: create literal 1 com.choreograph.tyda.Timestamp$package.Timestamp
-SELECT timestamp_micros(CAST(1 AS BIGINT)) AS value FROM t1
+SELECT timestamp_micros(CAST(1 AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: create literal 148600399274030924 com.choreograph.tyda.Timestamp$package.Timestamp
-SELECT timestamp_micros(CAST(148600399274030924 AS BIGINT)) AS value FROM t1
+SELECT timestamp_micros(CAST(148600399274030924 AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: create literal 20.00 com.choreograph.tyda.Decimal$package.Decimal[13, 2]
@@ -527,7 +527,7 @@ SELECT CAST('20.00' AS DECIMAL) AS value FROM t1
 ------ end
 
 ------ Test: create literal A com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
-SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d FROM t1
+SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT64>) AS c, CAST(NULL AS STRUCT<i INT64>) AS d FROM t1
 ------ end
 
 ------ Test: create literal ArraySeq(0, -54, -2, -70, -66) com.choreograph.tyda.Binary$package.Binary
@@ -535,23 +535,23 @@ SELECT B'\x00\xca\xfe\xba\xbe' AS value FROM t1
 ------ end
 
 ------ Test: create literal List() scala.collection.immutable.List[scala.Int]
-SELECT CAST([] AS ARRAY<INT>) AS value FROM t1
+SELECT CAST([] AS ARRAY<INT64>) AS value FROM t1
 ------ end
 
 ------ Test: create literal List(1, 2) scala.collection.immutable.Seq[scala.Int]
-SELECT [CAST(1 AS INT), CAST(2 AS INT)] AS value FROM t1
+SELECT [CAST(1 AS INT64), CAST(2 AS INT64)] AS value FROM t1
 ------ end
 
 ------ Test: create literal List(List(), List(1, 2)) scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Int]]
-SELECT [struct(CAST([] AS ARRAY<INT>) AS value), struct([CAST(1 AS INT), CAST(2 AS INT)] AS value)] AS value FROM t1
+SELECT [struct(CAST([] AS ARRAY<INT64>) AS value), struct([CAST(1 AS INT64), CAST(2 AS INT64)] AS value)] AS value FROM t1
 ------ end
 
 ------ Test: create literal List(Some(1), None, Some(2)) scala.collection.immutable.Seq[scala.Option[scala.Int]]
-SELECT [CAST(1 AS INT), CAST(NULL AS INT), CAST(2 AS INT)] AS value FROM t1
+SELECT [CAST(1 AS INT64), CAST(NULL AS INT64), CAST(2 AS INT64)] AS value FROM t1
 ------ end
 
 ------ Test: create literal List(Some(List()), Some(List(1, 2)), None) scala.collection.immutable.Seq[scala.Option[scala.collection.immutable.Seq[scala.Int]]]
-SELECT [struct(CAST([] AS ARRAY<INT>) AS value), struct([CAST(1 AS INT), CAST(2 AS INT)] AS value), struct(CAST(NULL AS ARRAY<INT>) AS value)] AS value FROM t1
+SELECT [struct(CAST([] AS ARRAY<INT64>) AS value), struct([CAST(1 AS INT64), CAST(2 AS INT64)] AS value), struct(CAST(NULL AS ARRAY<INT64>) AS value)] AS value FROM t1
 ------ end
 
 ------ Test: create literal List(a, b) scala.collection.immutable.List[scala.Predef.String]
@@ -563,19 +563,19 @@ SELECT CAST(CAST([] AS ARRAY<STRUCT<_1 STRING,_2 STRING>>) AS ARRAY<STRUCT<key S
 ------ end
 
 ------ Test: create literal Map(a -> 1, b -> 2) scala.collection.immutable.Map[scala.Predef.String, scala.Int]
-SELECT CAST([struct('a' AS _1, CAST(1 AS INT) AS _2), struct('b' AS _1, CAST(2 AS INT) AS _2)] AS ARRAY<STRUCT<key STRING,value INT>>) AS value FROM t1
+SELECT CAST([struct('a' AS _1, CAST(1 AS INT64) AS _2), struct('b' AS _1, CAST(2 AS INT64) AS _2)] AS ARRAY<STRUCT<key STRING,value INT64>>) AS value FROM t1
 ------ end
 
 ------ Test: create literal Node(1,List(Node(2,List(Leaf(3), Leaf(4))), Node(5,List(Leaf(6))))) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Node[scala.Int, 1]
-SELECT CAST(1 AS INT) AS value, [struct(CAST(2 AS INT) AS value, [struct(CAST(3 AS INT) AS value), struct(CAST(4 AS INT) AS value)] AS children), struct(CAST(5 AS INT) AS value, [struct(CAST(6 AS INT) AS value)] AS children)] AS children FROM t1
+SELECT CAST(1 AS INT64) AS value, [struct(CAST(2 AS INT64) AS value, [struct(CAST(3 AS INT64) AS value), struct(CAST(4 AS INT64) AS value)] AS children), struct(CAST(5 AS INT64) AS value, [struct(CAST(6 AS INT64) AS value)] AS children)] AS children FROM t1
 ------ end
 
 ------ Test: create literal None scala.Option[com.choreograph.tyda.Duration$package.Duration]
-SELECT CAST(NULL AS BIGINT) AS value FROM t1
+SELECT CAST(NULL AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: create literal None scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
-SELECT CAST(NULL AS STRUCT<a INT,b STRING,c BOOLEAN>) AS value FROM t1
+SELECT CAST(NULL AS STRUCT<a INT64,b STRING,c BOOLEAN>) AS value FROM t1
 ------ end
 
 ------ Test: create literal None scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum.A]
@@ -583,67 +583,67 @@ SELECT CAST(NULL AS STRUCT<`the cake is a lie 🎂` BOOL>) AS value FROM t1
 ------ end
 
 ------ Test: create literal None scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum]
-SELECT CAST(NULL AS STRUCT<discriminant STRING,c STRUCT<i INT>,d STRUCT<i INT>>) AS value FROM t1
+SELECT CAST(NULL AS STRUCT<discriminant STRING,c STRUCT<i INT64>,d STRUCT<i INT64>>) AS value FROM t1
 ------ end
 
 ------ Test: create literal None scala.Option[scala.Int]
-SELECT CAST(NULL AS INT) AS value FROM t1
+SELECT CAST(NULL AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: create literal None scala.Option[scala.Option[scala.Int]]
-SELECT CAST(NULL AS STRUCT<value INT>) AS value FROM t1
+SELECT CAST(NULL AS STRUCT<value INT64>) AS value FROM t1
 ------ end
 
 ------ Test: create literal None scala.Option[scala.Option[scala.Option[scala.Int]]]
-SELECT CAST(NULL AS STRUCT<value STRUCT<value INT>>) AS value FROM t1
+SELECT CAST(NULL AS STRUCT<value STRUCT<value INT64>>) AS value FROM t1
 ------ end
 
 ------ Test: create literal None scala.Option[scala.collection.immutable.Map[scala.Predef.String, scala.Int]]
-SELECT CAST(NULL AS ARRAY<STRUCT<key STRING,value INT>>) AS value FROM t1
+SELECT CAST(NULL AS ARRAY<STRUCT<key STRING,value INT64>>) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(0) scala.Option[scala.Int]
-SELECT CAST(0 AS INT) AS value FROM t1
+SELECT CAST(0 AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(C(1)) scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum]
-SELECT struct('c' AS discriminant, struct(CAST(1 AS INT) AS i) AS c, CAST(NULL AS STRUCT<i INT>) AS d) AS value FROM t1
+SELECT struct('c' AS discriminant, struct(CAST(1 AS INT64) AS i) AS c, CAST(NULL AS STRUCT<i INT64>) AS d) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(List(Some(List(1, 2)), None, Some(List()))) scala.Option[scala.collection.immutable.Seq[scala.Option[scala.collection.immutable.Seq[scala.Int]]]]
-SELECT [struct([CAST(1 AS INT), CAST(2 AS INT)] AS value), struct(CAST(NULL AS ARRAY<INT>) AS value), struct(CAST([] AS ARRAY<INT>) AS value)] AS value FROM t1
+SELECT [struct([CAST(1 AS INT64), CAST(2 AS INT64)] AS value), struct(CAST(NULL AS ARRAY<INT64>) AS value), struct(CAST([] AS ARRAY<INT64>) AS value)] AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(None) scala.Option[scala.Option[scala.Int]]
-SELECT struct(CAST(NULL AS INT) AS value) AS value FROM t1
+SELECT struct(CAST(NULL AS INT64) AS value) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(None) scala.Option[scala.Option[scala.Option[scala.Int]]]
-SELECT struct(CAST(NULL AS STRUCT<value INT>) AS value) AS value FROM t1
+SELECT struct(CAST(NULL AS STRUCT<value INT64>) AS value) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(Some(0)) scala.Option[scala.Option[scala.Int]]
-SELECT struct(CAST(0 AS INT) AS value) AS value FROM t1
+SELECT struct(CAST(0 AS INT64) AS value) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(Some(List(1, 2))) scala.Option[scala.Option[scala.collection.immutable.Seq[scala.Int]]]
-SELECT struct([CAST(1 AS INT), CAST(2 AS INT)] AS value) AS value FROM t1
+SELECT struct([CAST(1 AS INT64), CAST(2 AS INT64)] AS value) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(Some(None)) scala.Option[scala.Option[scala.Option[scala.Int]]]
-SELECT struct(struct(CAST(NULL AS INT) AS value) AS value) AS value FROM t1
+SELECT struct(struct(CAST(NULL AS INT64) AS value) AS value) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(Some(Some(0))) scala.Option[scala.Option[scala.Option[scala.Int]]]
-SELECT struct(struct(CAST(0 AS INT) AS value) AS value) AS value FROM t1
+SELECT struct(struct(CAST(0 AS INT64) AS value) AS value) AS value FROM t1
 ------ end
 
 ------ Test: create literal Some(Struct(1,a,false)) scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
-SELECT struct(CAST(1 AS INT) AS a, 'a' AS b, FALSE AS c) AS value FROM t1
+SELECT struct(CAST(1 AS INT64) AS a, 'a' AS b, FALSE AS c) AS value FROM t1
 ------ end
 
 ------ Test: create literal Struct(1,a,false) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
-SELECT CAST(1 AS INT) AS a, 'a' AS b, FALSE AS c FROM t1
+SELECT CAST(1 AS INT64) AS a, 'a' AS b, FALSE AS c FROM t1
 ------ end
 
 ------ Test: create literal WithEmptyTuple(()) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithEmptyTuple
@@ -659,7 +659,7 @@ SELECT FALSE AS value FROM t1
 ------ end
 
 ------ Test: distinct on Seq[Int]
-SELECT array((SELECT DISTINCT c0 FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT c3.value FROM (SELECT c0 AS value, min(c1) AS c2 FROM unnest(t1.value) AS c0 WITH OFFSET AS c1 GROUP BY c0) AS c3 ORDER BY c3.c2)) AS value FROM t1
 ------ end
 
 ------ Test: endsWith string
@@ -671,15 +671,15 @@ SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
 ------ end
 
 ------ Test: equals on Seq
-SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT64), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT64)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
 ------ end
 
 ------ Test: equals on Seq with product
-SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT64), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT64)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
 ------ end
 
 ------ Test: equals on Seq with product optional field
-SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (TRUE AND (c1._1.a IS NOT DISTINCT FROM c1._2.a)) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (TRUE AND (c1._1.a IS NOT DISTINCT FROM c1._2.a)) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT64), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT64)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
 ------ end
 
 ------ Test: equals on nested Option
@@ -699,23 +699,23 @@ SELECT (t1.value IS NULL) AS value FROM t1
 ------ end
 
 ------ Test: expect does not raise error when Some
-SELECT coalesce(t1.value, CAST(error('should not happen') AS INT)) AS value FROM t1
+SELECT coalesce(t1.value, CAST(error('should not happen') AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: extra stuff after json object is ignored
-SELECT CASE WHEN ((json_query(t1._2, '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(t1._2, '$._1') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(t1._2, '$._1') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(t1._2, '$._1') AS INT) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(t1._2, '$._1') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(t1._2, '$._1') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(t1._2, '$._1') AS INT) END AS _1) END AS value FROM t1
+SELECT CASE WHEN ((json_query(t1._2, '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(t1._2, '$._1') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(t1._2, '$._1') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(t1._2, '$._1') AS INT64) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(t1._2, '$._1') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(t1._2, '$._1') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(t1._2, '$._1') AS INT64) END AS _1) END AS value FROM t1
 ------ end
 
 ------ Test: fail on division by zero
-SELECT CAST(div(t1.value, CAST(0 AS INT)) AS INT) AS value FROM t1
+SELECT CAST(div(t1.value, CAST(0 AS INT64)) AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: fail on int overflow
-SELECT (t1.value + CAST(2147483647 AS INT)) AS value FROM t1
+SELECT (t1.value + CAST(2147483647 AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: flatMap Option
-SELECT CASE WHEN (t1.value IS NULL) THEN CAST(NULL AS INT) ELSE t1.value.value END AS value FROM t1
+SELECT CASE WHEN (t1.value IS NULL) THEN CAST(NULL AS INT64) ELSE t1.value.value END AS value FROM t1
 ------ end
 
 ------ Test: fromBase64
@@ -839,7 +839,7 @@ SELECT CASE WHEN (CASE WHEN ((json_query(t1._2, '$') != 'null') AND (SAFE_CAST(j
 ------ end
 
 ------ Test: json duration as long of microseconds
-SELECT CASE WHEN (CASE WHEN ((json_query(t1._2, '$') != 'null') AND (SAFE_CAST(json_value(t1._2, '$._1') AS BIGINT) IS NOT NULL)) THEN struct(SAFE_CAST(json_value(t1._2, '$._1') AS BIGINT) AS _1) END IS NOT NULL) THEN CASE WHEN ((json_query(t1._2, '$') != 'null') AND (SAFE_CAST(json_value(t1._2, '$._1') AS BIGINT) IS NOT NULL)) THEN struct(SAFE_CAST(json_value(t1._2, '$._1') AS BIGINT) AS _1) END._1 END AS value FROM t1
+SELECT CASE WHEN (CASE WHEN ((json_query(t1._2, '$') != 'null') AND (SAFE_CAST(json_value(t1._2, '$._1') AS INT64) IS NOT NULL)) THEN struct(SAFE_CAST(json_value(t1._2, '$._1') AS INT64) AS _1) END IS NOT NULL) THEN CASE WHEN ((json_query(t1._2, '$') != 'null') AND (SAFE_CAST(json_value(t1._2, '$._1') AS INT64) IS NOT NULL)) THEN struct(SAFE_CAST(json_value(t1._2, '$._1') AS INT64) AS _1) END._1 END AS value FROM t1
 ------ end
 
 ------ Test: lt for com.choreograph.tyda.Date$package.Date
@@ -923,7 +923,7 @@ SELECT (t1._1 <= t1._2) AS value FROM t1
 ------ end
 
 ------ Test: make empty map
-SELECT CAST(CAST([] AS ARRAY<STRUCT<_1 INT,_2 STRING>>) AS ARRAY<STRUCT<key INT,value STRING>>) AS value FROM t1
+SELECT CAST(CAST([] AS ARRAY<STRUCT<_1 INT64,_2 STRING>>) AS ARRAY<STRUCT<key INT64,value STRING>>) AS value FROM t1
 ------ end
 
 ------ Test: make empty namedTuple
@@ -931,7 +931,7 @@ SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: make empty seq
-SELECT CAST([] AS ARRAY<INT>) AS value FROM t1
+SELECT CAST([] AS ARRAY<INT64>) AS value FROM t1
 ------ end
 
 ------ Test: make empty tuple
@@ -939,23 +939,23 @@ SELECT CAST(NULL AS BOOL) FROM t1
 ------ end
 
 ------ Test: make map
-SELECT CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2)] AS ARRAY<STRUCT<key INT,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT,value STRING>>) END AS value FROM t1
+SELECT CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
 ------ end
 
 ------ Test: make map fails on duplicate keys
-SELECT CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)] AS ARRAY<STRUCT<key INT,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT,value STRING>>) END AS value FROM t1
+SELECT CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2), struct(t1._1 AS _1, 'duplicate' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
 ------ end
 
 ------ Test: make map fails on literal duplicate keys
-SELECT CASE WHEN (array_length([struct(CAST(1 AS INT) AS _1, t1.value AS _2), struct(CAST(1 AS INT) AS _1, 'duplicate' AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(CAST(1 AS INT) AS _1, t1.value AS _2), struct(CAST(1 AS INT) AS _1, 'duplicate' AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(CAST(1 AS INT) AS _1, t1.value AS _2), struct(CAST(1 AS INT) AS _1, 'duplicate' AS _2)] AS ARRAY<STRUCT<key INT,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT,value STRING>>) END AS value FROM t1
+SELECT CASE WHEN (array_length([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(CAST(1 AS INT64) AS _1, t1.value AS _2), struct(CAST(1 AS INT64) AS _1, 'duplicate' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
 ------ end
 
 ------ Test: make map with a mix of literal and non-literal entries
-SELECT CASE WHEN (array_length([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT) AS _1, 'b' AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT) AS _1, 'b' AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT) AS _1, 'b' AS _2)] AS ARRAY<STRUCT<key INT,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT,value STRING>>) END AS value FROM t1
+SELECT CASE WHEN (array_length([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(t1._1 AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END AS value FROM t1
 ------ end
 
 ------ Test: make map with multiple entries
-SELECT CAST([struct(CAST(1 AS INT) AS _1, 'a' AS _2), struct(CAST(2 AS INT) AS _1, 'b' AS _2)] AS ARRAY<STRUCT<key INT,value STRING>>) AS value FROM t1
+SELECT CAST([struct(CAST(1 AS INT64) AS _1, 'a' AS _2), struct(CAST(2 AS INT64) AS _1, 'b' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) AS value FROM t1
 ------ end
 
 ------ Test: make namedTuple 2
@@ -979,7 +979,7 @@ SELECT t1.value AS int, 'literal' AS string FROM t1
 ------ end
 
 ------ Test: make range
-SELECT generate_array(t1._1, (t1._2 - CAST(1 AS INT))) AS value FROM t1
+SELECT generate_array(t1._1, (t1._2 - CAST(1 AS INT64))) AS value FROM t1
 ------ end
 
 ------ Test: make seq
@@ -1003,15 +1003,15 @@ SELECT t1.value AS _1, 'literal' AS _2 FROM t1
 ------ end
 
 ------ Test: malformed json array results in None
-SELECT CASE WHEN ((json_query_array(t1.value, '$') IS NOT NULL) AND (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT (CASE WHEN ((SAFE_CAST(json_value(c0, '$') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(c0, '$') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(c0, '$') AS INT) END IS NOT NULL) FROM unnest(json_query_array(t1.value, '$')) AS c0))) AS c1)) THEN array((SELECT CASE WHEN ((SAFE_CAST(json_value(c0, '$') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(c0, '$') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(c0, '$') AS INT) END FROM unnest(json_query_array(t1.value, '$')) AS c0)) END AS value FROM t1
+SELECT CASE WHEN ((json_query_array(t1.value, '$') IS NOT NULL) AND (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT (CASE WHEN ((SAFE_CAST(json_value(c0, '$') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(c0, '$') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(c0, '$') AS INT64) END IS NOT NULL) FROM unnest(json_query_array(t1.value, '$')) AS c0))) AS c1)) THEN array((SELECT CASE WHEN ((SAFE_CAST(json_value(c0, '$') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(c0, '$') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(c0, '$') AS INT64) END FROM unnest(json_query_array(t1.value, '$')) AS c0)) END AS value FROM t1
 ------ end
 
 ------ Test: malformed json object results in None
-SELECT CASE WHEN ((json_query(t1.value, '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(t1.value, '$._1') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(t1.value, '$._1') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(t1.value, '$._1') AS INT) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(t1.value, '$._1') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(t1.value, '$._1') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(t1.value, '$._1') AS INT) END AS _1) END AS value FROM t1
+SELECT CASE WHEN ((json_query(t1.value, '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(t1.value, '$._1') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(t1.value, '$._1') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(t1.value, '$._1') AS INT64) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(t1.value, '$._1') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(t1.value, '$._1') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(t1.value, '$._1') AS INT64) END AS _1) END AS value FROM t1
 ------ end
 
 ------ Test: map Option
-SELECT CASE WHEN (t1.value IS NOT NULL) THEN (t1.value = CAST(0 AS INT)) END AS value FROM t1
+SELECT CASE WHEN (t1.value IS NOT NULL) THEN (t1.value = CAST(0 AS INT64)) END AS value FROM t1
 ------ end
 
 ------ Test: map Option using nested outer
@@ -1031,7 +1031,7 @@ SELECT array((SELECT struct(c0.value AS value) FROM unnest(t1.value) AS c0)) AS 
 ------ end
 
 ------ Test: mapGet Option value
-SELECT (SELECT struct(c0.value AS value) FROM unnest(CAST([struct(CAST(1 AS INT) AS _1, t1.value AS _2)] AS ARRAY<STRUCT<key INT,value INT>>)) AS c0 WHERE (c0.key = CAST(1 AS INT))) AS _1, (SELECT struct(c1.value AS value) FROM unnest(CAST([struct(CAST(1 AS INT) AS _1, t1.value AS _2)] AS ARRAY<STRUCT<key INT,value INT>>)) AS c1 WHERE (c1.key = CAST(2 AS INT))) AS _2 FROM t1
+SELECT (SELECT struct(c0.value AS value) FROM unnest(CAST([struct(CAST(1 AS INT64) AS _1, t1.value AS _2)] AS ARRAY<STRUCT<key INT64,value INT64>>)) AS c0 WHERE (c0.key = CAST(1 AS INT64))) AS _1, (SELECT struct(c1.value AS value) FROM unnest(CAST([struct(CAST(1 AS INT64) AS _1, t1.value AS _2)] AS ARRAY<STRUCT<key INT64,value INT64>>)) AS c1 WHERE (c1.key = CAST(2 AS INT64))) AS _2 FROM t1
 ------ end
 
 ------ Test: mapGet existing key
@@ -1039,15 +1039,15 @@ SELECT (SELECT c0.value FROM unnest(t1._1) AS c0 WHERE (c0.key = t1._2)) AS valu
 ------ end
 
 ------ Test: mapGet missing key
-SELECT (SELECT c0.value FROM unnest(CAST([struct(CAST(1 AS INT) AS _1, 'x' AS _2)] AS ARRAY<STRUCT<key INT,value STRING>>)) AS c0 WHERE (c0.key = t1._2)) AS value FROM t1
+SELECT (SELECT c0.value FROM unnest(CAST([struct(CAST(1 AS INT64) AS _1, 'x' AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>)) AS c0 WHERE (c0.key = t1._2)) AS value FROM t1
 ------ end
 
 ------ Test: mapGet with literal key
-SELECT (SELECT c2.value FROM unnest(CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2)]) = array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2)]) AS c0))) AS c1)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2)] AS ARRAY<STRUCT<key INT,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT,value STRING>>) END) AS c2 WHERE (c2.key = t1._1)) AS value FROM t1
+SELECT (SELECT c5.value FROM unnest(CASE WHEN (array_length([struct(t1._1 AS _1, t1._2 AS _2)]) = array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT c0._1 FROM unnest([struct(t1._1 AS _1, t1._2 AS _2)]) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3)))) THEN CAST([struct(t1._1 AS _1, t1._2 AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value STRING>>) END) AS c5 WHERE (c5.key = t1._1)) AS value FROM t1
 ------ end
 
 ------ Test: match-case all cases sealed trait
-SELECT CASE WHEN (t1.b IS NOT NULL) THEN t1.b.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(error('Unknown case') AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.b IS NOT NULL) THEN t1.b.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT64) ELSE CAST(error('Unknown case') AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: match-case all cases string enum
@@ -1055,15 +1055,15 @@ SELECT CASE WHEN (CASE WHEN (t1.value = 'b') THEN struct(CAST(NULL AS BOOL) AS `
 ------ end
 
 ------ Test: match-case only otherwise
-SELECT CAST(99 AS INT) AS value FROM t1
+SELECT CAST(99 AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: match-case only when cases
-SELECT CASE WHEN (t1.d IS NOT NULL) THEN t1.d.i WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'b') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(2 AS INT) WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(error('Unknown case') AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.d IS NOT NULL) THEN t1.d.i WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'b') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(2 AS INT64) WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT64) ELSE CAST(error('Unknown case') AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: match-case when cases + otherwise
-SELECT CASE WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT) ELSE CAST(99 AS INT) END AS value FROM t1
+SELECT CASE WHEN (t1.c IS NOT NULL) THEN t1.c.i WHEN (CASE WHEN (t1.discriminant = 'a') THEN struct(CAST(NULL AS BOOL) AS `the cake is a lie 🎂`) END IS NOT NULL) THEN CAST(1 AS INT64) ELSE CAST(99 AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: max
@@ -1087,7 +1087,7 @@ SELECT t1._1.a AS a, t1._1.b AS b, t1._2.c AS c, t1._2.d AS d FROM t1
 ------ end
 
 ------ Test: named tuple concat literal
-SELECT t1.a AS a, t1.b AS b, 'abc' AS c, CAST(2 AS BIGINT) AS d FROM t1
+SELECT t1.a AS a, t1.b AS b, 'abc' AS c, CAST(2 AS INT64) AS d FROM t1
 ------ end
 
 ------ Test: nested Option
@@ -1095,7 +1095,7 @@ SELECT t1.value AS value FROM t1
 ------ end
 
 ------ Test: nested Option MakeSome
-SELECT CASE WHEN (t1.value IS NOT NULL) THEN struct(CASE WHEN (NOT (t1.value <= CAST(0 AS INT))) THEN t1.value END AS value) END AS value FROM t1
+SELECT CASE WHEN (t1.value IS NOT NULL) THEN struct(CASE WHEN (NOT (t1.value <= CAST(0 AS INT64))) THEN t1.value END AS value) END AS value FROM t1
 ------ end
 
 ------ Test: nested Option deep
@@ -1103,7 +1103,7 @@ SELECT CASE WHEN (t1.value IS NOT NULL) THEN struct(CASE WHEN (t1.value.value IS
 ------ end
 
 ------ Test: nested Option getOrElse
-SELECT coalesce(t1.value, struct(CAST(NULL AS INT) AS value)).value AS value FROM t1
+SELECT coalesce(t1.value, struct(CAST(NULL AS INT64) AS value)).value AS value FROM t1
 ------ end
 
 ------ Test: nested Option map
@@ -1111,11 +1111,11 @@ SELECT CASE WHEN (t1.value IS NOT NULL) THEN (t1.value.value IS NULL) END AS val
 ------ end
 
 ------ Test: nested seq inside option map
-SELECT coalesce(CASE WHEN (t1.value IS NOT NULL) THEN [struct(t1.value AS value)] END, CAST([] AS ARRAY<STRUCT<value ARRAY<INT>>>)) AS value FROM t1
+SELECT coalesce(CASE WHEN (t1.value IS NOT NULL) THEN [struct(t1.value AS value)] END, CAST([] AS ARRAY<STRUCT<value ARRAY<INT64>>>)) AS value FROM t1
 ------ end
 
 ------ Test: non ascii fields
-SELECT (CAST(t1.`瑞` AS INT) + CAST(t1.`典` AS INT)) AS value FROM t1
+SELECT (CAST(t1.`瑞` AS INT64) + CAST(t1.`典` AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: not equals on primitive
@@ -1127,7 +1127,7 @@ SELECT t1.a AS a FROM t1
 ------ end
 
 ------ Test: raise error in expect when None
-SELECT coalesce(CAST(NULL AS INT), CAST(error('oh no!') AS INT)) AS value FROM t1
+SELECT coalesce(CAST(NULL AS INT64), CAST(error('oh no!') AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: raise error is lazy in &&
@@ -1135,27 +1135,27 @@ SELECT (FALSE AND CAST(error('error') AS BOOLEAN)) AS value FROM t1
 ------ end
 
 ------ Test: raise error is lazy in coalesce
-SELECT coalesce(t1.value, CAST(error('error') AS INT)) AS value FROM t1
+SELECT coalesce(t1.value, CAST(error('error') AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: raise error is lazy in getOrElse
-SELECT coalesce(t1.value, CAST(error('error') AS INT)) AS value FROM t1
+SELECT coalesce(t1.value, CAST(error('error') AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: raise error is lazy in orElse
-SELECT coalesce(t1.value, CAST(error('error') AS INT)) AS value FROM t1
+SELECT coalesce(t1.value, CAST(error('error') AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: raise error is lazy in ternary ifFalse
-SELECT CASE WHEN TRUE THEN t1.value ELSE CAST(error('error') AS INT) END AS value FROM t1
+SELECT CASE WHEN TRUE THEN t1.value ELSE CAST(error('error') AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: raise error is lazy in ternary ifTrue
-SELECT CASE WHEN FALSE THEN CAST(error('error') AS INT) ELSE t1.value END AS value FROM t1
+SELECT CASE WHEN FALSE THEN CAST(error('error') AS INT64) ELSE t1.value END AS value FROM t1
 ------ end
 
 ------ Test: raise error is lazy in when
-SELECT CASE WHEN FALSE THEN CAST(error('error') AS INT) END AS value FROM t1
+SELECT CASE WHEN FALSE THEN CAST(error('error') AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: raise error is lazy in ||
@@ -1171,11 +1171,11 @@ SELECT coalesce(CAST(error('My error message') AS STRING), t1.value) AS value FR
 ------ end
 
 ------ Test: raiseError is strongly typed
-SELECT array((SELECT (c0 + CAST(1 AS INT)) FROM unnest(CAST(error('My error message') AS ARRAY<INT>)) AS c0)) AS value FROM t1
+SELECT array((SELECT (c0 + CAST(1 AS INT64)) FROM unnest(CAST(error('My error message') AS ARRAY<INT64>)) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: raiseError throws static error message
-SELECT CAST(error('My error message') AS INT) AS value FROM t1
+SELECT CAST(error('My error message') AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: remove
@@ -1199,7 +1199,7 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = T
 ------ end
 
 ------ Test: seq exists
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 < CAST(0 AS INT)) FROM unnest(t1.value) AS c0))) AS c1) AS value FROM t1
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 < CAST(0 AS INT64)) FROM unnest(t1.value) AS c0))) AS c1) AS value FROM t1
 ------ end
 
 ------ Test: seq exists outer
@@ -1207,11 +1207,11 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 < t
 ------ end
 
 ------ Test: seq filter
-SELECT array((SELECT c0 FROM unnest(t1.value) AS c0 WHERE (NOT (c0 <= CAST(0 AS INT))))) AS value FROM t1
+SELECT array((SELECT c0 FROM unnest(t1.value) AS c0 WHERE (NOT (c0 <= CAST(0 AS INT64))))) AS value FROM t1
 ------ end
 
 ------ Test: seq filter list
-SELECT array((SELECT c0 FROM unnest(t1.value) AS c0 WHERE (NOT (c0 <= CAST(0 AS INT))))) AS value FROM t1
+SELECT array((SELECT c0 FROM unnest(t1.value) AS c0 WHERE (NOT (c0 <= CAST(0 AS INT64))))) AS value FROM t1
 ------ end
 
 ------ Test: seq filter outer
@@ -1219,27 +1219,27 @@ SELECT array((SELECT c0 FROM unnest(t1._1) AS c0 WHERE (NOT (c0 <= t1._2)))) AS 
 ------ end
 
 ------ Test: seq flatMap
-SELECT array((SELECT c2 FROM unnest(array((SELECT struct([CAST(div(c0, CAST(2 AS INT)) AS INT), (CAST(div(c0, CAST(2 AS INT)) AS INT) + CAST(1 AS INT))] AS value) FROM unnest(t1.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM t1
+SELECT array((SELECT c2 FROM unnest(array((SELECT struct([CAST(div(c0, CAST(2 AS INT64)) AS INT64), (CAST(div(c0, CAST(2 AS INT64)) AS INT64) + CAST(1 AS INT64))] AS value) FROM unnest(t1.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM t1
 ------ end
 
 ------ Test: seq flatMap list
-SELECT array((SELECT c2 FROM unnest(array((SELECT struct([CAST(div(c0, CAST(2 AS INT)) AS INT), (CAST(div(c0, CAST(2 AS INT)) AS INT) + CAST(1 AS INT))] AS value) FROM unnest(t1.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM t1
+SELECT array((SELECT c2 FROM unnest(array((SELECT struct([CAST(div(c0, CAST(2 AS INT64)) AS INT64), (CAST(div(c0, CAST(2 AS INT64)) AS INT64) + CAST(1 AS INT64))] AS value) FROM unnest(t1.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM t1
 ------ end
 
 ------ Test: seq flatMap list with Option keeps Some, drops None
-SELECT array((SELECT c2 FROM unnest(array((SELECT struct(CASE WHEN (CASE WHEN (NOT (c0 <= CAST(0 AS INT))) THEN c0 END IS NOT NULL) THEN [CASE WHEN (NOT (c0 <= CAST(0 AS INT))) THEN c0 END] ELSE CAST([] AS ARRAY<INT>) END AS value) FROM unnest(t1.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM t1
+SELECT array((SELECT c2 FROM unnest(array((SELECT struct(CASE WHEN (CASE WHEN (NOT (c0 <= CAST(0 AS INT64))) THEN c0 END IS NOT NULL) THEN [CASE WHEN (NOT (c0 <= CAST(0 AS INT64))) THEN c0 END] ELSE CAST([] AS ARRAY<INT64>) END AS value) FROM unnest(t1.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM t1
 ------ end
 
 ------ Test: seq flatMap with Option keeps Some, drops None
-SELECT array((SELECT c2 FROM unnest(array((SELECT struct(CASE WHEN (CASE WHEN (NOT (c0 <= CAST(0 AS INT))) THEN c0 END IS NOT NULL) THEN [CASE WHEN (NOT (c0 <= CAST(0 AS INT))) THEN c0 END] ELSE CAST([] AS ARRAY<INT>) END AS value) FROM unnest(t1.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM t1
+SELECT array((SELECT c2 FROM unnest(array((SELECT struct(CASE WHEN (CASE WHEN (NOT (c0 <= CAST(0 AS INT64))) THEN c0 END IS NOT NULL) THEN [CASE WHEN (NOT (c0 <= CAST(0 AS INT64))) THEN c0 END] ELSE CAST([] AS ARRAY<INT64>) END AS value) FROM unnest(t1.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM t1
 ------ end
 
 ------ Test: seq forall
-SELECT (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT (c0 < CAST(0 AS INT)) FROM unnest(t1.value) AS c0))) AS c1) AS value FROM t1
+SELECT (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT (c0 < CAST(0 AS INT64)) FROM unnest(t1.value) AS c0))) AS c1) AS value FROM t1
 ------ end
 
 ------ Test: seq forall nested
-SELECT array((SELECT (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1 < CAST(0 AS INT)) FROM unnest(c0.value) AS c1))) AS c2) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1 < CAST(0 AS INT64)) FROM unnest(c0.value) AS c1))) AS c2) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq forall outer
@@ -1247,15 +1247,15 @@ SELECT (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT (c0 < t
 ------ end
 
 ------ Test: seq map
-SELECT array((SELECT CAST(div(c0, CAST(2 AS INT)) AS INT) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT CAST(div(c0, CAST(2 AS INT64)) AS INT64) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq map constructed
-SELECT array((SELECT CAST(div(c0, CAST(2 AS INT)) AS INT) FROM unnest([t1.value, CAST(2 AS INT), CAST(3 AS INT)]) AS c0)) AS value FROM t1
+SELECT array((SELECT CAST(div(c0, CAST(2 AS INT64)) AS INT64) FROM unnest([t1.value, CAST(2 AS INT64), CAST(3 AS INT64)]) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq map custom collection
-SELECT array((SELECT CAST(div(c0, CAST(2 AS INT)) AS INT) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT CAST(div(c0, CAST(2 AS INT64)) AS INT64) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq map from product
@@ -1263,11 +1263,11 @@ SELECT array((SELECT c0._1 FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq map list
-SELECT array((SELECT CAST(div(c0, CAST(2 AS INT)) AS INT) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT CAST(div(c0, CAST(2 AS INT64)) AS INT64) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq map nested
-SELECT array((SELECT struct(array((SELECT CAST(div(c1, CAST(2 AS INT)) AS INT) FROM unnest(c0.value) AS c1)) AS value) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT struct(array((SELECT CAST(div(c1, CAST(2 AS INT64)) AS INT64) FROM unnest(c0.value) AS c1)) AS value) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq map nested outer
@@ -1275,7 +1275,7 @@ SELECT array((SELECT struct(array((SELECT (NOT (c1 <= c0._2)) FROM unnest(c0._1)
 ------ end
 
 ------ Test: seq map nested with
-SELECT array((SELECT struct(array((SELECT (NOT (c1 <= CAST(1 AS INT))) FROM unnest(c0._1) AS c1)) AS a) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT struct(array((SELECT (NOT (c1 <= CAST(1 AS INT64))) FROM unnest(c0._1) AS c1)) AS a) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq map outer
@@ -1283,7 +1283,7 @@ SELECT array((SELECT (NOT (c0 <= t1._2)) FROM unnest(t1._1) AS c0)) AS value FRO
 ------ end
 
 ------ Test: seq map to product
-SELECT array((SELECT struct(c0 AS _1, CAST(1 AS INT) AS _2) FROM unnest(t1.value) AS c0)) AS value FROM t1
+SELECT array((SELECT struct(c0 AS _1, CAST(1 AS INT64) AS _2) FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: seq toSeq
@@ -1291,7 +1291,7 @@ SELECT t1.value AS value FROM t1
 ------ end
 
 ------ Test: seq zip
-SELECT array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0)) AS value FROM t1
+SELECT array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT64), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT64)))) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: size on List[String]
@@ -1307,7 +1307,7 @@ SELECT CASE WHEN ((t1._2 = '') AND (NOT (t1._1 = ''))) THEN array_concat(split(t
 ------ end
 
 ------ Test: spreadOption
-SELECT CASE WHEN (t1.value IS NULL) THEN struct(CAST(NULL AS INT) AS a, CAST(NULL AS STRING) AS b, CAST(NULL AS BOOLEAN) AS c) ELSE struct(t1.value.a AS a, t1.value.b AS b, t1.value.c AS c) END.a AS a, CASE WHEN (t1.value IS NULL) THEN struct(CAST(NULL AS INT) AS a, CAST(NULL AS STRING) AS b, CAST(NULL AS BOOLEAN) AS c) ELSE struct(t1.value.a AS a, t1.value.b AS b, t1.value.c AS c) END.b AS b, CASE WHEN (t1.value IS NULL) THEN struct(CAST(NULL AS INT) AS a, CAST(NULL AS STRING) AS b, CAST(NULL AS BOOLEAN) AS c) ELSE struct(t1.value.a AS a, t1.value.b AS b, t1.value.c AS c) END.c AS c FROM t1
+SELECT CASE WHEN (t1.value IS NULL) THEN struct(CAST(NULL AS INT64) AS a, CAST(NULL AS STRING) AS b, CAST(NULL AS BOOLEAN) AS c) ELSE struct(t1.value.a AS a, t1.value.b AS b, t1.value.c AS c) END.a AS a, CASE WHEN (t1.value IS NULL) THEN struct(CAST(NULL AS INT64) AS a, CAST(NULL AS STRING) AS b, CAST(NULL AS BOOLEAN) AS c) ELSE struct(t1.value.a AS a, t1.value.b AS b, t1.value.c AS c) END.b AS b, CASE WHEN (t1.value IS NULL) THEN struct(CAST(NULL AS INT64) AS a, CAST(NULL AS STRING) AS b, CAST(NULL AS BOOLEAN) AS c) ELSE struct(t1.value.a AS a, t1.value.b AS b, t1.value.c AS c) END.c AS c FROM t1
 ------ end
 
 ------ Test: string startsWith
@@ -1319,7 +1319,7 @@ SELECT STARTS_WITH(t1._1, 'foo') AS value FROM t1
 ------ end
 
 ------ Test: support field names that are SQL keywords
-SELECT CAST(1 AS INT) AS `select`, CAST(2 AS INT) AS `group`, CAST(3 AS INT) AS `by` FROM t1
+SELECT CAST(1 AS INT64) AS `select`, CAST(2 AS INT64) AS `group`, CAST(3 AS INT64) AS `by` FROM t1
 ------ end
 
 ------ Test: ternary
@@ -1343,19 +1343,19 @@ SELECT to_json_string(t1.value) AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
-SELECT CASE WHEN ((json_query(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$') != 'null') AND (((CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT) END IS NOT NULL) AND (json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.b') IS NOT NULL)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.c') AS BOOLEAN) IS NOT NULL))) THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT) END AS a, json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.b') AS b, SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.c') AS BOOLEAN) AS c) END AS value FROM t1
+SELECT CASE WHEN ((json_query(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$') != 'null') AND (((CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT64) END IS NOT NULL) AND (json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.b') IS NOT NULL)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.c') AS BOOLEAN) IS NOT NULL))) THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.a') AS INT64) END AS a, json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.b') AS b, SAFE_CAST(json_value(to_json_string(struct(t1.a AS a, t1.b AS b, t1.c AS c)), '$.c') AS BOOLEAN) AS c) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.NamedTuple.NamedTuple[scala.Tuple1["0digitfirst"], scala.Tuple1[scala.Int]]
-SELECT CASE WHEN ((json_query(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT) END AS `0digitfirst`) END AS value FROM t1
+SELECT CASE WHEN ((json_query(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT64) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`0digitfirst` AS `0digitfirst`)), '$."0digitfirst"') AS INT64) END AS `0digitfirst`) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.NamedTuple.NamedTuple[scala.Tuple1["name with space"], scala.Tuple1[scala.Int]]
-SELECT CASE WHEN ((json_query(to_json_string(struct(t1.`name with space` AS `name with space`)), '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT) END AS `name with space`) END AS value FROM t1
+SELECT CASE WHEN ((json_query(to_json_string(struct(t1.`name with space` AS `name with space`)), '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT64) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`name with space` AS `name with space`)), '$."name with space"') AS INT64) END AS `name with space`) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.NamedTuple.NamedTuple[scala.Tuple1["name-with-dash"], scala.Tuple1[scala.Int]]
-SELECT CASE WHEN ((json_query(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT) END AS `name-with-dash`) END AS value FROM t1
+SELECT CASE WHEN ((json_query(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$') != 'null') AND (CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT64) END IS NOT NULL)) THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1.`name-with-dash` AS `name-with-dash`)), '$."name-with-dash"') AS INT64) END AS `name-with-dash`) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.Tuple1[com.choreograph.tyda.Date$package.Date]
@@ -1363,7 +1363,7 @@ SELECT CASE WHEN ((json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.Tuple1[com.choreograph.tyda.Duration$package.Duration]
-SELECT CASE WHEN ((json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null') AND (SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS BIGINT) IS NOT NULL)) THEN struct(SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS BIGINT) AS _1) END AS value FROM t1
+SELECT CASE WHEN ((json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null') AND (SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS INT64) IS NOT NULL)) THEN struct(SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS INT64) AS _1) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.Tuple1[com.choreograph.tyda.Timestamp$package.Timestamp]
@@ -1371,35 +1371,35 @@ SELECT CASE WHEN ((json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.Tuple1[scala.Option[scala.Int]]
-SELECT CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null') THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS INT) END AS _1) END AS value FROM t1
+SELECT CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null') THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1') AS INT64) END AS _1) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.Tuple1[scala.Option[scala.Option[scala.Int]]]
-SELECT CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null') THEN struct(CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$._1') != 'null') THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value') AS INT) END AS value) END AS _1) END AS value FROM t1
+SELECT CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null') THEN struct(CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$._1') != 'null') THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value') AS INT64) END AS value) END AS _1) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.Tuple1[scala.Option[scala.Option[scala.Option[scala.Int]]]]
-SELECT CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null') THEN struct(CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$._1') != 'null') THEN struct(CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$._1.value') != 'null') THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value.value') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value.value') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value.value') AS INT) END AS value) END AS value) END AS _1) END AS value FROM t1
+SELECT CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$') != 'null') THEN struct(CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$._1') != 'null') THEN struct(CASE WHEN (json_query(to_json_string(struct(t1._1 AS _1)), '$._1.value') != 'null') THEN struct(CASE WHEN ((SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value.value') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value.value') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(to_json_string(struct(t1._1 AS _1)), '$._1.value.value') AS INT64) END AS value) END AS value) END AS _1) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.collection.immutable.Map[scala.Predef.String, scala.Int]
-SELECT CASE WHEN ((json_query_array(to_json_string(t1.value), '$') IS NOT NULL) AND (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT ((json_query(c0, '$') != 'null') AND ((json_value(c0, '$.key') IS NOT NULL) AND (CASE WHEN ((SAFE_CAST(json_value(c0, '$.value') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(c0, '$.value') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(c0, '$.value') AS INT) END IS NOT NULL))) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0))) AS c1)) THEN CAST(array((SELECT struct(json_value(c0, '$.key') AS key, CASE WHEN ((SAFE_CAST(json_value(c0, '$.value') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(c0, '$.value') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(c0, '$.value') AS INT) END AS value) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0)) AS ARRAY<STRUCT<key STRING,value INT>>) END AS value FROM t1
+SELECT CASE WHEN ((json_query_array(to_json_string(t1.value), '$') IS NOT NULL) AND (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT ((json_query(c0, '$') != 'null') AND ((json_value(c0, '$.key') IS NOT NULL) AND (CASE WHEN ((SAFE_CAST(json_value(c0, '$.value') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(c0, '$.value') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(c0, '$.value') AS INT64) END IS NOT NULL))) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0))) AS c1)) THEN CAST(array((SELECT struct(json_value(c0, '$.key') AS key, CASE WHEN ((SAFE_CAST(json_value(c0, '$.value') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(c0, '$.value') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(c0, '$.value') AS INT64) END AS value) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0)) AS ARRAY<STRUCT<key STRING,value INT64>>) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
-SELECT CASE WHEN ((json_query_array(to_json_string(t1.value), '$') IS NOT NULL) AND (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT ((json_query(c0, '$') != 'null') AND (((CASE WHEN ((SAFE_CAST(json_value(c0, '$.a') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(c0, '$.a') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(c0, '$.a') AS INT) END IS NOT NULL) AND (json_value(c0, '$.b') IS NOT NULL)) AND (SAFE_CAST(json_value(c0, '$.c') AS BOOLEAN) IS NOT NULL))) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0))) AS c1)) THEN array((SELECT struct(CASE WHEN ((SAFE_CAST(json_value(c0, '$.a') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(c0, '$.a') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(c0, '$.a') AS INT) END AS a, json_value(c0, '$.b') AS b, SAFE_CAST(json_value(c0, '$.c') AS BOOLEAN) AS c) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0)) END AS value FROM t1
+SELECT CASE WHEN ((json_query_array(to_json_string(t1.value), '$') IS NOT NULL) AND (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT ((json_query(c0, '$') != 'null') AND (((CASE WHEN ((SAFE_CAST(json_value(c0, '$.a') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(c0, '$.a') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(c0, '$.a') AS INT64) END IS NOT NULL) AND (json_value(c0, '$.b') IS NOT NULL)) AND (SAFE_CAST(json_value(c0, '$.c') AS BOOLEAN) IS NOT NULL))) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0))) AS c1)) THEN array((SELECT struct(CASE WHEN ((SAFE_CAST(json_value(c0, '$.a') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(c0, '$.a') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(c0, '$.a') AS INT64) END AS a, json_value(c0, '$.b') AS b, SAFE_CAST(json_value(c0, '$.c') AS BOOLEAN) AS c) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0)) END AS value FROM t1
 ------ end
 
 ------ Test: toJson/fromJson roundtrip for scala.collection.immutable.Seq[scala.Int]
-SELECT CASE WHEN ((json_query_array(to_json_string(t1.value), '$') IS NOT NULL) AND (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT (CASE WHEN ((SAFE_CAST(json_value(c0, '$') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(c0, '$') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(c0, '$') AS INT) END IS NOT NULL) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0))) AS c1)) THEN array((SELECT CASE WHEN ((SAFE_CAST(json_value(c0, '$') AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(json_value(c0, '$') AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(json_value(c0, '$') AS INT) END FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0)) END AS value FROM t1
+SELECT CASE WHEN ((json_query_array(to_json_string(t1.value), '$') IS NOT NULL) AND (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT (CASE WHEN ((SAFE_CAST(json_value(c0, '$') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(c0, '$') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(c0, '$') AS INT64) END IS NOT NULL) FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0))) AS c1)) THEN array((SELECT CASE WHEN ((SAFE_CAST(json_value(c0, '$') AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(json_value(c0, '$') AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(json_value(c0, '$') AS INT64) END FROM unnest(json_query_array(to_json_string(t1.value), '$')) AS c0)) END AS value FROM t1
 ------ end
 
 ------ Test: toMap
-SELECT CAST([struct(CAST(1 AS INT) AS _1, t1._1 AS _2), struct(CAST(2 AS INT) AS _1, t1._2 AS _2), struct(CAST(3 AS INT) AS _1, t1._3 AS _2)] AS ARRAY<STRUCT<key INT,value STRING>>) AS value FROM t1
+SELECT CAST([struct(CAST(1 AS INT64) AS _1, t1._1 AS _2), struct(CAST(2 AS INT64) AS _1, t1._2 AS _2), struct(CAST(3 AS INT64) AS _1, t1._3 AS _2)] AS ARRAY<STRUCT<key INT64,value STRING>>) AS value FROM t1
 ------ end
 
 ------ Test: toMap with many
-SELECT CASE WHEN (array_length(array((SELECT DISTINCT c1 FROM unnest(array((SELECT struct(c0 AS _1, c0 AS _2) FROM unnest(t1.value) AS c0))) AS c1))) = array_length(array((SELECT DISTINCT c5 FROM unnest(array((SELECT c4._1 FROM unnest(array((SELECT DISTINCT c3 FROM unnest(array((SELECT struct(c2 AS _1, c2 AS _2) FROM unnest(t1.value) AS c2))) AS c3))) AS c4))) AS c5)))) THEN CAST(array((SELECT DISTINCT c7 FROM unnest(array((SELECT struct(c6 AS _1, c6 AS _2) FROM unnest(t1.value) AS c6))) AS c7)) AS ARRAY<STRUCT<key INT,value INT>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT,value INT>>) END AS value FROM t1
+SELECT CASE WHEN (array_length(array((SELECT c4.value FROM (SELECT c1 AS value, min(c2) AS c3 FROM unnest(array((SELECT struct(c0 AS _1, c0 AS _2) FROM unnest(t1.value) AS c0))) AS c1 WITH OFFSET AS c2 GROUP BY c1) AS c4 ORDER BY c4.c3))) = array_length(array((SELECT c14.value FROM (SELECT c11 AS value, min(c12) AS c13 FROM unnest(array((SELECT c10._1 FROM unnest(array((SELECT c9.value FROM (SELECT c6 AS value, min(c7) AS c8 FROM unnest(array((SELECT struct(c5 AS _1, c5 AS _2) FROM unnest(t1.value) AS c5))) AS c6 WITH OFFSET AS c7 GROUP BY c6) AS c9 ORDER BY c9.c8))) AS c10))) AS c11 WITH OFFSET AS c12 GROUP BY c11) AS c14 ORDER BY c14.c13)))) THEN CAST(array((SELECT c19.value FROM (SELECT c16 AS value, min(c17) AS c18 FROM unnest(array((SELECT struct(c15 AS _1, c15 AS _2) FROM unnest(t1.value) AS c15))) AS c16 WITH OFFSET AS c17 GROUP BY c16) AS c19 ORDER BY c19.c18)) AS ARRAY<STRUCT<key INT64,value INT64>>) ELSE CAST(error('Duplicate keys found') AS ARRAY<STRUCT<key INT64,value INT64>>) END AS value FROM t1
 ------ end
 
 ------ Test: trim string
@@ -1407,63 +1407,63 @@ SELECT trim(t1.value, ' ') AS value FROM t1
 ------ end
 
 ------ Test: truncating divide first argument by second
-SELECT CAST(div(t1._1, t1._2) AS BIGINT) AS value FROM t1
+SELECT CAST(div(t1._1, t1._2) AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: truncating divide first int argument by second
-SELECT CAST(div(t1._1, t1._2) AS INT) AS value FROM t1
+SELECT CAST(div(t1._1, t1._2) AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to com.choreograph.tyda.Decimal$package.Decimal[19, 0]
-SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) AS value FROM t1
+SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[10, 3]
-SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(3 AS INT)) AS value FROM t1
+SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(3 AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[38, 9]
-SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT)) AS value FROM t1
+SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT64)) AS value FROM t1
 ------ end
 
 ------ Test: try cast java.lang.String to scala.Byte
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS TINYINT) >= CAST(-128 AS BIGINT)) AND (SAFE_CAST(t1.value AS TINYINT) <= CAST(127 AS BIGINT))) THEN SAFE_CAST(t1.value AS TINYINT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-128 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(127 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: try cast java.lang.String to scala.Int
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(t1.value AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(t1.value AS INT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: try cast java.lang.String to scala.Long
-SELECT SAFE_CAST(t1.value AS BIGINT) AS value FROM t1
+SELECT SAFE_CAST(t1.value AS INT64) AS value FROM t1
 ------ end
 
 ------ Test: try cast java.lang.String to scala.Short
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS SMALLINT) >= CAST(-32768 AS BIGINT)) AND (SAFE_CAST(t1.value AS SMALLINT) <= CAST(32767 AS BIGINT))) THEN SAFE_CAST(t1.value AS SMALLINT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-32768 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(32767 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: try cast scala.Int to scala.Byte
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS TINYINT) >= CAST(-128 AS BIGINT)) AND (SAFE_CAST(t1.value AS TINYINT) <= CAST(127 AS BIGINT))) THEN SAFE_CAST(t1.value AS TINYINT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-128 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(127 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: try cast scala.Int to scala.Short
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS SMALLINT) >= CAST(-32768 AS BIGINT)) AND (SAFE_CAST(t1.value AS SMALLINT) <= CAST(32767 AS BIGINT))) THEN SAFE_CAST(t1.value AS SMALLINT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-32768 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(32767 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: try cast scala.Long to scala.Byte
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS TINYINT) >= CAST(-128 AS BIGINT)) AND (SAFE_CAST(t1.value AS TINYINT) <= CAST(127 AS BIGINT))) THEN SAFE_CAST(t1.value AS TINYINT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-128 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(127 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: try cast scala.Long to scala.Int
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT) >= CAST(-2147483648 AS BIGINT)) AND (SAFE_CAST(t1.value AS INT) <= CAST(2147483647 AS BIGINT))) THEN SAFE_CAST(t1.value AS INT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-2147483648 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(2147483647 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: try cast scala.Long to scala.Short
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS SMALLINT) >= CAST(-32768 AS BIGINT)) AND (SAFE_CAST(t1.value AS SMALLINT) <= CAST(32767 AS BIGINT))) THEN SAFE_CAST(t1.value AS SMALLINT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-32768 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(32767 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: try cast scala.Short to scala.Byte
-SELECT CASE WHEN ((SAFE_CAST(t1.value AS TINYINT) >= CAST(-128 AS BIGINT)) AND (SAFE_CAST(t1.value AS TINYINT) <= CAST(127 AS BIGINT))) THEN SAFE_CAST(t1.value AS TINYINT) END AS value FROM t1
+SELECT CASE WHEN ((SAFE_CAST(t1.value AS INT64) >= CAST(-128 AS INT64)) AND (SAFE_CAST(t1.value AS INT64) <= CAST(127 AS INT64))) THEN SAFE_CAST(t1.value AS INT64) END AS value FROM t1
 ------ end
 
 ------ Test: update adding new field

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -659,7 +659,7 @@ SELECT FALSE AS value FROM t1
 ------ end
 
 ------ Test: distinct on Seq[Int]
-SELECT array((SELECT c3.value FROM (SELECT c0 AS value, min(c1) AS c2 FROM unnest(t1.value) AS c0 WITH OFFSET AS c1 GROUP BY c0) AS c3 ORDER BY c3.c2)) AS value FROM t1
+SELECT array((SELECT DISTINCT c0 FROM unnest(t1.value) AS c0)) AS value FROM t1
 ------ end
 
 ------ Test: endsWith string

--- a/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
@@ -11,7 +11,7 @@ SELECT t0._1 AS value FROM (SELECT DISTINCT table1.a AS _1, table1.b AS _2 FROM 
 ------ end
 
 ------ Test: empty collection
-SELECT t0.a AS a, t0.b AS b, t0.c AS c, t0.d AS d FROM (SELECT CAST(0 AS INT) AS a, '' AS b, FALSE AS c, [CAST(0.0 AS FLOAT64)] AS d) AS t0 WHERE FALSE
+SELECT t0.a AS a, t0.b AS b, t0.c AS c, t0.d AS d FROM (SELECT CAST(0 AS INT64) AS a, '' AS b, FALSE AS c, [CAST(0.0 AS FLOAT64)] AS d) AS t0 WHERE FALSE
 ------ end
 
 ------ Test: equals with Option
@@ -27,7 +27,7 @@ SELECT `table-name`.`dashed-column` AS `dashed-column` FROM `table-name`
 ------ end
 
 ------ Test: escape value columns
-SELECT CAST(1 AS INT) AS `from`, CAST(2 AS BIGINT) AS `has space`
+SELECT CAST(1 AS INT64) AS `from`, CAST(2 AS INT64) AS `has space`
 ------ end
 
 ------ Test: explode multiple expression
@@ -35,7 +35,7 @@ SELECT table1.a AS _1, t0 AS _2 FROM table1, unnest(table1.d) AS t0
 ------ end
 
 ------ Test: fromSeq
-(SELECT CAST(1 AS INT) AS value) UNION ALL ((SELECT CAST(2 AS INT) AS value) UNION ALL (SELECT CAST(3 AS INT) AS value))
+(SELECT CAST(1 AS INT64) AS value) UNION ALL ((SELECT CAST(2 AS INT64) AS value) UNION ALL (SELECT CAST(3 AS INT64) AS value))
 ------ end
 
 ------ Test: full outer join product on lhs
@@ -43,11 +43,11 @@ SELECT t0.value AS _1, t1.value AS _2 FROM (SELECT struct(table1.a AS a, table1.
 ------ end
 
 ------ Test: group by all
-SELECT count(CASE WHEN (table4.a IS NOT NULL) THEN CAST(1 AS INT) END) AS value FROM table4 GROUP BY CAST(NULL AS INT)
+SELECT count(CASE WHEN (table4.a IS NOT NULL) THEN CAST(1 AS INT64) END) AS value FROM table4 GROUP BY CAST(NULL AS INT64)
 ------ end
 
 ------ Test: grouped aggregation + filter
-SELECT table1.b AS _1, min(table1.a) AS _2 FROM table1 GROUP BY table1.b HAVING (min(table1.a) < CAST(10 AS INT))
+SELECT table1.b AS _1, min(table1.a) AS _2 FROM table1 GROUP BY table1.b HAVING (min(table1.a) < CAST(10 AS INT64))
 ------ end
 
 ------ Test: groupped aggregate after grouped aggregate
@@ -79,7 +79,7 @@ SELECT table1.a AS _1, t0.value AS _2 FROM table1 LEFT JOIN (SELECT struct(table
 ------ end
 
 ------ Test: literal enum
-SELECT ((TRUE AND (t0._1.discriminant = 'c')) AND (t0._1.a IS NULL)) AS value FROM (SELECT struct('a' AS discriminant, struct(CAST(1 AS INT) AS a) AS a) AS _1) AS t0
+SELECT ((TRUE AND (t0._1.discriminant = 'c')) AND (t0._1.a IS NULL)) AS value FROM (SELECT struct('a' AS discriminant, struct(CAST(1 AS INT64) AS a) AS a) AS _1) AS t0
 ------ end
 
 ------ Test: literal enum as string
@@ -107,11 +107,11 @@ SELECT table1.a AS _1, table2.a AS _2, table3.a AS _3 FROM table1 JOIN table2 ON
 ------ end
 
 ------ Test: select and where, with select first
-SELECT table1.a AS value FROM table1 WHERE (NOT (table1.a <= CAST(10 AS INT)))
+SELECT table1.a AS value FROM table1 WHERE (NOT (table1.a <= CAST(10 AS INT64)))
 ------ end
 
 ------ Test: select and where, with where first
-SELECT table1.a AS value FROM table1 WHERE (NOT (table1.a <= CAST(10 AS INT)))
+SELECT table1.a AS value FROM table1 WHERE (NOT (table1.a <= CAST(10 AS INT64)))
 ------ end
 
 ------ Test: select distinct

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/DatasetSuiteAsGoldenSuite.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/DatasetSuiteAsGoldenSuite.scala
@@ -50,7 +50,7 @@ trait DatasetSuiteAsGoldenSuite extends DatasetSuite, SqlGoldenTestSuite {
       name: String,
       input: Seq[T],
       computation: Dataset[T] => Dataset[R],
-      expectedError: String
+      expectedError: String | scala.util.matching.Regex
   ): Unit = {
     testSqlOrSkip(name) { computation(Dataset.readTable[T, EmptyTuple](s"${tablePrefix}1").select(_._1)) }
   }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/BigQueryIntegrationTestEnvVariables.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/BigQueryIntegrationTestEnvVariables.scala
@@ -17,6 +17,14 @@ object BigQueryIntegrationTestEnvVariables {
     ): Unit
   }
 
+  def skipIfProjectIsSet(): Unit = {
+    val shouldRun = !sys.env.contains(ProjectId)
+    assume(
+      condition = shouldRun,
+      s"Skipping local GoogleSQL tests: real BigQuery integration is active ($ProjectId is set)"
+    ): Unit
+  }
+
   def getProjectId: Option[String] = sys.env.get(ProjectId)
 
   def getProjectIdOrSkip: String =

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
@@ -238,7 +238,7 @@ trait DatasetAggregatesSuite extends DatasetSuite {
     "sum Decimal overflow should error",
     Seq(NumericLimits[Decimal[MaxPrecision, 0]].max, Decimal[MaxPrecision, 0](1)),
     ds => ds.aggregate(sum),
-    "cannot be represented"
+    "(cannot be represented)|(exceeds limit for number of digits)".r
   )
 
   test[(Int, Int), (Int, Int)](

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetSuite.scala
@@ -2,6 +2,7 @@ package com.choreograph.tyda.testsuites
 
 import scala.reflect.ClassTag
 import scala.util.Random
+import scala.util.matching.Regex
 
 import org.scalactic.Equality
 import org.scalatest.Assertions.fail
@@ -182,7 +183,7 @@ trait DatasetSuite extends AnyFunSuite {
       name: String,
       input: Seq[T],
       computation: Dataset[T] => Dataset[R],
-      expectedError: String
+      expectedError: String | Regex
   ): Unit =
     test(name) {
       val ds = computation(Dataset.FromSeq(input))
@@ -190,11 +191,18 @@ trait DatasetSuite extends AnyFunSuite {
       e match {
         // TODO: Use ScalaTestControlException alias
         case e: (TestPendingException | TestCanceledException | TestFailedException) => throw e
-        case _ => Option(e.getMessage) match {
-            case None => fail(s"Expected exception with $expectedError but got exception with no message.", e)
-            case Some(message) => assert(
-                message.contains(expectedError),
-                s"Error message did not contain expected text.\nExpected to contain: $expectedError\nActual message: ${message}"
+        case _ =>
+          val message = Option(e.getMessage).getOrElse(
+            fail(s"Expected exception with $expectedError but got exception with no message.", e)
+          )
+          expectedError match {
+            case expected: String => assert(
+                message.contains(expected),
+                s"Error message did not contain expected text.\nExpected to contain: $expected\nActual message: $message"
+              )
+            case expected: Regex => assert(
+                expected.findFirstMatchIn(message).isDefined,
+                s"Error message did not match regex '$expected'.\nActual message: $message"
               )
           }
       }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -862,7 +862,11 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
 
   {
     given Arbitrary[Int] = Arbitrary.int.filter(_ > 0)
-    testFailure[Int, Int]("fail on int overflow", _ + Expr.lit(Int.MaxValue), "(overflow)|(out of range)".r)
+    testFailure[Int, Int](
+      "fail on int overflow",
+      _ + Expr.lit(Int.MaxValue),
+      "(overflow)|(out of range)|(too large for int)".r
+    )
   }
 
   {


### PR DESCRIPTION
Adds a local GoogleSQL test runner based on Google's prebuilt execute_query binary. This is to provide automated BigQuery-like coverage in CI, without requiring BigQuery credentials.

The real BigQuery integration suites remain opt-in via TYDA_BIGQUERY_TEST_PROJECT_ID and TYDA_BIGQUERY_TEST_TMP_LOCATION. Local GoogleSQL suites run when the executable is configured and BigQuery integration is not set. See readme for further instructions on running the local tests.