### PR TITLE
Improve test cases for enum/equals

### DIFF
--- a/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicBigQueryGoldenSuite.golden
@@ -2,6 +2,10 @@
 SELECT table1.a AS a, table1.b AS b FROM table1
 ------ end
 
+------ Test: creation of enums
+((SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d) UNION ALL (SELECT 'b' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUCT<i INT>) AS d)) UNION ALL ((SELECT 'c' AS discriminant, struct(CAST(1 AS INT) AS i) AS c, CAST(NULL AS STRUCT<i INT>) AS d) UNION ALL (SELECT 'd' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, struct(CAST(2 AS INT) AS i) AS d))
+------ end
+
 ------ Test: distinct List
 SELECT DISTINCT table1.value AS value FROM table1
 ------ end

--- a/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/DatasetBasicSparkSqlGoldenSuite.golden
@@ -2,6 +2,10 @@
 SELECT table1.a AS a, table1.b AS b FROM table1
 ------ end
 
+------ Test: creation of enums
+SELECT t0.discriminant AS discriminant, t0.c AS c, t0.d AS d FROM VALUES ('a', CAST(NULL AS STRUCT<i INT NOT NULL>), CAST(NULL AS STRUCT<i INT NOT NULL>)), ('b', CAST(NULL AS STRUCT<i INT NOT NULL>), CAST(NULL AS STRUCT<i INT NOT NULL>)), ('c', named_struct('i', CAST(1 AS INT)), CAST(NULL AS STRUCT<i INT NOT NULL>)), ('d', CAST(NULL AS STRUCT<i INT NOT NULL>), named_struct('i', CAST(2 AS INT))) AS t0(discriminant, c, d)
+------ end
+
 ------ Test: distinct List
 SELECT DISTINCT table1.value AS value FROM table1
 ------ end

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationBigQueryGoldenSuite.golden
@@ -462,6 +462,10 @@ SELECT array((SELECT struct(CAST(c0.value AS ARRAY<BIGINT>) AS value) FROM unnes
 SELECT coalesce(t1._1, t1._2) AS value FROM t1
 ------ end
 
+------ Test: compare to literal enum variant
+SELECT (((TRUE AND (t1.discriminant = 'b')) AND (t1.c IS NULL)) AND (t1.d IS NULL)) AS value FROM t1
+------ end
+
 ------ Test: concat seq
 SELECT array_concat(t1._1, t1._2) AS value FROM t1
 ------ end
@@ -548,6 +552,10 @@ SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT>) AS c, CAST(NULL AS STRUC
 
 ------ Test: create literal ArraySeq(0, -54, -2, -70, -66) com.choreograph.tyda.Binary$package.Binary
 SELECT B'\x00\xca\xfe\xba\xbe' AS value FROM t1
+------ end
+
+------ Test: create literal C(1) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
+SELECT 'c' AS discriminant, struct(CAST(1 AS INT) AS i) AS c, CAST(NULL AS STRUCT<i INT>) AS d FROM t1
 ------ end
 
 ------ Test: create literal List() scala.collection.immutable.List[scala.Int]
@@ -714,6 +722,10 @@ SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
 SELECT (((t1._1 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END IS NULL) THEN TRUE ELSE (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._1 IS NOT DISTINCT FROM CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._2) END) AS value FROM t1
 ------ end
 
+------ Test: equals on scala.Option[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT (((t1._1 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END IS NULL) THEN TRUE ELSE ((array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._1) = array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._1[c0] AS _1, CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._1) < array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._2)) THEN array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._1) ELSE array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) END) AS value FROM t1
+------ end
+
 ------ Test: equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
 SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
 ------ end
@@ -724,6 +736,10 @@ SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical
 
 ------ Test: equals on scala.collection.immutable.Seq[scala.Boolean]
 SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[scala.Option[scala.Boolean]]
+SELECT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 IS NOT DISTINCT FROM c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) AS value FROM t1
 ------ end
 
 ------ Test: equals on scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
@@ -1190,6 +1206,10 @@ SELECT (NOT (t1._1 IS NOT DISTINCT FROM t1._2)) AS value FROM t1
 SELECT (NOT (((t1._1 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END IS NULL) THEN TRUE ELSE (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._1 IS NOT DISTINCT FROM CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1.value AS _1, t1._2.value AS _2) END._2) END)) AS value FROM t1
 ------ end
 
+------ Test: not equals on scala.Option[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT (NOT (((t1._1 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END IS NULL) THEN TRUE ELSE ((array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._1) = array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._1[c0] AS _1, CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._1) < array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._2)) THEN array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._1) ELSE array_length(CASE WHEN ((t1._1 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(t1._1 AS _1, t1._2 AS _2) END._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2)) END)) AS value FROM t1
+------ end
+
 ------ Test: not equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
 SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2))) AS value FROM t1
 ------ end
@@ -1200,6 +1220,10 @@ SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(lo
 
 ------ Test: not equals on scala.collection.immutable.Seq[scala.Boolean]
 SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 = c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2))) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[scala.Option[scala.Boolean]]
+SELECT (NOT ((array_length(t1._1) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c2), TRUE) FROM unnest(array((SELECT (c1._1 IS NOT DISTINCT FROM c1._2) FROM unnest(array((SELECT struct(t1._1[c0] AS _1, t1._2[c0] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(t1._1) < array_length(t1._2)) THEN array_length(t1._1) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c0))) AS c1))) AS c2))) AS value FROM t1
 ------ end
 
 ------ Test: not equals on scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]
@@ -1318,6 +1342,10 @@ SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (c0 IS 
 SELECT (SELECT coalesce(logical_or(c1), FALSE) FROM unnest(array((SELECT (((c0 IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((c0 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2.value AS _2) END IS NULL) THEN TRUE ELSE (CASE WHEN ((c0 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2.value AS _2) END._1 IS NOT DISTINCT FROM CASE WHEN ((c0 IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2.value AS _2) END._2) END) FROM unnest(t1._1) AS c0))) AS c1) AS value FROM t1
 ------ end
 
+------ Test: seq contains scala.Option[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT (((c0.value IS NULL) = (t1._2 IS NULL)) AND CASE WHEN (CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END IS NULL) THEN TRUE ELSE ((array_length(CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END._1) = array_length(CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END._1[c1] AS _1, CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END._1) < array_length(CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END._2)) THEN array_length(CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END._1) ELSE array_length(CASE WHEN ((c0.value IS NOT NULL) AND (t1._2 IS NOT NULL)) THEN struct(c0.value AS _1, t1._2 AS _2) END._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) END) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
+------ end
+
 ------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
 SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.value[c1] AS _1, t1._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
 ------ end
@@ -1328,6 +1356,10 @@ SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array
 
 ------ Test: seq contains scala.collection.immutable.Seq[scala.Boolean]
 SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 = c2._2) FROM unnest(array((SELECT struct(c0.value[c1] AS _1, t1._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[scala.Option[scala.Boolean]]
+SELECT (SELECT coalesce(logical_or(c4), FALSE) FROM unnest(array((SELECT ((array_length(c0.value) = array_length(t1._2)) AND (SELECT coalesce(logical_and(c3), TRUE) FROM unnest(array((SELECT (c2._1 IS NOT DISTINCT FROM c2._2) FROM unnest(array((SELECT struct(c0.value[c1] AS _1, t1._2[c1] AS _2) FROM unnest(generate_array(CAST(0 AS INT), (CASE WHEN (array_length(c0.value) < array_length(t1._2)) THEN array_length(c0.value) ELSE array_length(t1._2) END - CAST(1 AS INT)))) AS c1))) AS c2))) AS c3)) FROM unnest(t1._1) AS c0))) AS c4) AS value FROM t1
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[scala.Tuple2[scala.Int, scala.Int]]

--- a/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/ExprEvaluationSparkSqlGoldenSuite.golden
@@ -462,6 +462,10 @@ SELECT CAST(t1.value AS ARRAY<ARRAY<BIGINT>>) AS value FROM t1
 SELECT coalesce(t1._1, t1._2) AS value FROM t1
 ------ end
 
+------ Test: compare to literal enum variant
+SELECT (named_struct('discriminant', t1.discriminant, 'c', t1.c, 'd', t1.d) = named_struct('discriminant', 'b', 'c', CAST(NULL AS STRUCT<i INT NOT NULL>), 'd', CAST(NULL AS STRUCT<i INT NOT NULL>))) AS value FROM t1
+------ end
+
 ------ Test: concat seq
 SELECT concat(t1._1, t1._2) AS value FROM t1
 ------ end
@@ -548,6 +552,10 @@ SELECT 'a' AS discriminant, CAST(NULL AS STRUCT<i INT NOT NULL>) AS c, CAST(NULL
 
 ------ Test: create literal ArraySeq(0, -54, -2, -70, -66) com.choreograph.tyda.Binary$package.Binary
 SELECT X'00cafebabe' AS value FROM t1
+------ end
+
+------ Test: create literal C(1) com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.TestEnum
+SELECT 'c' AS discriminant, named_struct('i', CAST(1 AS INT)) AS c, CAST(NULL AS STRUCT<i INT NOT NULL>) AS d FROM t1
 ------ end
 
 ------ Test: create literal List() scala.collection.immutable.List[scala.Int]
@@ -714,6 +722,10 @@ SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
 SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
 ------ end
 
+------ Test: equals on scala.Option[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT (t1._1 IS NOT DISTINCT FROM t1._2) AS value FROM t1
+------ end
+
 ------ Test: equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
 SELECT (t1._1 = t1._2) AS value FROM t1
 ------ end
@@ -723,6 +735,10 @@ SELECT (t1._1 = t1._2) AS value FROM t1
 ------ end
 
 ------ Test: equals on scala.collection.immutable.Seq[scala.Boolean]
+SELECT (t1._1 = t1._2) AS value FROM t1
+------ end
+
+------ Test: equals on scala.collection.immutable.Seq[scala.Option[scala.Boolean]]
 SELECT (t1._1 = t1._2) AS value FROM t1
 ------ end
 
@@ -1190,6 +1206,10 @@ SELECT (NOT (t1._1 IS NOT DISTINCT FROM t1._2)) AS value FROM t1
 SELECT (NOT (t1._1 IS NOT DISTINCT FROM t1._2)) AS value FROM t1
 ------ end
 
+------ Test: not equals on scala.Option[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT (NOT (t1._1 IS NOT DISTINCT FROM t1._2)) AS value FROM t1
+------ end
+
 ------ Test: not equals on scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
 SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
 ------ end
@@ -1199,6 +1219,10 @@ SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
 ------ end
 
 ------ Test: not equals on scala.collection.immutable.Seq[scala.Boolean]
+SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
+------ end
+
+------ Test: not equals on scala.collection.immutable.Seq[scala.Option[scala.Boolean]]
 SELECT (NOT (t1._1 = t1._2)) AS value FROM t1
 ------ end
 
@@ -1318,6 +1342,10 @@ SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE,
 SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 
+------ Test: seq contains scala.Option[scala.collection.immutable.Seq[scala.Boolean]]
+SELECT aggregate(transform(t1._1, c0 -> (c0 IS NOT DISTINCT FROM t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
 ------ Test: seq contains scala.collection.immutable.Seq[com.choreograph.tyda.testsuites.ExprEvaluationSuiteBase.Struct]
 SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
@@ -1327,6 +1355,10 @@ SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR
 ------ end
 
 ------ Test: seq contains scala.collection.immutable.Seq[scala.Boolean]
+SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
+------ end
+
+------ Test: seq contains scala.collection.immutable.Seq[scala.Option[scala.Boolean]]
 SELECT aggregate(transform(t1._1, c0 -> (c0 = t1._2)), FALSE, (c1, c2) -> (c1 OR c2), c3 -> c3) AS value FROM t1
 ------ end
 

--- a/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserBigQueryGoldenSuite.golden
@@ -70,10 +70,6 @@ SELECT table1.a AS _1, t0.value AS _2 FROM table1 LEFT JOIN (SELECT table2.a AS 
 SELECT table1.a AS _1, t0.value AS _2 FROM table1 LEFT JOIN (SELECT struct(table2.a AS a, table2.b AS b, table2.c AS c, table2.d AS d) AS value FROM table2) AS t0 ON (table1.a = t0.value.a)
 ------ end
 
------- Test: literal enum
-SELECT ((TRUE AND (t0._1.discriminant = 'c')) AND (t0._1.a IS NULL)) AS value FROM (SELECT struct('a' AS discriminant, struct(CAST(1 AS INT) AS a) AS a) AS _1) AS t0
------- end
-
 ------ Test: literal enum as string
 SELECT (t0.value = 'second') AS value FROM (SELECT 'first' AS value) AS t0
 ------ end

--- a/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
+++ b/tyda-sql/src/test/resources/golden/UnparserSparkSqlGoldenSuite.golden
@@ -70,10 +70,6 @@ SELECT table1.a AS _1, t0.value AS _2 FROM table1 LEFT JOIN (SELECT table2.a AS 
 SELECT table1.a AS _1, t0.value AS _2 FROM table1 LEFT JOIN (SELECT named_struct('a', table2.a, 'b', table2.b, 'c', table2.c, 'd', table2.d) AS value FROM table2) AS t0 ON (table1.a = t0.value.a)
 ------ end
 
------- Test: literal enum
-SELECT (t0._1 = named_struct('discriminant', 'c', 'a', CAST(NULL AS STRUCT<a INT NOT NULL>))) AS value FROM VALUES (named_struct('discriminant', 'a', 'a', named_struct('a', CAST(1 AS INT)))) AS t0(_1)
------- end
-
 ------ Test: literal enum as string
 SELECT (t0.value = 'second') AS value FROM VALUES ('first') AS t0(value)
 ------ end

--- a/tyda-sql/src/test/scala/com/choreograph/tyda/sql/UnparserSuite.scala
+++ b/tyda-sql/src/test/scala/com/choreograph/tyda/sql/UnparserSuite.scala
@@ -86,8 +86,6 @@ abstract class UnparserSuite extends SqlGoldenTestSuite {
 
   testSql("fromSeq") { Dataset.from(Seq(1, 2, 3)) }
 
-  testSql("literal enum") { Dataset.from(Seq(E1.A(1)).map(Tuple1(_))).select(_._1 == E1.C) }
-
   testSql("literal singleton") { Dataset.from[E1.C.type](Seq(E1.C)) }
 
   testSql("literal enum as string") { Dataset.from(Seq(E2.First)).select(_ == E2.Second) }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/DatasetBasicSuite.scala
@@ -8,17 +8,22 @@ import com.choreograph.tyda.functions.explode
 import com.choreograph.tyda.functions.lit
 
 object DatasetBasicSuite {
-  type WideTuple = (Int, Int, Int, Int, Int, Int, Int)
-  final case class SimpleProduct(a: Int, b: String)
-  enum SimpleEnum {
+  private type WideTuple = (Int, Int, Int, Int, Int, Int, Int)
+  private final case class SimpleProduct(a: Int, b: String)
+  private enum SimpleEnum {
     case A, B
   }
-  final case class M1(a: Int, b: String, c: Boolean, d: Seq[Long])
+  private enum TestEnum {
+    case A, B
+    case C(i: Int)
+    case D(i: Int)
+  }
+  private final case class M1(a: Int, b: String, c: Boolean, d: Seq[Long])
 }
 
 // Testsuite focusing on select and filter that will compare a Dataset backend to a reference implementation.
 trait DatasetBasicSuite extends DatasetSuite {
-  import DatasetBasicSuite.{WideTuple, SimpleProduct, SimpleEnum, M1}
+  import DatasetBasicSuite.{WideTuple, SimpleProduct, SimpleEnum, TestEnum, M1}
   import DatasetSuite.{MyEnum, TinyByte}
 
   test[Boolean, Boolean]("filter", _.filter(identity))
@@ -138,5 +143,9 @@ trait DatasetBasicSuite extends DatasetSuite {
   test[M1, (Long, Long)](
     "multiple explodes in separate selects",
     ds => ds.select(identity, explode(_.d)).select(_._2, explode(_._1.d))
+  )
+  test[EmptyTuple, TestEnum](
+    "creation of enums",
+    _ => Dataset.from(Seq(TestEnum.A, TestEnum.B, TestEnum.C(1), TestEnum.D(2)))
   )
 }

--- a/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
+++ b/tyda-test-suites/src/main/scala/com/choreograph/tyda/testsuites/ExprEvaluationSuiteBase.scala
@@ -183,6 +183,8 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testEqualsAndContains[Option[Boolean]]
   testEqualsAndContains[Option[Option[Boolean]]]
   testEqualsAndContains[Seq[Boolean]]
+  testEqualsAndContains[Option[Seq[Boolean]]]
+  testEqualsAndContains[Seq[Option[Boolean]]]
   testEqualsAndContains[Seq[Struct]]
   testEqualsAndContains[Seq[WithOptionField]]
   testEqualsAndContains[Seq[Seq[Boolean]]]
@@ -1061,6 +1063,12 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
     _ == true
   )
 
+  testHasSameBehavior[TestEnum, Boolean](
+    "compare to literal enum variant",
+    _ == lit(TestEnum.B),
+    _ == TestEnum.B
+  )
+
   val specialStrings = Seq("\b", "\f", "\n", "\r", "\t", "\u000B", "'", "\\", "\"", "`", "${var}")
   testHasSameBehavior[Int, Seq[String]](
     "handle special strings",
@@ -1265,6 +1273,7 @@ trait ExprEvaluationSuiteBase extends AnyFunSuite {
   testLiteralCreation[Option[Struct]](None)
   testLiteralCreation[Option[Struct]](Some(Struct(1, "a", false)))
   testLiteralCreation[TestEnum](TestEnum.A)
+  testLiteralCreation[TestEnum](TestEnum.C(1))
   testLiteralCreation[Option[TestEnum]](None)
   testLiteralCreation[Option[TestEnum.A.type]](None)
   testLiteralCreation[Option[TestEnum]](Some(TestEnum.C(1)))


### PR DESCRIPTION
Serves as preparation for implementing sql IN support.

Moves one test from UnparserSuite which has turned out to be relevant for witnessing that IN gets correctly implemented.