### PR TITLE
Add fallible cast from Decimal[P,S] to Long with HALF_UP rounding

### DIFF
--- a/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/ExprEvaluation.scala
+++ b/tyda-iterator/src/main/scala/com/choreograph/tyda/iterator/ExprEvaluation.scala
@@ -366,6 +366,7 @@ object ExprEvaluation {
       case cast @ CanTryCast.DecimalToDecimal() =>
         import cast.given
         v => Decimal(v.toBigDecimal)
+      case CanTryCast.DecimalToLong() => _.roundToLong
       case CanTryCast.StringToByte => checkedFromString[Byte]
       case CanTryCast.StringToShort => checkedFromString[Short]
       case CanTryCast.StringToInt => checkedFromString[Int]

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
@@ -258,8 +258,13 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
         createUdf(integral.quot, convert(lhs), convert(rhs), s"$integral.quot")(using lhs.codec, lhs.codec)
       case ExprNode.Cast(from, canCast) => convert(from).cast(catalystType(expr.codec))
       case ExprNode.TryCast(from, canTryCast) =>
-        val casted = tryCast(convert(from), expr.codec)
-        if from.codec == Codec.String then when(!convert(from).rlike("\\p{Cc}"), casted) else casted
+        val fromCol = convert(from)
+        val preRounded = (from.codec, canTryCast.codec) match {
+          case (Codec.Decimal(_, _), Codec.Long) => org.apache.spark.sql.functions.round(fromCol, 0)
+          case _ => fromCol
+        }
+        val casted = tryCast(preRounded, expr.codec)
+        if from.codec == Codec.String then when(!fromCol.rlike("\\p{Cc}"), casted) else casted
       case ExprNode.TimestampToMicros(inner) => unix_micros(convert(inner))
       case ExprNode.MicrosToTimestamp(inner) => timestamp_micros(convert(inner))
       case ExprNode.DurationToMicros(inner) => convert(inner)

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -644,8 +644,13 @@ private def cast(expr: SqlExpr, to: Codec[?], dialect: SqlDialect): SqlExpr =
   SqlExpr.Cast(expr, ToDdl.toDdlType(to, dialect.ddl))
 
 private def tryCast(expr: SqlExpr, from: Codec[?], to: Codec[?], dialect: SqlDialect): SqlExpr =
+  val preRounded = (from, to) match {
+    case (Codec.Decimal(_, _), Codec.Long) =>
+      SqlExpr.Function("round", Seq(expr, literalToSqlExpr(0, Codec.Int, dialect)))
+    case _ => expr
+  }
   SqlExpr
-    .Cast(dialect.tryCast, expr, ToDdl.toDdlType(to, dialect.ddl))
+    .Cast(dialect.tryCast, preRounded, ToDdl.toDdlType(to, dialect.ddl))
     .pipe(addControlCharCheckIfNeeded(expr, _, from, dialect))
     .pipe(addIntRangeCheckIfNeeded(_, to, dialect))
     .pipe(addDecimalRangeAndRoundingIfNeeded(_, to, dialect))

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -1426,11 +1426,11 @@ SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-999
 SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
------- Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 9] to Long is consistent with Decimal rounding
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 1] to Long is consistent with Decimal rounding
 SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
------- Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 9] to scala.Long
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 1] to scala.Long
 SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
@@ -1438,12 +1438,16 @@ SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ end
+
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to com.choreograph.tyda.Decimal$package.Decimal[19, 0]
 SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) AS value FROM t1
 ------ end
 
------- Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to Long is consistent with Decimal rounding
-SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to scala.Long
+SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[10, 3]
@@ -1452,10 +1456,6 @@ SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999' AS BI
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[38, 9]
 SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT)) AS value FROM t1
------- end
-
------- Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 9] to scala.Long
-SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[38, 9] to Long is consistent with Decimal rounding

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -1418,12 +1418,32 @@ SELECT CAST(div(t1._1, t1._2) AS BIGINT) AS value FROM t1
 SELECT CAST(div(t1._1, t1._2) AS INT) AS value FROM t1
 ------ end
 
------- Test: try cast Decimal to Long is consistent with Decimal rounding
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 0] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 0] to scala.Long
+SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 9] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 9] to scala.Long
+SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 0] to Long is consistent with Decimal rounding
 SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to com.choreograph.tyda.Decimal$package.Decimal[19, 0]
 SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[10, 3]
@@ -1432,6 +1452,14 @@ SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999' AS BI
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[38, 9]
 SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT)) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 9] to scala.Long
+SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[38, 9] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS BIGDECIMAL) >= CAST('-99999999999999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS BIGDECIMAL) <= CAST('99999999999999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS BIGDECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[38, 9] to scala.Long

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -278,6 +278,10 @@ SELECT CASE WHEN (NOT (t1._1 <= CAST(0 AS INT))) THEN t1._1 WHEN (NOT (t1._2 <= 
 SELECT CASE WHEN t1._1 THEN t1._2 ELSE t1._3 END AS value FROM t1
 ------ end
 
+------ Test: cast Long to Decimal[38,9] then tryCast to Long roundtrip
+SELECT SAFE_CAST(round(CAST(t1.value AS DECIMAL), CAST(0 AS INT)) AS BIGINT) AS value FROM t1
+------ end
+
 ------ Test: cast com.choreograph.tyda.Decimal$package.Decimal[10, 0] to com.choreograph.tyda.Decimal$package.Decimal[20, 5]
 SELECT CAST(t1.value AS DECIMAL) AS value FROM t1
 ------ end
@@ -1414,6 +1418,10 @@ SELECT CAST(div(t1._1, t1._2) AS BIGINT) AS value FROM t1
 SELECT CAST(div(t1._1, t1._2) AS INT) AS value FROM t1
 ------ end
 
+------ Test: try cast Decimal to Long is consistent with Decimal rounding
+SELECT CASE WHEN (round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE SAFE_CAST(round(round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ end
+
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to com.choreograph.tyda.Decimal$package.Decimal[19, 0]
 SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('9999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(0 AS INT)) AS value FROM t1
 ------ end
@@ -1424,6 +1432,10 @@ SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-9999999' AS BI
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[38, 9]
 SELECT round(CASE WHEN ((SAFE_CAST(t1.value AS DECIMAL) >= CAST('-99999999999999999999999999999' AS BIGDECIMAL)) AND (SAFE_CAST(t1.value AS DECIMAL) <= CAST('99999999999999999999999999999' AS BIGDECIMAL))) THEN SAFE_CAST(t1.value AS DECIMAL) END, CAST(9 AS INT)) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[38, 9] to scala.Long
+SELECT SAFE_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
 ------ Test: try cast java.lang.String to scala.Byte

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -1430,11 +1430,11 @@ SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(18,0)) IS NULL) THEN CAST(NULL AS
 SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
------- Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 9] to Long is consistent with Decimal rounding
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 1] to Long is consistent with Decimal rounding
 SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(18,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(18,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
------- Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 9] to scala.Long
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 1] to scala.Long
 SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
@@ -1442,12 +1442,16 @@ SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(19,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(19,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(19,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(19,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ end
+
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to com.choreograph.tyda.Decimal$package.Decimal[19, 0]
 SELECT TRY_CAST(t1.value AS DECIMAL(19,0)) AS value FROM t1
 ------ end
 
------- Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to Long is consistent with Decimal rounding
-SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(19,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(19,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to scala.Long
+SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[10, 3]
@@ -1456,10 +1460,6 @@ SELECT TRY_CAST(t1.value AS DECIMAL(10,3)) AS value FROM t1
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[38, 9]
 SELECT TRY_CAST(t1.value AS DECIMAL(38,9)) AS value FROM t1
------- end
-
------- Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 9] to scala.Long
-SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[38, 9] to Long is consistent with Decimal rounding

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -1422,12 +1422,32 @@ SELECT CAST(div(t1._1, t1._2) AS BIGINT) AS value FROM t1
 SELECT CAST(div(t1._1, t1._2) AS INT) AS value FROM t1
 ------ end
 
------- Test: try cast Decimal to Long is consistent with Decimal rounding
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 0] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(18,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(18,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 0] to scala.Long
+SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 9] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(18,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(18,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[18, 9] to scala.Long
+SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 0] to Long is consistent with Decimal rounding
 SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(19,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(19,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to com.choreograph.tyda.Decimal$package.Decimal[19, 0]
 SELECT TRY_CAST(t1.value AS DECIMAL(19,0)) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(19,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(19,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[10, 3]
@@ -1436,6 +1456,14 @@ SELECT TRY_CAST(t1.value AS DECIMAL(10,3)) AS value FROM t1
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[38, 9]
 SELECT TRY_CAST(t1.value AS DECIMAL(38,9)) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 9] to scala.Long
+SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[38, 9] to Long is consistent with Decimal rounding
+SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(38,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(38,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
 ------ end
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[38, 9] to scala.Long

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -278,6 +278,10 @@ SELECT CASE WHEN (NOT (t1._1 <= CAST(0 AS INT))) THEN t1._1 WHEN (NOT (t1._2 <= 
 SELECT CASE WHEN t1._1 THEN t1._2 ELSE t1._3 END AS value FROM t1
 ------ end
 
+------ Test: cast Long to Decimal[38,9] then tryCast to Long roundtrip
+SELECT TRY_CAST(round(CAST(t1.value AS DECIMAL(38,9)), CAST(0 AS INT)) AS BIGINT) AS value FROM t1
+------ end
+
 ------ Test: cast com.choreograph.tyda.Decimal$package.Decimal[10, 0] to com.choreograph.tyda.Decimal$package.Decimal[20, 5]
 SELECT CAST(t1.value AS DECIMAL(20,5)) AS value FROM t1
 ------ end
@@ -1418,6 +1422,10 @@ SELECT CAST(div(t1._1, t1._2) AS BIGINT) AS value FROM t1
 SELECT CAST(div(t1._1, t1._2) AS INT) AS value FROM t1
 ------ end
 
+------ Test: try cast Decimal to Long is consistent with Decimal rounding
+SELECT CASE WHEN (TRY_CAST(t1.value AS DECIMAL(19,0)) IS NULL) THEN CAST(NULL AS BIGINT) ELSE TRY_CAST(round(TRY_CAST(t1.value AS DECIMAL(19,0)), CAST(0 AS INT)) AS BIGINT) END AS value FROM t1
+------ end
+
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 1] to com.choreograph.tyda.Decimal$package.Decimal[19, 0]
 SELECT TRY_CAST(t1.value AS DECIMAL(19,0)) AS value FROM t1
 ------ end
@@ -1428,6 +1436,10 @@ SELECT TRY_CAST(t1.value AS DECIMAL(10,3)) AS value FROM t1
 
 ------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[19, 3] to com.choreograph.tyda.Decimal$package.Decimal[38, 9]
 SELECT TRY_CAST(t1.value AS DECIMAL(38,9)) AS value FROM t1
+------ end
+
+------ Test: try cast com.choreograph.tyda.Decimal$package.Decimal[38, 9] to scala.Long
+SELECT TRY_CAST(round(t1.value, CAST(0 AS INT)) AS BIGINT) AS value FROM t1
 ------ end
 
 ------ Test: try cast java.lang.String to scala.Byte

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -1182,6 +1182,19 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testTryCast[Decimal[19, 1], Decimal[19, 0]](v => Decimal[19, 0](v.toBigDecimal))
   testTryCast[Decimal[19, 3], Decimal[10, 3]](v => Decimal[10, 3](v.toBigDecimal))
 
+  testTryCast[Decimal[38, 9], Long](_.roundToLong)
+  testHasSameBehavior[Decimal[19, 3], Option[Long]](
+    "try cast Decimal to Long is consistent with Decimal rounding",
+    _.tryCast[Decimal[19, 0]].flatMap(_.tryCast[Long]),
+    _.roundToLong
+  )
+
+  testHasSameBehavior[Long, Option[Long]](
+    "cast Long to Decimal[38,9] then tryCast to Long roundtrip",
+    _.cast[Decimal[38, 9]].tryCast[Long],
+    Some(_)
+  )
+
   def testLiteralCreation[T: ClassTag: Arbitrary: Codec: TypeName](fixed: T) =
     testHasSameBehavior[T, T](
       s"create literal ${fixed.toString} ${TypeName.name[T]}",

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -1183,11 +1183,28 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testTryCast[Decimal[19, 3], Decimal[10, 3]](v => Decimal[10, 3](v.toBigDecimal))
 
   testTryCast[Decimal[38, 9], Long](_.roundToLong)
-  testHasSameBehavior[Decimal[19, 3], Option[Long]](
-    "try cast Decimal to Long is consistent with Decimal rounding",
-    _.tryCast[Decimal[19, 0]].flatMap(_.tryCast[Long]),
-    _.roundToLong
-  )
+  testTryCast[Decimal[19, 9], Long](_.roundToLong)
+  testTryCast[Decimal[18, 9], Long](_.roundToLong)
+  testTryCast[Decimal[18, 0], Long](x => Some(x.toLong))
+
+  def testDecimalToLongRounding[P <: Int, S <: Int](using
+      Codec[Decimal[P, S]],
+      Arbitrary[Decimal[P, S]],
+      TypeName[Decimal[P, S]],
+      CanTryCast[Decimal[P, S], Decimal[P, 0]],
+      CanTryCast[Decimal[P, 0], Long]
+  ) =
+    testHasSameBehavior[Decimal[P, S], Option[Long]](
+      s"try cast ${TypeName.name[Decimal[P, S]]} to Long is consistent with Decimal rounding",
+      _.tryCast[Decimal[P, 0]].flatMap(_.tryCast[Long]),
+      _.roundToLong
+    )
+
+  testDecimalToLongRounding[38, 9]
+  testDecimalToLongRounding[19, 3]
+  testDecimalToLongRounding[19, 0]
+  testDecimalToLongRounding[18, 9]
+  testDecimalToLongRounding[18, 0]
 
   testHasSameBehavior[Long, Option[Long]](
     "cast Long to Decimal[38,9] then tryCast to Long roundtrip",

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -1183,8 +1183,8 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testTryCast[Decimal[19, 3], Decimal[10, 3]](v => Decimal[10, 3](v.toBigDecimal))
 
   testTryCast[Decimal[38, 9], Long](_.roundToLong)
-  testTryCast[Decimal[19, 9], Long](_.roundToLong)
-  testTryCast[Decimal[18, 9], Long](_.roundToLong)
+  testTryCast[Decimal[19, 1], Long](_.roundToLong)
+  testTryCast[Decimal[18, 1], Long](_.roundToLong)
   testTryCast[Decimal[18, 0], Long](x => Some(x.toLong))
 
   def testDecimalToLongRounding[P <: Int, S <: Int](using
@@ -1201,9 +1201,9 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
     )
 
   testDecimalToLongRounding[38, 9]
-  testDecimalToLongRounding[19, 3]
+  testDecimalToLongRounding[19, 1]
   testDecimalToLongRounding[19, 0]
-  testDecimalToLongRounding[18, 9]
+  testDecimalToLongRounding[18, 1]
   testDecimalToLongRounding[18, 0]
 
   testHasSameBehavior[Long, Option[Long]](

--- a/tyda/src/main/scala/com/choreograph/tyda/CanTryCast.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/CanTryCast.scala
@@ -28,6 +28,8 @@ object CanTryCast {
       val valid: Decimal.Valid[P2, S2]
   ) extends CanTryCast[Decimal[P1, S1], Decimal[P2, S2]]
 
+  private[tyda] final case class DecimalToLong[P <: Int, S <: Int]() extends CanTryCast[Decimal[P, S], Long]
+
   private[tyda] case object StringToByte extends CanTryCast[String, Byte]
   private[tyda] case object StringToShort extends CanTryCast[String, Short]
   private[tyda] case object StringToInt extends CanTryCast[String, Int]
@@ -54,6 +56,8 @@ object CanTryCast {
   given decimalToDecimal[P1 <: Int, S1 <: Int, P2 <: Int, S2 <: Int](using
       valid: Decimal.Valid[P2, S2]
   ): CanTryCast[Decimal[P1, S1], Decimal[P2, S2]] = DecimalToDecimal()
+
+  given decimalToLong[P <: Int, S <: Int]: CanTryCast[Decimal[P, S], Long] = DecimalToLong()
 
   given stringToByte: CanTryCast[String, Byte] = StringToByte
   given stringToShort: CanTryCast[String, Short] = StringToShort


### PR DESCRIPTION
The cast returns None when the rounded value falls outside the Long range; otherwise rounds the fractional part using HALF_UP (e.g. 1.5 -> 2, -1.5 -> -2).

Three approaches were considered:

1. Decimal -> Double -> Long (two steps via existing CanCast[Decimal, Double] plus a new CanTryCast[Double, Long]). Rejected because Double has only ~15-17 significant digits, so values with more integer digits than that (which Decimal[38,9] can have) produce incorrect Long results or spurious None due to rounding in the intermediate Double representation.

2. Decimal -> Decimal[18,0] -> Long (tryCast to a scale-0 decimal small enough that a subsequent cast to Long is infallible, since Decimal[18,0] max = 10^18-1 < Long.MaxValue). Rejected because it silently returns None for the ~8.2e18 valid Long values in the range [10^18, Long.MaxValue], making it strictly worse in both verbosity and range coverage than a direct cast.

3. Direct CanTryCast[Decimal[P,S], Long] (this implementation). Uses exact BigDecimal arithmetic throughout, covering the full Long range. Is consistent with first doing a tryCast to Decimal[P,0].