### PR TITLE
Move distinct before select into DatasetBasicSuite

### DIFF
--- a/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
@@ -11,7 +11,7 @@ SELECT DISTINCT table1.value AS value FROM table1
 ------ end
 
 ------ Test: distinct before select
-SELECT t0.a AS value FROM (SELECT DISTINCT t1.a AS a, t1.b AS b FROM t1) AS t0
+SELECT t0.a AS value FROM (SELECT DISTINCT table1.a AS a, table1.b AS b FROM table1) AS t0
 ------ end
 
 ------ Test: distinct primitive

--- a/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
@@ -10,6 +10,10 @@ SELECT DISTINCT table1.value AS value FROM table1
 SELECT DISTINCT table1.value AS value FROM table1
 ------ end
 
+------ Test: distinct before select
+SELECT t0.a AS value FROM (SELECT DISTINCT t1.a AS a, t1.b AS b FROM t1) AS t0
+------ end
+
 ------ Test: distinct primitive
 SELECT DISTINCT table1.value AS value FROM table1
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
@@ -11,7 +11,7 @@ SELECT DISTINCT table1.value AS value FROM table1
 ------ end
 
 ------ Test: distinct before select
-SELECT t0.a AS value FROM (SELECT DISTINCT t1.a AS a, t1.b AS b FROM t1) AS t0
+SELECT t0.a AS value FROM (SELECT DISTINCT table1.a AS a, table1.b AS b FROM table1) AS t0
 ------ end
 
 ------ Test: distinct primitive

--- a/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
@@ -10,6 +10,10 @@ SELECT DISTINCT table1.value AS value FROM table1
 SELECT DISTINCT table1.value AS value FROM table1
 ------ end
 
+------ Test: distinct before select
+SELECT t0.a AS value FROM (SELECT DISTINCT t1.a AS a, t1.b AS b FROM t1) AS t0
+------ end
+
 ------ Test: distinct primitive
 SELECT DISTINCT table1.value AS value FROM table1
 ------ end

--- a/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
@@ -6,10 +6,6 @@ SELECT CASE WHEN (count(1) <> 0) THEN min(t0._2) END AS value FROM (SELECT table
 SELECT B'\x00\xca\xfe\xba\xbe' AS value
 ------ end
 
------- Test: distinct before select
-SELECT t0._1 AS value FROM (SELECT DISTINCT table1.a AS _1, table1.b AS _2 FROM table1) AS t0
------- end
-
 ------ Test: empty collection
 SELECT t0.a AS a, t0.b AS b, t0.c AS c, t0.d AS d FROM (SELECT CAST(0 AS INT) AS a, '' AS b, FALSE AS c, [CAST(0.0 AS FLOAT64)] AS d) AS t0 WHERE FALSE
 ------ end

--- a/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
@@ -6,10 +6,6 @@ SELECT CASE WHEN (count(1) <> 0) THEN min(t0._2) END AS value FROM (SELECT table
 SELECT t0.value AS value FROM VALUES (X'00cafebabe') AS t0(value)
 ------ end
 
------- Test: distinct before select
-SELECT t0._1 AS value FROM (SELECT DISTINCT table1.a AS _1, table1.b AS _2 FROM table1) AS t0
------- end
-
 ------ Test: empty collection
 SELECT t0.a AS a, t0.b AS b, t0.c AS c, t0.d AS d FROM VALUES (CAST(0 AS INT), '', FALSE, array(CAST(0.0 AS DOUBLE))) AS t0(a, b, c, d) WHERE FALSE
 ------ end

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/UnparserSuite.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/UnparserSuite.scala
@@ -55,8 +55,6 @@ abstract class UnparserSuite extends SqlGoldenTestSuite {
     ds.groupByKey(_.b).aggregateValue(min(_.a)).pairs.groupByKey(_._2).aggregateValue(min(_._1)).values
   }
 
-  testSql("distinct before select") { ds.select(_.a, _.b).distinct.select(_._1) }
-
   testSql("make struct") { ds.select(r => some(tuple(r.a, r.b, r.c))) }
 
   testSql("make named struct") { ds.select(r => some(namedTuple(a = r.a, b = r.b, c = r.c))) }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
@@ -95,6 +95,7 @@ trait DatasetBasicSuite extends DatasetSuite {
   test[TinyByte, TinyByte]("distinct primitive", _.distinct)
   test[Option[TinyByte], Option[TinyByte]]("distinct Option", _.distinct)
   test[List[TinyByte], List[TinyByte]]("distinct List", _.distinct)
+  test[(a: Boolean, b: Boolean), Boolean]("distinct before select", _.distinct.select(_.a))
 
   test[Int, Int, Int]("union", (left, right) => left.union(right))
   test[(Int, Int), (Int, Int), (Int, Int)]("union on struct", (left, right) => left.union(right))


### PR DESCRIPTION
Since the UnparserSuite does not actually run the queries, certain types of bugs can easily fall through if behavior is only pinned in the UnparserSuite