### PR TITLE
Remove usage of deprecated constructor

### DIFF
--- a/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/CodecParquetWriter.scala
+++ b/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/CodecParquetWriter.scala
@@ -2,8 +2,8 @@ package com.choreograph.tyda.parquet
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.util.HadoopOutputFile
 import org.apache.parquet.hadoop.ParquetWriter
+import org.apache.parquet.hadoop.util.HadoopOutputFile
 
 import com.choreograph.tyda.Codec
 

--- a/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/CodecParquetWriter.scala
+++ b/tyda-parquet/src/main/scala/com/choreograph/tyda/parquet/CodecParquetWriter.scala
@@ -2,6 +2,7 @@ package com.choreograph.tyda.parquet
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.util.HadoopOutputFile
 import org.apache.parquet.hadoop.ParquetWriter
 
 import com.choreograph.tyda.Codec
@@ -9,7 +10,9 @@ import com.choreograph.tyda.Codec
 object CodecParquetWriter {
   def apply[T: Codec](path: Path): ParquetWriter[T] = new Builder[T](path).build()
 
-  final class Builder[T: Codec](path: Path) extends ParquetWriter.Builder[T, Builder[T]](path) {
+  private def fromPath(path: Path): HadoopOutputFile = HadoopOutputFile.fromPath(path, new Configuration())
+
+  final class Builder[T: Codec](path: Path) extends ParquetWriter.Builder[T, Builder[T]](fromPath(path)) {
     override protected def self(): Builder[T] = this
 
     override protected def getWriteSupport(conf: Configuration): CodecWriteSupport[T] =


### PR DESCRIPTION
The ParquetWriter.Builder(Path path) constructur gets deprecated in
https://github.com/apache/parquet-java/pull/3301, which is in release 1.17 of parquet-hadoop:
https://github.com/apache/parquet-java/releases#release-apache-parquet-1.17.0