### PR TITLE
Remove usage of to-be deprecated constructor

### DIFF
--- a/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/CodecParquetWriter.scala
+++ b/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/CodecParquetWriter.scala
@@ -2,6 +2,7 @@ package com.choreograph.tyda.parquet
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.util.HadoopOutputFile
 import org.apache.parquet.hadoop.ParquetWriter
 
 import com.choreograph.tyda.Codec
@@ -9,7 +10,9 @@ import com.choreograph.tyda.Codec
 object CodecParquetWriter {
   def apply[T: Codec](path: Path): ParquetWriter[T] = new Builder[T](path).build()
 
-  final class Builder[T: Codec](path: Path) extends ParquetWriter.Builder[T, Builder[T]](path) {
+  private def fromPath(path: Path): HadoopOutputFile = HadoopOutputFile.fromPath(path, new Configuration())
+
+  final class Builder[T: Codec](path: Path) extends ParquetWriter.Builder[T, Builder[T]](fromPath(path)) {
     override protected def self(): Builder[T] = this
 
     override protected def getWriteSupport(conf: Configuration): CodecWriteSupport[T] =


### PR DESCRIPTION
The ParquetWriter.Builder constructur that takes a Path gets deprecated in commit c6c553b412ac2fb9ad641803e918ddf5220cc757.