### PR TITLE
Add more seq.contains coverage

### DIFF
--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -670,32 +670,56 @@ SELECT array((SELECT DISTINCT c0 FROM unnest(t1.value) AS c0)) AS value FROM t1
 SELECT ends_with(t1._1, t1._2) AS value FROM t1
 ------ end
 
------- Test: equals on Option
-SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
------- end
-
------- Test: equals on Seq
-SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
------- end
-
------- Test: equals on Seq with product
-SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
------- end
-
------- Test: equals on Seq with product optional field
-SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (TRUE AND (c1._1.a IS NOT DISTINCT FROM c1._2.a)) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
------- end
-
------- Test: equals on nested Option
-SELECT (((t1._1 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END IS NULL) THEN TRUE ELSE (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._1 IS NOT DISTINCT FROM CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._2) END) AS value FROM t1
------- end
-
------- Test: equals on primitive
+------ Test: equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
 SELECT (t1._1 = t1._2) AS value FROM t1
 ------ end
 
------- Test: equals on struct with optional field
+------ Test: equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
 SELECT (TRUE AND (t1._1.a IS NOT DISTINCT FROM t1._2.a)) AS value FROM t1
+------ end
+
+------ Test: equals on scala.Boolean
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
+SELECT (TRUE AND ((array_length(t1._1.seq) = array_length(t1._2.seq)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1.seq[c0] AS _1, t1._2.seq[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1.seq) < array_length(t1._2.seq)) THEN array_length(t1._1.seq) ELSE array_length(t1._2.seq) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2))) AS value FROM t1
+------ end
+
+------ Test: equals on scala.Option[scala.Boolean]
+SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.Option[scala.Option[scala.Boolean]]
+SELECT (((t1._1 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END IS NULL) THEN TRUE ELSE (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._1 IS NOT DISTINCT FROM CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._2) END) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField]
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (TRUE AND (c1._1.a IS NOT DISTINCT FROM c1._2.a)) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[scala.Boolean]
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c5), TRUE) FROM unnest(array((SELECT ((array_length(c1._1) = array_length(c1._2)) AND (SELECT coalesce(logical_and(c4), TRUE) FROM unnest(array((SELECT (c3._1 = c3._2) FROM unnest(array((SELECT struct(c1._1[c2] AS _1, c1._2[c2] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c1._1) < array_length(c1._2)) THEN array_length(c1._1) ELSE array_length(c1._2) END - CAST(1 AS INT)))) AS c2))) AS c3))) AS c4)) FROM unnest(array((SELECT struct(t1._1[c0].value AS _1, t1._2[c0].value AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c5)) AS value FROM t1
 ------ end
 
 ------ Test: equals to None
@@ -1122,8 +1146,56 @@ SELECT coalesce(CASE WHEN (t1.value IS NOT NULL) THEN [struct(t1.value AS value)
 SELECT (CAST(t1.`瑞` AS INT) + CAST(t1.`典` AS INT)) AS value FROM t1
 ------ end
 
------- Test: not equals on primitive
+------ Test: not equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
 SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
+SELECT (NOT (TRUE AND (t1._1.a IS NOT DISTINCT FROM t1._2.a))) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.Boolean
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
+SELECT (NOT (TRUE AND ((array_length(t1._1.seq) = array_length(t1._2.seq)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1.seq[c0] AS _1, t1._2.seq[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1.seq) < array_length(t1._2.seq)) THEN array_length(t1._1.seq) ELSE array_length(t1._2.seq) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)))) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.Option[scala.Boolean]
+SELECT (NOT (t1._1 IS NOT DISTINCT FROM t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.Option[scala.Option[scala.Boolean]]
+SELECT (NOT (((t1._1 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END IS NULL) THEN TRUE ELSE (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._1 IS NOT DISTINCT FROM CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._2) END)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
+SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2))) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField]
+SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (TRUE AND (c1._1.a IS NOT DISTINCT FROM c1._2.a)) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2))) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[scala.Boolean]
+SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2))) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
+SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2))) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c5), TRUE) FROM unnest(array((SELECT ((array_length(c1._1) = array_length(c1._2)) AND (SELECT coalesce(logical_and(c4), TRUE) FROM unnest(array((SELECT (c3._1 = c3._2) FROM unnest(array((SELECT struct(c1._1[c2] AS _1, c1._2[c2] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c1._1) < array_length(c1._2)) THEN array_length(c1._1) ELSE array_length(c1._2) END - CAST(1 AS INT)))) AS c2))) AS c3))) AS c4)) FROM unnest(array((SELECT struct(t1._1[c0].value AS _1, t1._2[c0].value AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c5))) AS value FROM t1
 ------ end
 
 ------ Test: project
@@ -1206,12 +1278,12 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = T
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
 ------ end
 
------- Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (((TRUE AND (c0.discriminant = t1._2.discriminant)) AND (c0.c IS NOT DISTINCT FROM t1._2.c)) AND (c0.d IS NOT DISTINCT FROM t1._2.d)) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
------- end
-
 ------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (TRUE AND (c0.a IS NOT DISTINCT FROM t1._2.a)) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Boolean
@@ -1222,20 +1294,36 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
 ------ end
 
------- Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["opt"], scala.Tuple1[scala.Option[scala.Boolean]]]
-SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (TRUE AND (c0.opt IS NOT DISTINCT FROM t1._2.opt)) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
------- end
-
------- Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["opt"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
-SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT (TRUE AND ((array_length(c0.opt) = array_length(t1._2.opt)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.opt[c1] AS _1, t1._2.opt[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.opt) < array_length(t1._2.opt)) THEN array_length(c0.opt) ELSE array_length(t1._2.opt) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3))) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
+------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
+SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT (TRUE AND ((array_length(c0.seq) = array_length(t1._2.seq)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.seq[c1] AS _1, t1._2.seq[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.seq) < array_length(t1._2.seq)) THEN array_length(c0.seq) ELSE array_length(t1._2.seq) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3))) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.Option[scala.Boolean]
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 IS NOT DISTINCT FROM t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
 ------ end
 
+------ Test: seq contains scala.Option[scala.Option[scala.Boolean]]
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (((c0 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((c0 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2.value AS _2) END IS NULL) THEN TRUE ELSE (CASE WHEN ((c0 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2.value AS _2) END._1 IS NOT DISTINCT FROM CASE WHEN ((c0 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2.value AS _2) END._2) END) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
+SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.value[c1] AS _1, t1._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField]
+SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (TRUE AND (c2._1.a IS NOT DISTINCT FROM c2._2.a)) FROM unnest(array((SELECT struct(c0.value[c1] AS _1, t1._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
+------ end
+
 ------ Test: seq contains scala.collection.immutable.Seq[scala.Boolean]
 SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.value[c1] AS _1, t1._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
+SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.value[c1] AS _1, t1._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT (SELECT coalesce(logical_or(c7), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c6), TRUE) FROM unnest(array((SELECT ((array_length(c2._1) = array_length(c2._2)) AND (SELECT coalesce(logical_and(c5), TRUE) FROM unnest(array((SELECT (c4._1 = c4._2) FROM unnest(array((SELECT struct(c2._1[c3] AS _1, c2._2[c3] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c2._1) < array_length(c2._2)) THEN array_length(c2._1) ELSE array_length(c2._2) END - CAST(1 AS INT)))) AS c3))) AS c4))) AS c5)) FROM unnest(array((SELECT struct(c0.value[c1].value AS _1, t1._2[c1].value AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c6)) FROM unnest(t1._1) AS c0))) AS c7) AS value FROM t1
 ------ end
 
 ------ Test: seq exists

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -1202,8 +1202,40 @@ SELECT (t1.value = TRUE) AS value FROM t1
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = TRUE) FROM unnest(t1.value) AS c0))) AS c1) AS value FROM t1
 ------ end
 
------- Test: seq contains option
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (((TRUE AND (c0.discriminant = t1._2.discriminant)) AND (c0.c IS NOT DISTINCT FROM t1._2.c)) AND (c0.d IS NOT DISTINCT FROM t1._2.d)) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.Boolean
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["opt"], scala.Tuple1[scala.Option[scala.Boolean]]]
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (TRUE AND (c0.opt IS NOT DISTINCT FROM t1._2.opt)) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["opt"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
+SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT (TRUE AND ((array_length(c0.opt) = array_length(t1._2.opt)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.opt[c1] AS _1, t1._2.opt[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.opt) < array_length(t1._2.opt)) THEN array_length(c0.opt) ELSE array_length(t1._2.opt) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3))) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.Option[scala.Boolean]
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 IS NOT DISTINCT FROM t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[scala.Boolean]
+SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.value[c1] AS _1, t1._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
 ------ end
 
 ------ Test: seq exists

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -1202,6 +1202,10 @@ SELECT (t1.value = TRUE) AS value FROM t1
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 = TRUE) FROM unnest(t1.value) AS c0))) AS c1) AS value FROM t1
 ------ end
 
+------ Test: seq contains option
+SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 IS NOT DISTINCT FROM t1._2) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
+------ end
+
 ------ Test: seq exists
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 < CAST(0 AS INT)) FROM unnest(t1.value) AS c0))) AS c1) AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -670,31 +670,55 @@ SELECT array_distinct(t1.value) AS value FROM t1
 SELECT endswith(t1._1, t1._2) AS value FROM t1
 ------ end
 
------- Test: equals on Option
+------ Test: equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.Boolean
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.Option[scala.Boolean]
 SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
 ------ end
 
------- Test: equals on Seq
-SELECT (t1._1 = t1._2) AS value FROM t1
------- end
-
------- Test: equals on Seq with product
-SELECT (t1._1 = t1._2) AS value FROM t1
------- end
-
------- Test: equals on Seq with product optional field
-SELECT (t1._1 = t1._2) AS value FROM t1
------- end
-
------- Test: equals on nested Option
+------ Test: equals on scala.Option[scala.Option[scala.Boolean]]
 SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
 ------ end
 
------- Test: equals on primitive
+------ Test: equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
 SELECT (t1._1 = t1._2) AS value FROM t1
 ------ end
 
------- Test: equals on struct with optional field
+------ Test: equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField]
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[scala.Boolean]
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Boolean]]
 SELECT (t1._1 = t1._2) AS value FROM t1
 ------ end
 
@@ -1122,7 +1146,55 @@ SELECT coalesce(CASE WHEN (t1.value IS NOT NULL) THEN array(t1.value) END, CAST(
 SELECT (CAST(t1.`瑞` AS INT) + CAST(t1.`典` AS INT)) AS value FROM t1
 ------ end
 
------- Test: not equals on primitive
+------ Test: not equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.Boolean
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.Option[scala.Boolean]
+SELECT (NOT (t1._1 IS NOT DISTINCT FROM t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.Option[scala.Option[scala.Boolean]]
+SELECT (NOT (t1._1 IS NOT DISTINCT FROM t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField]
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[scala.Boolean]
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Boolean]]
 SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
 ------ end
 
@@ -1206,11 +1278,11 @@ SELECT aggregate(transform(t1.value, c0 -> (c0 = TRUE)), FALSE, (c1, c2) -> (c1 
 SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
------- Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
 SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
------- Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField
 SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
@@ -1222,11 +1294,7 @@ SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR
 SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
------- Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["opt"], scala.Tuple1[scala.Option[scala.Boolean]]]
-SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
------- end
-
------- Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["opt"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
+------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["seq"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
 SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
@@ -1234,7 +1302,27 @@ SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR
 SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
+------ Test: seq contains scala.Option[scala.Option[scala.Boolean]]
+SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.WithOptionField]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
 ------ Test: seq contains scala.collection.immutable.Seq[scala.Boolean]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[scala.collection.immutable.Seq[scala.Boolean]]
 SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -1202,6 +1202,10 @@ SELECT (t1.value = TRUE) AS value FROM t1
 SELECT aggregate(transform(t1.value, c0 -> (c0 = TRUE)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
+------ Test: seq contains option
+SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
 ------ Test: seq exists
 SELECT aggregate(transform(t1.value, c0 -> (c0 < CAST(0 AS INT))), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -1202,8 +1202,40 @@ SELECT (t1.value = TRUE) AS value FROM t1
 SELECT aggregate(transform(t1.value, c0 -> (c0 = TRUE)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
------- Test: seq contains option
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnumString
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.Boolean
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["bool"], scala.Tuple1[scala.Boolean]]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["opt"], scala.Tuple1[scala.Option[scala.Boolean]]]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.NamedTuple.NamedTuple[scala.Tuple1["opt"], scala.Tuple1[scala.collection.immutable.Seq[scala.Boolean]]]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.Option[scala.Boolean]
 SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[scala.Boolean]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
 ------ Test: seq exists

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -429,12 +429,26 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
     _.map(t => (a = t._1.map(_ > t._2)))
   )
   testHasSameBehavior[Seq[Int], Boolean]("seq exists", _.exists(_ < 0), _.exists(_ < 0))
+
   testHasSameBehavior[Seq[Boolean], Boolean]("seq contains", _.contains(true), _.contains(elem = true))
-  testHasSameBehavior[(Seq[Option[Boolean]], Option[Boolean]), Boolean](
-    "seq contains option",
-    x => x._1.contains(x._2),
-    x => x._1.contains(x._2)
-  )
+
+  def testSeqContains[T: TypeName: Codec: Arbitrary] =
+    testHasSameBehavior[(Seq[T], T), Boolean](
+      s"seq contains ${TypeName.name}",
+      x => x._1.contains(x._2),
+      x => x._1.contains(x._2)
+    )
+
+  testSeqContains[Boolean]
+  testSeqContains[Option[Boolean]]
+  testSeqContains[Seq[Boolean]]
+  testSeqContains[(bool: Boolean)]
+  testSeqContains[(opt: Option[Boolean])]
+  testSeqContains[(opt: Seq[Boolean])]
+  testSeqContains[Struct]
+  testSeqContains[TestEnum]
+  testSeqContains[TestEnumString]
+
   testHasSameBehavior[Seq[Int], Boolean]("seq forall", _.forall(_ < 0), _.forall(_ < 0))
   testHasSameBehavior[Seq[Seq[Int]], Seq[Boolean]](
     "seq forall nested",

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -430,6 +430,11 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   )
   testHasSameBehavior[Seq[Int], Boolean]("seq exists", _.exists(_ < 0), _.exists(_ < 0))
   testHasSameBehavior[Seq[Boolean], Boolean]("seq contains", _.contains(true), _.contains(elem = true))
+  testHasSameBehavior[(Seq[Option[Boolean]], Option[Boolean]), Boolean](
+    "seq contains option",
+    x => x._1.contains(x._2),
+    x => x._1.contains(x._2)
+  )
   testHasSameBehavior[Seq[Int], Boolean]("seq forall", _.forall(_ < 0), _.forall(_ < 0))
   testHasSameBehavior[Seq[Seq[Int]], Seq[Boolean]](
     "seq forall nested",

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -88,7 +88,7 @@ object ExprEvaluationSuiteBase {
     case _ => NestedOption[Levels - 1, Option[Value]]
   }
 
-  private final case class WithOptionField(a: Option[Int]) derives Arbitrary, Codec
+  private final case class WithOptionField(a: Option[Boolean]) derives Arbitrary, Codec
 
   private final case class WithEmptyTuple(empty: EmptyTuple) derives Arbitrary, Codec
   private final case class WithNamedTupleEmpty(empty: NamedTuple.Empty) derives Arbitrary, Codec
@@ -169,30 +169,30 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
     t => !t._1 == !t._2
   )
 
-  testHasSameBehavior[(Int, Int), Boolean]("equals on primitive", t => t._1 == t._2, _ == _)
-  testHasSameBehavior[(Int, Int), Boolean]("not equals on primitive", t => t._1 != t._2, _ != _)
-  testHasSameBehavior[(Option[Int], Option[Int]), Boolean]("equals on Option", t => t._1 == t._2, _ == _)
-  testHasSameBehavior[(Option[Option[Boolean]], Option[Option[Boolean]]), Boolean](
-    "equals on nested Option",
-    t => t._1 == t._2,
-    _ == _
-  )
-  testHasSameBehavior[(Seq[Boolean], Seq[Boolean]), Boolean]("equals on Seq", t => t._1 == t._2, _ == _)
-  testHasSameBehavior[(WithOptionField, WithOptionField), Boolean](
-    "equals on struct with optional field",
-    t => t._1 == t._2,
-    _ == _
-  )
-  testHasSameBehavior[(Seq[(Int, Int)], Seq[(Int, Int)]), Boolean](
-    "equals on Seq with product",
-    t => t._1 == t._2,
-    _ == _
-  )
-  testHasSameBehavior[(Seq[WithOptionField], Seq[WithOptionField]), Boolean](
-    "equals on Seq with product optional field",
-    t => t._1 == t._2,
-    _ == _
-  )
+  def testEqualsAndContains[T: Codec: Arbitrary: TypeName] = {
+    testHasSameBehavior[(T, T), Boolean](s"equals on ${TypeName.name}", t => t._1 == t._2, _ == _)
+    testHasSameBehavior[(T, T), Boolean](s"not equals on ${TypeName.name}", t => t._1 != t._2, _ != _)
+    testHasSameBehavior[(Seq[T], T), Boolean](
+      s"seq contains ${TypeName.name}",
+      x => x._1.contains(x._2),
+      x => x._1.contains(x._2)
+    )
+  }
+
+  testEqualsAndContains[Boolean]
+  testEqualsAndContains[Option[Boolean]]
+  testEqualsAndContains[Option[Option[Boolean]]]
+  testEqualsAndContains[Seq[Boolean]]
+  testEqualsAndContains[Seq[Struct]]
+  testEqualsAndContains[Seq[WithOptionField]]
+  testEqualsAndContains[Seq[Seq[Boolean]]]
+  testEqualsAndContains[(bool: Boolean)]
+  testEqualsAndContains[WithOptionField]
+  testEqualsAndContains[(seq: Seq[Boolean])]
+  testEqualsAndContains[Seq[(Int, Int)]]
+  testEqualsAndContains[Struct]
+  testEqualsAndContains[TestEnumString]
+
   testHasSameBehavior[Option[Int], Boolean]("equals to None", _ == None, _ == None)
 
   testHasSameBehavior[Option[Option[Int]], Option[Option[Int]]]("nested Option", identity, identity)
@@ -431,23 +431,6 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testHasSameBehavior[Seq[Int], Boolean]("seq exists", _.exists(_ < 0), _.exists(_ < 0))
 
   testHasSameBehavior[Seq[Boolean], Boolean]("seq contains", _.contains(true), _.contains(elem = true))
-
-  def testSeqContains[T: TypeName: Codec: Arbitrary] =
-    testHasSameBehavior[(Seq[T], T), Boolean](
-      s"seq contains ${TypeName.name}",
-      x => x._1.contains(x._2),
-      x => x._1.contains(x._2)
-    )
-
-  testSeqContains[Boolean]
-  testSeqContains[Option[Boolean]]
-  testSeqContains[Seq[Boolean]]
-  testSeqContains[(bool: Boolean)]
-  testSeqContains[(opt: Option[Boolean])]
-  testSeqContains[(opt: Seq[Boolean])]
-  testSeqContains[Struct]
-  testSeqContains[TestEnum]
-  testSeqContains[TestEnumString]
 
   testHasSameBehavior[Seq[Int], Boolean]("seq forall", _.forall(_ < 0), _.forall(_ < 0))
   testHasSameBehavior[Seq[Seq[Int]], Seq[Boolean]](

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -429,9 +429,7 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
     _.map(t => (a = t._1.map(_ > t._2)))
   )
   testHasSameBehavior[Seq[Int], Boolean]("seq exists", _.exists(_ < 0), _.exists(_ < 0))
-
   testHasSameBehavior[Seq[Boolean], Boolean]("seq contains", _.contains(true), _.contains(elem = true))
-
   testHasSameBehavior[Seq[Int], Boolean]("seq forall", _.forall(_ < 0), _.forall(_ < 0))
   testHasSameBehavior[Seq[Seq[Int]], Seq[Boolean]](
     "seq forall nested",


### PR DESCRIPTION
This is preparation for adding support for the `IN` operator in sql based runners.

Since the `IN` operator relates to the (non-null-safe) equals operator, we 
make sure to run tests for all the same types for `contains` as we do for `equals`.