### PR TITLE
Remove superfluous select in sql

### DIFF
--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/CompiledExprIndependentSelects.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/CompiledExprIndependentSelects.scala
@@ -1,0 +1,68 @@
+package com.choreograph.tyda.sql
+
+import scala.annotation.tailrec
+
+import com.choreograph.tyda.CompiledExpr
+import com.choreograph.tyda.ExprNode
+import com.choreograph.tyda.ExprNode.Reference
+import com.choreograph.tyda.NonEmpty
+import com.choreograph.tyda.shapeless3extras.mapConst
+import com.choreograph.tyda.shapeless3extras.tupleInstances
+import com.choreograph.tyda.sql.SelectBuilder.FinalSelect
+import com.choreograph.tyda.sql.SelectBuilder.finalSelect
+
+private object CompiledExprIndependentSelects {
+
+  extension [T](seq: NonEmpty[Seq[Option[T]]]) {
+    def sequence: Option[NonEmpty[Seq[T]]] =
+      Option.when(seq.forall(_.nonEmpty))(NonEmpty.from(seq.flatten)).flatten
+  }
+
+  def unapply[R, T](
+      expr: CompiledExpr[T, R]
+  ): Option[NonEmpty[Seq[(fieldName: String, fieldAccesses: NonEmpty[Seq[String]])]]] = {
+    val exprs = finalSelect(expr.arg, expr.expr) match {
+      case FinalSelect.Multiple(exprs) => exprs
+      case _ => return None
+    }
+
+    val arg = expr.arg
+    exprs
+      .map { case (expr, fieldName) =>
+        (expr.expr match {
+          case ExprNodeNestedSelects(`arg`, selects) if selects.size == 1 => Some(selects)
+          case _ => None
+        }).map((fieldName = fieldName, fieldAccesses = _))
+      }
+      .sequence
+      .filter { selects =>
+        val firsts = selects.map(_.fieldAccesses.head)
+        firsts.distinct.length == firsts.length
+      }
+  }
+}
+
+private object ExprNodeNestedSelects {
+
+  @tailrec
+  private def impl(
+      node: ExprNode[?],
+      acc: Seq[String]
+  ): (Option[(ExprNode.Reference[?], NonEmpty[Seq[String]])]) =
+    node match {
+      case arg @ ExprNode.Reference(_, _) => NonEmpty.from(acc).map((arg, _))
+      case ExprNode.Select(innerNode, name) => impl(innerNode, name +: acc)
+      case ExprNode.MakeProduct(values, codec) => acc match {
+          case head +: tail =>
+            val idx = codec.fields.mapConst([t] => _.name).indexOf(head)
+            tupleInstances(values).mapConst([t] => identity(_)).lift(idx) match {
+              case Some(node) => impl(node, tail)
+              case None => None
+            }
+          case Nil => None
+        }
+      case _ => None
+    }
+
+  def unapply(node: ExprNode[?]): Option[(ExprNode.Reference[?], NonEmpty[Seq[String]])] = impl(node, Seq())
+}

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -318,14 +318,9 @@ private final case class SelectBuilder[T, R](
       explode: CompiledExplodeExpr[R, R2]
   ): Result[SelectBuilder[?, R2]] = {
     val newSelect = andThenRelaxed(select, explode)
-    explode.codec match {
-      case Codec.Product(_, _, _) | Codec.Sum(_, _) =>
-        // When exploding to a structured type we end up with a single column and need to flatten it manually
-        buildWithSelect(
-          NonEmpty[Seq]((newSelect, "_1"))
-        ).flatMap(makeSubquery[Tuple1[R2]](_, summon).select(CompiledExpr(_._1)))
-      case _ => buildWithSelect(NonEmpty[Seq]((newSelect, "value"))).map(makeSubquery(_, explode.codec))
-    }
+    buildWithSelect(
+      NonEmpty[Seq]((newSelect, "_1"))
+    ).flatMap(makeSubquery[Tuple1[R2]](_, summon).select(CompiledExpr(_._1)))
   }
 
   private def selectExplodeJoin[R2: Codec](
@@ -433,23 +428,52 @@ private final case class SelectBuilder[T, R](
             false,
             None,
             None
-          ) => return Right(query)
+          ) =>
+        /* For builders that are only select directly from a subquery, we return the subquery to avoid an
+         * unnecessary select */
+        return Right(query)
+      case SelectBuilder(
+            _,
+            TypedFrom(From.Subquery(query @ Query.Select(distinct = false), _), _, _),
+            CompiledExprIndependentSelects(names),
+            None,
+            None,
+            None,
+            false,
+            None,
+            None
+          ) =>
+        /* For builders that only make independent field accesses from a subquery, we combine the select into
+         * the subquery and return that directly to avoid a superfluous select. Independent in this case means
+         * that no field of the subquery is accessed more than once in the select; in particular this rules
+         * out the case where an explode from the subquery would be inlined into multiple fields of the
+         * combined select, causing us to erroneously produce a cartesian product. */
+
+        extension [T](seq: NonEmpty[Seq[Option[T]]]) {
+          def sequence: Option[NonEmpty[Seq[T]]] =
+            Option.when(seq.forall(_.nonEmpty))(NonEmpty.from(seq.flatten)).flatten
+        }
+
+        names
+          .map { case (fieldName, fieldAccesses) =>
+            query
+              .select
+              .collectFirst { case SqlExpr.As(e, a) if a.value == fieldAccesses.head => e }
+              .map(a =>
+                SqlExpr.As(
+                  fieldAccesses.tail.foldLeft(a)((acc, name) => SqlExpr.FieldAccess(acc, name)),
+                  fieldName
+                )
+              )
+          }
+          .sequence match {
+          case Some(newSelect) => return Right(query.copy(select = newSelect))
+          case None => ()
+        }
       case _ => ()
     }
-    def finalSelect[A](expr: ExprNode[A]): FinalSelect[T] =
-      expr.codec match {
-        case Codec.Product(_, fieldInstances, _) =>
-          val maybeFields = NonEmpty.from(
-            fieldInstances
-              .mapConst[Field[?]]([t] => identity(_))
-              .map(f => (RelaxedCompiledExpr(select.arg, ExprNode.Select(expr, f.name)), f.name))
-          )
-          maybeFields.map(FinalSelect.Multiple(_)).getOrElse(FinalSelect.Empty())
-        case sum @ Codec.Sum(_, _) => finalSelect(ExprNode.ToRepr(expr, sum))
-        case _ => FinalSelect.Multiple(NonEmpty((RelaxedCompiledExpr(select), "value")))
-      }
 
-    buildWithSelect(finalSelect(select.expr))
+    buildWithSelect(finalSelect(select.arg, select.expr))
   }
 
   private def buildWithSelect(
@@ -531,6 +555,19 @@ private object SelectBuilder {
     val select = CompiledExpr[T, T](identity)(using from.output.codec)
     SelectBuilder(args, from, select)
   }
+
+  private[sql] def finalSelect[T, R](arg: ExprNode.Reference[T], expr: ExprNode[R]): FinalSelect[T] =
+    expr.codec match {
+      case Codec.Product(_, fieldInstances, _) =>
+        val maybeFields = NonEmpty.from(
+          fieldInstances
+            .mapConst[Field[?]]([t] => identity(_))
+            .map(f => (RelaxedCompiledExpr(arg, ExprNode.Select(expr, f.name)), f.name))
+        )
+        maybeFields.map(FinalSelect.Multiple(_)).getOrElse(FinalSelect.Empty())
+      case sum @ Codec.Sum(_, _) => finalSelect(arg, ExprNode.ToRepr(expr, sum))
+      case _ => FinalSelect.Multiple(NonEmpty((RelaxedCompiledExpr(arg, expr), "value")))
+    }
 
   extension [R <: Option[?]: Codec](lhs: SelectBuilder[R, R]) {
     private def fullJoinNullable[R2 <: Option[?]: Codec](

--- a/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
@@ -47,7 +47,7 @@ SELECT explode(table1.value) AS value FROM table1
 ------ end
 
 ------ Test: explode Seq Option Seq
-SELECT explode(t0.value) AS value FROM (SELECT explode(table1.value) AS value FROM table1) AS t0 WHERE (t0.value IS NOT NULL)
+SELECT explode(t0._1) AS value FROM (SELECT explode(table1.value) AS _1 FROM table1) AS t0 WHERE (t0._1 IS NOT NULL)
 ------ end
 
 ------ Test: explode multiple nested Seq
@@ -55,7 +55,7 @@ SELECT explode(table1._1) AS _1, explode(table1._2) AS _2 FROM table1
 ------ end
 
 ------ Test: explode nested Seq
-SELECT explode(t0.value) AS value FROM (SELECT explode(table1.value) AS value FROM table1) AS t0
+SELECT explode(t0._1) AS value FROM (SELECT explode(table1.value) AS _1 FROM table1) AS t0
 ------ end
 
 ------ Test: explode to complex enum
@@ -75,7 +75,7 @@ SELECT table1._1 AS key, sum(table1._2) AS value FROM table1 GROUP BY table1._1 
 ------ end
 
 ------ Test: limit after explode
-SELECT t0.value AS value FROM (SELECT explode(table1._2) AS value FROM table1) AS t0 LIMIT 5
+SELECT t0._1 AS value FROM (SELECT explode(table1._2) AS _1 FROM table1) AS t0 LIMIT 5
 ------ end
 
 ------ Test: limit after filter

--- a/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderByBigQueryGoldenSuite.golden
@@ -135,7 +135,7 @@ SELECT t0.value AS value FROM (SELECT table1.value AS value FROM table1 ORDER BY
 ------ end
 
 ------ Test: orderBy then select
-SELECT t0._2 AS value FROM (SELECT table1._1 AS _1, table1._2 AS _2 FROM table1 ORDER BY table1._1) AS t0
+SELECT table1._2 AS value FROM table1 ORDER BY table1._1
 ------ end
 
 ------ Test: orderBy tuple with struct

--- a/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetOrderBySparkSqlGoldenSuite.golden
@@ -135,7 +135,7 @@ SELECT t0.value AS value FROM (SELECT table1.value AS value FROM table1 ORDER BY
 ------ end
 
 ------ Test: orderBy then select
-SELECT t0._2 AS value FROM (SELECT table1._1 AS _1, table1._2 AS _2 FROM table1 ORDER BY table1._1) AS t0
+SELECT table1._2 AS value FROM table1 ORDER BY table1._1
 ------ end
 
 ------ Test: orderBy tuple with struct

--- a/tyda-sql/src/test/resources/golden/DatasetSubquerySparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetSubquerySparkSqlGoldenSuite.golden
@@ -15,7 +15,7 @@ SELECT table1.value AS value FROM table1 WHERE EXISTS (SELECT CAST(1 AS INT) AS 
 ------ end
 
 ------ Test: explode subquery
-SELECT explode(table1.value) AS _1, coalesce((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM (SELECT explode(table2.value) AS value FROM table2) AS t0), CAST(0 AS BIGINT)) AS _2 FROM table1
+SELECT explode(table1.value) AS _1, coalesce((SELECT CASE WHEN (count(1) <> 0) THEN count(CAST(1 AS INT)) END AS value FROM (SELECT explode(table2.value) AS _1 FROM table2) AS t0), CAST(0 AS BIGINT)) AS _2 FROM table1
 ------ end
 
 ------ Test: scalar subquery


### PR DESCRIPTION
In cases where we do an extra select on a subquery simply to reorganize the final output,
we can merge that select into the existing subquery.

The purpose of merging such selects is that it improves sql readability, and the benefit of having it happen automatically is that it allows us to more freely make use of subqueries in the SelectBuilder without impacting sql readability. As a case in point, we are able to simplify the selectExplodeFunction instead of almost repeating what happens in finalSelect.