### PR TITLE
Support Expr[T].in(T*) in expr api

### DIFF
--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/ArrayContains.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/ArrayContains.scala
@@ -19,14 +19,27 @@ private[tyda] object ArrayContains {
     }
   }
 
-  // Matches trees that does a contains check on a array that can we rewritten into a `In` expression in SQL.
+  private object ArrayAny {
+    def unapply[U](expr: ExprNode[U]): Option[ExprNode[?]] =
+      expr match {
+        case ExprNode.AggregateSeq(arr, ExprNode.Literal(false, _), PrimitiveAggregate.BoolOr()) => Some(arr)
+        case _ => None
+      }
+  }
+
+  private object MapEq {
+    def unapply[U](expr: ExprNode[U]): Option[Result[?]] =
+      expr match {
+        case ExprNode.MapSeq(arr, EqPredicate(elem)) => Some(Result(arr, elem))
+        case _ => None
+      }
+  }
+
+  // Matches trees that do a contains check on a array that can we rewritten into a `In` expression in SQL.
   def unapply[U](expr: ExprNode[U]): Option[Result[?]] =
     expr match {
-      case ExprNode.AggregateSeq(
-            ExprNode.MapSeq(arr, EqPredicate(elem)),
-            ExprNode.Literal(false, _),
-            PrimitiveAggregate.BoolOr()
-          ) => Some(Result(arr, elem))
+      case ArrayAny(MapEq(res)) => Some(res)
+      case ArrayAny(ToFromRepr(MapEq(res))) => Some(res)
       case _ => None
     }
 }

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/ArrayContains.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/ArrayContains.scala
@@ -1,0 +1,32 @@
+package com.choreograph.tyda.rewrite
+
+import com.choreograph.tyda.CompiledExpr
+import com.choreograph.tyda.ExprNode
+import com.choreograph.tyda.PrimitiveAggregate
+
+private[tyda] object ArrayContains {
+  final case class Result[T](arr: ExprNode[Seq[T]], element: ExprNode[T])
+
+  private object EqPredicate {
+    def unapply[T, R](compiled: CompiledExpr[T, R]): Option[ExprNode[T]] = {
+      val arg = compiled.arg
+      def isIndependentOfArg(e: ExprNode[?]): Boolean = e.forall(_ != arg)
+      compiled.expr match {
+        case ExprNode.Equals(`arg`, e) if isIndependentOfArg(e) => Some(e)
+        case ExprNode.Equals(e, `arg`) if isIndependentOfArg(e) => Some(e)
+        case _ => None
+      }
+    }
+  }
+
+  // Matches trees that does a contains check on a array that can we rewritten into a `In` expression in SQL.
+  def unapply[U](expr: ExprNode[U]): Option[Result[?]] =
+    expr match {
+      case ExprNode.AggregateSeq(
+            ExprNode.MapSeq(arr, EqPredicate(elem)),
+            ExprNode.Literal(false, _),
+            PrimitiveAggregate.BoolOr()
+          ) => Some(Result(arr, elem))
+      case _ => None
+    }
+}

--- a/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/ArrayContains.scala
+++ b/tyda-rewrite/src/main/scala/com/choreograph/tyda/rewrite/ArrayContains.scala
@@ -12,6 +12,7 @@ private[tyda] object ArrayContains {
       val arg = compiled.arg
       def isIndependentOfArg(e: ExprNode[?]): Boolean = e.forall(_ != arg)
       compiled.expr match {
+        case ExprNode.Equals(Nullable(_), Nullable(_)) => None
         case ExprNode.Equals(`arg`, e) if isIndependentOfArg(e) => Some(e)
         case ExprNode.Equals(e, `arg`) if isIndependentOfArg(e) => Some(e)
         case _ => None

--- a/tyda-rewrite/src/test/scala/com/choreograph/tyda/rewrite/ArrayContainsSpec.scala
+++ b/tyda-rewrite/src/test/scala/com/choreograph/tyda/rewrite/ArrayContainsSpec.scala
@@ -1,0 +1,35 @@
+package com.choreograph.tyda.rewrite
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.choreograph.tyda.ExprNode
+
+class ArrayContainsSpec extends AnyFunSuite {
+
+  test("ArrayContains should match Expr[Seq[T]].contains") {
+    val rNode = ExprNode.Reference[Seq[Int]]()
+    val contains = rNode.contains(1)
+    assert(contains match {
+      case ArrayContains(`rNode`, ExprNode.Literal(1, _)) => true
+      case _ => false
+    })
+  }
+
+  test("ArrayContains should match Expr[Vector[T]].contains") {
+    val rNode = ExprNode.Reference[Vector[Int]]()
+    val contains = rNode.contains(1)
+    assert(contains match {
+      case ArrayContains(ExprNode.ToRepr(`rNode`, _), ExprNode.Literal(1, _)) => true
+      case _ => false
+    })
+  }
+
+  test("ArrayContains should match Expr[T].in") {
+    val rNode = ExprNode.Reference[Int]()
+    val contains = rNode.in(1, 2, 3)
+    assert(contains match {
+      case ArrayContains(ExprNode.MakeSeq(_, _), `rNode`) => true
+      case _ => false
+    })
+  }
+}

--- a/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
+++ b/tyda-spark/src/main/scala/com/choreograph/tyda/spark/ExprOnSpark.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.aggregate
 import org.apache.spark.sql.functions.array
+import org.apache.spark.sql.functions.array_contains
 import org.apache.spark.sql.functions.array_distinct
 import org.apache.spark.sql.functions.base64
 import org.apache.spark.sql.functions.call_function
@@ -45,6 +46,7 @@ import com.choreograph.tyda.Errors
 import com.choreograph.tyda.ExprNode
 import com.choreograph.tyda.Forbidden
 import com.choreograph.tyda.rewrite.ArrayCodec
+import com.choreograph.tyda.rewrite.ArrayContains
 import com.choreograph.tyda.rewrite.CheckArrayIndexPositive
 import com.choreograph.tyda.rewrite.IsNone
 import com.choreograph.tyda.rewrite.Nullable
@@ -131,6 +133,8 @@ private class ExprOnSpark[T](cfs: Map[ExprNode.Reference[?], ColumnFactory[?]]) 
 
   def convert(expr: ExprNode[?])(using spark: SparkSession): Column =
     expr match {
+      case ArrayContains(ExprNode.MakeSeq(values, _), element) => convert(element).isin(values.map(convert)*)
+      case ArrayContains(arr, element) => array_contains(convert(arr), convert(element))
       case ExprNode.Select(ref: ExprNode.Reference[?], name) => cfFromRef(ref).column(name)
       case ExprNode.Select(p, name) => convert(p)(name)
       case ref @ ExprNode.Reference(_, _) => cfFromRef(ref).row

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -336,7 +336,7 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
           elemExpr <- inner(element)
         } yield dialect.arrayContains match {
           case SqlDialect.ArrayContains.InUnnest =>
-            SqlExpr.In(elemExpr, Seq(SqlExpr.Function("unnest", Seq(arrExpr))))
+            SqlExpr.InSubquery(elemExpr, SqlExpr.Function("unnest", Seq(arrExpr)))
           case SqlDialect.ArrayContains.Function(arrayContains) =>
             SqlExpr.Function(arrayContains, Seq(arrExpr, elemExpr))
         }

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ExprUnparser.scala
@@ -21,6 +21,7 @@ import com.choreograph.tyda.PrimitiveAggregate
 import com.choreograph.tyda.SumMagnet
 import com.choreograph.tyda.TreeApi.Continue
 import com.choreograph.tyda.rewrite.ArrayCodec
+import com.choreograph.tyda.rewrite.ArrayContains
 import com.choreograph.tyda.rewrite.CollectionOrNullableCollectionCodec
 import com.choreograph.tyda.rewrite.IsNone
 import com.choreograph.tyda.rewrite.NotNullNonEmptyDummyLiteral
@@ -325,6 +326,19 @@ private def exprToSqlExpr[T](fullExpr: ExprNode[T], args: UnparserArgs): Result[
             SqlExpr.Function(makeArray, Seq(SqlExpr.Subquery(query)))
           case SqlDialect.ArrayHigherOrderFunctions.Lambda(filter = filterFunction) =>
             SqlExpr.Function(filterFunction, Seq(arr, SqlExpr.LambdaFunction(arg, predExpr)))
+        }
+      case ArrayContains(ExprNode.MakeSeq(values, _), element) => for {
+          valuesExpr <- values.map(inner).sequence
+          elemExpr <- inner(element)
+        } yield SqlExpr.In(elemExpr, valuesExpr)
+      case ArrayContains(arr, element) => for {
+          arrExpr <- inner(arr)
+          elemExpr <- inner(element)
+        } yield dialect.arrayContains match {
+          case SqlDialect.ArrayContains.InUnnest =>
+            SqlExpr.In(elemExpr, Seq(SqlExpr.Function("unnest", Seq(arrExpr))))
+          case SqlDialect.ArrayContains.Function(arrayContains) =>
+            SqlExpr.Function(arrayContains, Seq(arrExpr, elemExpr))
         }
       case ExprNode.AggregateSeq(operand, onEmpty, primitive) => dialect.arrayHigherOrderFunctions match {
           case SqlDialect.ArrayHigherOrderFunctions.Subquery(makeArray, unnest) => for {

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/SqlDialect.scala
@@ -25,6 +25,7 @@ final case class SqlDialect(
     arrayDistinct: SqlDialect.ArrayDistinct,
     arrayConcat: String,
     arrayConcatAgg: SqlDialect.ArrayConcatAgg,
+    arrayContains: SqlDialect.ArrayContains,
     arrayElement: SqlDialect.ArrayElement,
     arrayJoin: String,
     arraySize: String,
@@ -302,6 +303,11 @@ object SqlDialect {
     case NaNIsLargest
   }
 
+  enum ArrayContains {
+    case Function(name: String)
+    case InUnnest
+  }
+
   enum ArrayHigherOrderFunctions {
 
     /** Supports higher order functions using lambda syntax. e.g.
@@ -419,6 +425,7 @@ object SqlDialect {
     arrayDistinct = ArrayDistinct.Subquery("array", "unnest"),
     arrayConcat = "array_concat",
     arrayConcatAgg = ArrayConcatAgg.Function("array_concat_agg"),
+    arrayContains = ArrayContains.InUnnest,
     arrayElement = ArrayElement.Braces,
     arrayJoin = "array_to_string",
     arraySize = "array_length",
@@ -493,6 +500,7 @@ object SqlDialect {
     arrayDistinct = ArrayDistinct.Function("array_distinct"),
     arrayConcat = "concat",
     arrayConcatAgg = ArrayConcatAgg.FlattenCollect("flatten"),
+    arrayContains = ArrayContains.Function("array_contains"),
     arrayElement = ArrayElement.Function("element_at"),
     arrayJoin = "array_join",
     arraySize = "size",

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlExpr.scala
@@ -19,6 +19,8 @@ private[sql] enum SqlExpr {
   case Cast(variant: String, expr: SqlExpr, to: DdlType)
   case Subquery(query: Query)
   case Exists(query: Query)
+  case InSubquery(expr: SqlExpr, subquery: SqlExpr)
+  case In(expr: SqlExpr, values: Seq[SqlExpr])
   case LambdaFunction(args: Seq[SqlExpr], body: SqlExpr)
 }
 

--- a/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
+++ b/tyda-sql/src/main/scala/com/choreograph/tyda/sql/ast/SqlWriter.scala
@@ -70,6 +70,8 @@ private[tyda] final case class SqlWriter(writer: Writer) {
       case SqlExpr.Cast(variant, e, toType) => writeSql"$variant($e AS $toType)"
       case SqlExpr.Subquery(query) => writeSql1"($query)"
       case SqlExpr.Exists(query) => writeSql1"EXISTS ($query)"
+      case SqlExpr.InSubquery(expr, subquery) => writeSql"$expr IN $subquery"
+      case SqlExpr.In(expr, values) => writeSql"$expr IN ($values)"
       case SqlExpr.LambdaFunction(args, body) => args match {
           case Seq(arg) => writeSql"$arg -> $body"
           case args => writeSql"($args) -> $body"

--- a/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
@@ -1,5 +1,5 @@
 ------ Test: collect subquery
-SELECT table1.value AS value FROM table1 WHERE table1.value IN (unnest(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(table2.value) END AS value FROM table2), CAST([] AS ARRAY<TINYINT>))))
+SELECT table1.value AS value FROM table1 WHERE table1.value IN unnest(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(table2.value) END AS value FROM table2), CAST([] AS ARRAY<TINYINT>)))
 ------ end
 
 ------ Test: count subquery

--- a/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetSubqueryBigQueryGoldenSuite.golden
@@ -1,5 +1,5 @@
 ------ Test: collect subquery
-SELECT table1.value AS value FROM table1 WHERE (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = table1.value) FROM unnest(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(table2.value) END AS value FROM table2), CAST([] AS ARRAY<TINYINT>))) AS c0))) AS c1)
+SELECT table1.value AS value FROM table1 WHERE table1.value IN (unnest(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN array_agg(table2.value) END AS value FROM table2), CAST([] AS ARRAY<TINYINT>))))
 ------ end
 
 ------ Test: count subquery

--- a/tyda-sql/src/test/resources/golden/DatasetSubquerySparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetSubquerySparkSqlGoldenSuite.golden
@@ -1,5 +1,5 @@
 ------ Test: collect subquery
-SELECT table1.value AS value FROM table1 WHERE aggregate(transform(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN collect_list(table2.value) END AS value FROM table2), CAST(array() AS ARRAY<TINYINT>)), c0 -> (c0 = table1.value)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3)
+SELECT table1.value AS value FROM table1 WHERE array_contains(coalesce((SELECT CASE WHEN (count(1) <> 0) THEN collect_list(table2.value) END AS value FROM table2), CAST(array() AS ARRAY<TINYINT>)), table1.value)
 ------ end
 
 ------ Test: count subquery

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -906,10 +906,6 @@ SELECT t1._1 IN (t1._2, CASE WHEN t1._4 THEN t1._1 ELSE t1._3 END) AS value FROM
 SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
 ------ end
 
------- Test: in literals match
-SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
------- end
-
 ------ Test: in match struct
 SELECT t1._1 IN (t1._2, t1._3) AS value FROM t1
 ------ end
@@ -1355,7 +1351,7 @@ SELECT TRUE IN unnest(t1.value) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
-SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
+SELECT t1._2 IN unnest(t1._1) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
@@ -1363,7 +1359,7 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (((TRUE
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
-SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
+SELECT t1._2 IN unnest(t1._1) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
@@ -1371,11 +1367,11 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (TRUE A
 ------ end
 
 ------ Test: seq contains scala.Boolean
-SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
+SELECT t1._2 IN unnest(t1._1) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
-SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
+SELECT t1._2 IN unnest(t1._1) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
@@ -1387,7 +1383,7 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT CASE WH
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Boolean]
-SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
+SELECT t1._2 IN unnest(t1._1) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -899,6 +899,10 @@ SELECT t1._1 AS _1, t1._2 AS _2 FROM t1
 ------ end
 
 ------ Test: in exprs
+SELECT t1._1 IN (t1._2, CASE WHEN t1._4 THEN t1._1 ELSE t1._3 END) AS value FROM t1
+------ end
+
+------ Test: in literals
 SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
 ------ end
 
@@ -906,12 +910,8 @@ SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FRO
 SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
 ------ end
 
------- Test: in literals no match
-SELECT t1.value IN (CAST(10 AS INT), CAST(20 AS INT), CAST(30 AS INT)) AS value FROM t1
------- end
-
------- Test: in strings
-SELECT t1.value IN ('foo', 'bar', 'baz') AS value FROM t1
+------ Test: in match struct
+SELECT t1._1 IN (t1._2, t1._3) AS value FROM t1
 ------ end
 
 ------ Test: isNaN for Double
@@ -1351,7 +1351,7 @@ SELECT (t1.value = TRUE) AS value FROM t1
 ------ end
 
 ------ Test: seq contains
-SELECT TRUE IN (unnest(t1.value)) AS value FROM t1
+SELECT TRUE IN unnest(t1.value) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -1383,7 +1383,7 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT CASE WH
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Boolean]
-SELECT t1._2 IN unnest(t1._1) AS value FROM t1
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 IS NOT DISTINCT FROM t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -898,6 +898,22 @@ SELECT CAST(NULL AS BOOL) FROM t1
 SELECT t1._1 AS _1, t1._2 AS _2 FROM t1
 ------ end
 
+------ Test: in exprs
+SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
+------ end
+
+------ Test: in literals match
+SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
+------ end
+
+------ Test: in literals no match
+SELECT t1.value IN (CAST(10 AS INT), CAST(20 AS INT), CAST(30 AS INT)) AS value FROM t1
+------ end
+
+------ Test: in strings
+SELECT t1.value IN ('foo', 'bar', 'baz') AS value FROM t1
+------ end
+
 ------ Test: isNaN for Double
 SELECT is_nan(t1.value) AS value FROM t1
 ------ end
@@ -1335,11 +1351,11 @@ SELECT (t1.value = TRUE) AS value FROM t1
 ------ end
 
 ------ Test: seq contains
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = TRUE) FROM unnest(t1.value) AS c0))) AS c1) AS value FROM t1
+SELECT TRUE IN (unnest(t1.value)) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
@@ -1347,7 +1363,7 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (((TRUE
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
@@ -1355,11 +1371,11 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (TRUE A
 ------ end
 
 ------ Test: seq contains scala.Boolean
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
@@ -1371,7 +1387,7 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT CASE WH
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Boolean]
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 IS NOT DISTINCT FROM t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+SELECT t1._2 IN (unnest(t1._1)) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -899,6 +899,10 @@ SELECT t1._1 AS _1, t1._2 AS _2 FROM t1
 ------ end
 
 ------ Test: in exprs
+SELECT t1._1 IN (t1._2, CASE WHEN t1._4 THEN t1._1 ELSE t1._3 END) AS value FROM t1
+------ end
+
+------ Test: in literals
 SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
 ------ end
 
@@ -906,12 +910,8 @@ SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FRO
 SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
 ------ end
 
------- Test: in literals no match
-SELECT t1.value IN (CAST(10 AS INT), CAST(20 AS INT), CAST(30 AS INT)) AS value FROM t1
------- end
-
------- Test: in strings
-SELECT t1.value IN ('foo', 'bar', 'baz') AS value FROM t1
+------ Test: in match struct
+SELECT t1._1 IN (t1._2, t1._3) AS value FROM t1
 ------ end
 
 ------ Test: isNaN for Double

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -898,6 +898,22 @@ SELECT CAST(NULL AS void) FROM t1
 SELECT t1._1 AS _1, t1._2 AS _2 FROM t1
 ------ end
 
+------ Test: in exprs
+SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
+------ end
+
+------ Test: in literals match
+SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
+------ end
+
+------ Test: in literals no match
+SELECT t1.value IN (CAST(10 AS INT), CAST(20 AS INT), CAST(30 AS INT)) AS value FROM t1
+------ end
+
+------ Test: in strings
+SELECT t1.value IN ('foo', 'bar', 'baz') AS value FROM t1
+------ end
+
 ------ Test: isNaN for Double
 SELECT isnan(t1.value) AS value FROM t1
 ------ end
@@ -1335,79 +1351,79 @@ SELECT (t1.value = TRUE) AS value FROM t1
 ------ end
 
 ------ Test: seq contains
-SELECT aggregate(transform(t1.value, c0 -> (c0 = TRUE)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1.value, TRUE) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Boolean
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
-SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Boolean]
-SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Option[scala.Boolean]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.collection.immutable.Seq[scala.Boolean]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[scala.Boolean]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[scala.Option[scala.Boolean]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Boolean]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq exists

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -906,10 +906,6 @@ SELECT t1._1 IN (t1._2, CASE WHEN t1._4 THEN t1._1 ELSE t1._3 END) AS value FROM
 SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
 ------ end
 
------- Test: in literals match
-SELECT t1.value IN (CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS value FROM t1
------- end
-
 ------ Test: in match struct
 SELECT t1._1 IN (t1._2, t1._3) AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -1379,23 +1379,23 @@ SELECT array_contains(t1._1, t1._2) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
-SELECT array_contains(t1._1, t1._2) AS value FROM t1
+SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Boolean]
-SELECT array_contains(t1._1, t1._2) AS value FROM t1
+SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Option[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]]
-SELECT array_contains(t1._1, t1._2) AS value FROM t1
+SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Option[scala.Boolean]]
-SELECT array_contains(t1._1, t1._2) AS value FROM t1
+SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.collection.immutable.Seq[scala.Boolean]]
-SELECT array_contains(t1._1, t1._2) AS value FROM t1
+SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -446,6 +446,22 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   )
   testHasSameBehavior[Seq[Int], Boolean]("seq exists", _.exists(_ < 0), _.exists(_ < 0))
   testHasSameBehavior[Seq[Boolean], Boolean]("seq contains", _.contains(true), _.contains(elem = true))
+  testHasSameBehavior[Int, Boolean]("in literals match", _.in(1, 2, 3), v => Seq(1, 2, 3).contains(v))
+  testHasSameBehavior[Int, Boolean](
+    "in literals no match",
+    _.in(10, 20, 30),
+    v => Seq(10, 20, 30).contains(v)
+  )
+  testHasSameBehavior[Int, Boolean](
+    "in exprs",
+    i => i.in(lit(1), lit(2), lit(3)),
+    v => Seq(1, 2, 3).contains(v)
+  )
+  testHasSameBehavior[String, Boolean](
+    "in strings",
+    _.in("foo", "bar", "baz"),
+    v => Seq("foo", "bar", "baz").contains(v)
+  )
   testHasSameBehavior[Seq[Int], Boolean]("seq forall", _.forall(_ < 0), _.forall(_ < 0))
   testHasSameBehavior[Seq[Seq[Int]], Seq[Boolean]](
     "seq forall nested",

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -51,6 +51,7 @@ import com.choreograph.tyda.functions.range
 import com.choreograph.tyda.functions.seq
 import com.choreograph.tyda.functions.some
 import com.choreograph.tyda.functions.startsWith
+import com.choreograph.tyda.functions.ternary
 import com.choreograph.tyda.functions.toBase64
 import com.choreograph.tyda.functions.toJson
 import com.choreograph.tyda.functions.tuple
@@ -447,20 +448,16 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testHasSameBehavior[Seq[Int], Boolean]("seq exists", _.exists(_ < 0), _.exists(_ < 0))
   testHasSameBehavior[Seq[Boolean], Boolean]("seq contains", _.contains(true), _.contains(elem = true))
   testHasSameBehavior[Int, Boolean]("in literals match", _.in(1, 2, 3), v => Seq(1, 2, 3).contains(v))
-  testHasSameBehavior[Int, Boolean](
-    "in literals no match",
-    _.in(10, 20, 30),
-    v => Seq(10, 20, 30).contains(v)
-  )
-  testHasSameBehavior[Int, Boolean](
+  testHasSameBehavior[Int, Boolean]("in literals", _.in(1, 2, 3), v => Seq(1, 2, 3).contains(v))
+  testHasSameBehavior[(Int, Int, Int, Boolean), Boolean](
     "in exprs",
-    i => i.in(lit(1), lit(2), lit(3)),
-    v => Seq(1, 2, 3).contains(v)
+    { case Expr(i1, i2, i3, b) => i1.in(i2, ternary(b, i1, i3)) },
+    (i1, i2, i3, b) => i1 == i2 || i1 == (if b then i1 else i3)
   )
-  testHasSameBehavior[String, Boolean](
-    "in strings",
-    _.in("foo", "bar", "baz"),
-    v => Seq("foo", "bar", "baz").contains(v)
+  testHasSameBehavior[(Struct, Struct, Struct), Boolean](
+    "in match struct",
+    { case Expr(a, b, c) => a.in(b, c) },
+    { case (a, b, c) => Seq(b, c).contains(a) }
   )
   testHasSameBehavior[Seq[Int], Boolean]("seq forall", _.forall(_ < 0), _.forall(_ < 0))
   testHasSameBehavior[Seq[Seq[Int]], Seq[Boolean]](

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -447,7 +447,6 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   )
   testHasSameBehavior[Seq[Int], Boolean]("seq exists", _.exists(_ < 0), _.exists(_ < 0))
   testHasSameBehavior[Seq[Boolean], Boolean]("seq contains", _.contains(true), _.contains(elem = true))
-  testHasSameBehavior[Int, Boolean]("in literals match", _.in(1, 2, 3), v => Seq(1, 2, 3).contains(v))
   testHasSameBehavior[Int, Boolean]("in literals", _.in(1, 2, 3), v => Seq(1, 2, 3).contains(v))
   testHasSameBehavior[(Int, Int, Int, Boolean), Boolean](
     "in exprs",

--- a/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
+++ b/tyda/src/main/scala/com/choreograph/tyda/ExprApi.scala
@@ -737,6 +737,20 @@ trait ExprApi[Expr[T]] {
       exists(e => lift(ExprNode.Equals(unlift(e), unlift(AsExpr(value)))))
   }
 
+  extension [T: Codec](expr: Expr[T]) {
+
+    /** Check if the expression's value is contained in the given literal
+      * values.
+      */
+    @targetName("inLiteral")
+    def in(value: T, values: T*): Expr[Boolean] =
+      seq((value +: values).map(v => lift[T](ExprNode.Literal(v)))).contains(expr)
+
+    /** Check if the expression's value is contained in the given expressions.
+      */
+    def in(value: Expr[T], values: Expr[T]*): Expr[Boolean] = seq(value +: values).contains(expr)
+  }
+
   extension [U, CC[X] <: SeqCC[X, CC], C <: SeqCC[Iterable[U], CC]](seq: Expr[C]) {
 
     /** Flattens a sequence of iterables into a single sequence.


### PR DESCRIPTION
No new nodes are needed, instead use the existing seq operations and use a matcher on those. We also add code to generate array_contains when we are doing a simple look up.

The motivation here is that the output is simpler and express the intent more cleanly and Spark has special rules round `in` and will change it into a hash look up for larger collections.