### PR TITLE
More specs to witness correct behavior of seq ops in relation to unnest

### DIFF
--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SelectBuilder.scala
@@ -298,7 +298,8 @@ private final case class SelectBuilder[T, R](
 
   private def containsSeqHigherOrderOp(expr: ExprNode[?]): Boolean =
     expr.exists {
-      case ExprNode.MapSeq(_, _) | ExprNode.FlattenSeq(_) | ExprNode.AggregateSeq(_, _, _) => true
+      case ExprNode.MapSeq(_, _) | ExprNode.FlattenSeq(_) | ExprNode.AggregateSeq(_, _, _) | ExprNode
+            .DistinctSeq(_) | ExprNode.FilterSeq(_, _) => true
       case _ => false
     }
 

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
@@ -90,6 +90,26 @@ SELECT array_agg(table1._2) AS value FROM table1 GROUP BY table1._1
 SELECT array_agg(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
 ------ end
 
+------ Test: concat and distinct
+SELECT array((SELECT DISTINCT c0 FROM unnest(array_concat_agg(table1._2)) AS c0)) AS value FROM table1 GROUP BY table1._1
+------ end
+
+------ Test: concat and exists
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (NOT (CAST(c0 AS INT) <= CAST(0 AS INT))) FROM unnest(t0.value) AS c0))) AS c1) AS value FROM (SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
+------ end
+
+------ Test: concat and filter
+SELECT array((SELECT c0 FROM unnest(array_concat_agg(table1._2)) AS c0 WHERE (NOT (CAST(c0 AS INT) <= CAST(1 AS INT))))) AS value FROM table1 GROUP BY table1._1
+------ end
+
+------ Test: concat and flatten
+SELECT array((SELECT c2 FROM unnest(array((SELECT struct([c0, c0] AS value) FROM unnest(t0.value) AS c0))) AS c1, unnest(c1.value) AS c2)) AS value FROM (SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
+------ end
+
+------ Test: concat and forall
+SELECT (SELECT coalesce(logical_and(c1), TRUE) FROM unnest(array((SELECT (NOT (CAST(c0 AS INT) <= CAST(0 AS INT))) FROM unnest(t0.value) AS c0))) AS c1) AS value FROM (SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
+------ end
+
 ------ Test: concat and map
 SELECT array((SELECT (CAST(c0 AS INT) + CAST(1 AS INT)) FROM unnest(t0.value) AS c0)) AS value FROM (SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesBigQueryGoldenSuite.golden
@@ -91,7 +91,7 @@ SELECT array_agg(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
 ------ end
 
 ------ Test: concat and distinct
-SELECT array((SELECT DISTINCT c0 FROM unnest(array_concat_agg(table1._2)) AS c0)) AS value FROM table1 GROUP BY table1._1
+SELECT array((SELECT DISTINCT c0 FROM unnest(t0.value) AS c0)) AS value FROM (SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
 ------ end
 
 ------ Test: concat and exists
@@ -99,7 +99,7 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (NOT (C
 ------ end
 
 ------ Test: concat and filter
-SELECT array((SELECT c0 FROM unnest(array_concat_agg(table1._2)) AS c0 WHERE (NOT (CAST(c0 AS INT) <= CAST(1 AS INT))))) AS value FROM table1 GROUP BY table1._1
+SELECT array((SELECT c0 FROM unnest(t0.value) AS c0 WHERE (NOT (CAST(c0 AS INT) <= CAST(1 AS INT))))) AS value FROM (SELECT array_concat_agg(table1._2) AS value FROM table1 GROUP BY table1._1) AS t0
 ------ end
 
 ------ Test: concat and flatten

--- a/tyda-sql/src/test/resources/golden/DatasetAggregatesSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetAggregatesSparkSqlGoldenSuite.golden
@@ -90,6 +90,26 @@ SELECT collect_list(table1._2) AS value FROM table1 GROUP BY table1._1
 SELECT collect_list(table1.value) AS value FROM table1 GROUP BY CAST(NULL AS INT)
 ------ end
 
+------ Test: concat and distinct
+SELECT array_distinct(flatten(collect_list(table1._2))) AS value FROM table1 GROUP BY table1._1
+------ end
+
+------ Test: concat and exists
+SELECT aggregate(transform(flatten(collect_list(table1._2)), c0 -> (NOT (CAST(c0 AS INT) <= CAST(0 AS INT)))), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM table1 GROUP BY table1._1
+------ end
+
+------ Test: concat and filter
+SELECT filter(flatten(collect_list(table1._2)), c0 -> (NOT (CAST(c0 AS INT) <= CAST(1 AS INT)))) AS value FROM table1 GROUP BY table1._1
+------ end
+
+------ Test: concat and flatten
+SELECT flatten(transform(flatten(collect_list(table1._2)), c0 -> array(c0, c0))) AS value FROM table1 GROUP BY table1._1
+------ end
+
+------ Test: concat and forall
+SELECT aggregate(transform(flatten(collect_list(table1._2)), c0 -> (NOT (CAST(c0 AS INT) <= CAST(0 AS INT)))), TRUE, (c1, c2) -> (c1 AND c2), c3 -> c3) AS value FROM table1 GROUP BY table1._1
+------ end
+
 ------ Test: concat and map
 SELECT transform(flatten(collect_list(table1._2)), c0 -> (CAST(c0 AS INT) + CAST(1 AS INT))) AS value FROM table1 GROUP BY table1._1
 ------ end

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetAggregatesSuite.scala
@@ -29,6 +29,7 @@ import com.choreograph.tyda.aggregates.minBy
 import com.choreograph.tyda.aggregates.reduce
 import com.choreograph.tyda.aggregates.sum
 import com.choreograph.tyda.functions.lit
+import com.choreograph.tyda.functions.seq
 import com.choreograph.tyda.functions.some
 import com.choreograph.tyda.functions.tuple
 import com.choreograph.tyda.functions.when
@@ -129,6 +130,26 @@ trait DatasetAggregatesSuite extends DatasetSuite {
   test[Pair, (TinyByte, Seq[Int])](
     "collect and map pairs",
     ds => ds.groupByKey(_._1).aggregateValue(collect(_._2)).pairs.select(_._1, _._2.map(_.cast[Int] + 1))
+  )
+  test[PairSeq, Seq[TinyByte]](
+    "concat and filter",
+    ds => ds.groupByKey(_._1).aggregateValue(concat(_._2)).values.select(_.filter(_.cast[Int] > 1))
+  )
+  test[PairSeq, Seq[TinyByte]](
+    "concat and flatten",
+    ds => ds.groupByKey(_._1).aggregateValue(concat(_._2)).values.select(_.map(x => seq(x, x)).flatten)
+  )
+  test[PairSeq, Seq[TinyByte]](
+    "concat and distinct",
+    ds => ds.groupByKey(_._1).aggregateValue(concat(_._2)).values.select(_.distinct)
+  )
+  test[PairSeq, Boolean](
+    "concat and forall",
+    ds => ds.groupByKey(_._1).aggregateValue(concat(_._2)).values.select(_.forall(_.cast[Int] > 0))
+  )
+  test[PairSeq, Boolean](
+    "concat and exists",
+    ds => ds.groupByKey(_._1).aggregateValue(concat(_._2)).values.select(_.exists(_.cast[Int] > 0))
   )
 
   test[Int, Int]("min whole row", ds => ds.groupByKey(_ => lit(1)).aggregateValue(min).values)


### PR DESCRIPTION
Fixes a bug in containsSeqHigherOrderOp. Without the fix, we will see errors such as

Failed:
- com.choreograph.tyda.bigquery.DatasetAggregatesSuiteBigQuery:
  * concat and filter - Implementation threw an exception during execution:
Aggregate function ARRAY_CONCAT_AGG not allowed in UNNEST at [1:37]

Reference explain:
Select1: x => fromRepr(x.filter(x1 => !(x1.cast[int] <= 1)))
    Select1: x => x.value
        Select1: x => (x._1.key, x._2.value)
            GroupedAggregate: x => (x._1), x => (concat(x._2))
                FromSeq: List()

Implementation explain:
SQL:
SELECT array((SELECT c0 FROM unnest(array_concat_agg(t0._2)) AS c0 WHERE (NOT (CAST(c0 AS INT) <= CAST(1 AS INT))))) AS value FROM (SELECT CAST(0 AS TINYINT) AS _1, [CAST(0 AS TINYINT)] AS _2) AS t0 WHERE FALSE GROUP BY t0._1

Query Plan:
Aggregate function ARRAY_CONCAT_AGG not allowed in UNNEST at [1:37]
